### PR TITLE
Fix SwaggerUI openapi.json Link

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -40,7 +40,7 @@
       
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "https://raw.githubusercontent.com/JohnRDOrazio/LiturgicalCalendar/master/openapi.json",
+        url: "https://raw.githubusercontent.com/Liturgical-Calendar/LiturgicalCalendarAPI/master/schemas/openapi.json",
         "dom_id": "#swagger-ui",
         deepLinking: true,
         presets: [


### PR DESCRIPTION
I was clicking around the litcal.org website and noticed SwaggerUI is broken. Looks like some repositories were recently rearranged and the link for the `openapi.json` file needs to be updated.