### PR TITLE
allow loading and editing i18n data for calendars

### DIFF
--- a/assets/js/DiocesanCalendarPayload.js
+++ b/assets/js/DiocesanCalendarPayload.js
@@ -40,51 +40,7 @@ class DiocesanCalendarPayload {
     }
 }
 
-/**
- * @typedef DiocesanCalendarDELETEPayload
- * @prop {string} diocese
- * @prop {string} nation
- */
-
-class DiocesanCalendarDELETEPayload {
-    /**
-     * Create a new DiocesanCalendarDELETEPaylod.
-     * @param {string} diocese - Diocese code.
-     * @param {string} nation - Nation code.
-     * @returns {DiocesanCalendarDELETEPayload} A new instance of DiocesanCalendarDELETEPayload.
-     */
-    constructor( diocese, nation ) {
-        const allowedProps = new Set(['diocese', 'nation']);
-        this.diocese = diocese;
-        this.nation = nation;
-
-        return new Proxy( this, {
-            get: (target, prop) => {
-                // Allow JSON.stringify
-                if (prop === 'toJSON') {
-                    return () => ({
-                        diocese: this.diocese,
-                        nation: this.nation
-                    });
-                }
-                if ( allowedProps.has( prop ) ) {
-                    return Reflect.get(target, prop);
-                }
-                throw new Error( `Cannot access invalid property "${prop}".` );
-            },
-
-            set( target, prop, value ) {
-                if ( allowedProps.has( prop ) ) {
-                    //TODO: Add validation for diocese and nation
-                    return Reflect.set(target, prop, value);
-                }
-                throw new Error( `Cannot add new property "${prop}".` );
-            }
-        } );
-    }
-}
 
 export {
-    DiocesanCalendarPayload,
-    DiocesanCalendarDELETEPayload
+    DiocesanCalendarPayload
 }

--- a/assets/js/DiocesanCalendarPayload.js
+++ b/assets/js/DiocesanCalendarPayload.js
@@ -7,13 +7,26 @@
  * @prop {string} metadata.region
  */
 
+
 class DiocesanCalendarPayload {
+    /**
+     * Constructs a DiocesanCalendarPayload instance.
+     *
+     * @param {Array<RowData>} litcal - The liturgical calendar data.
+     * @param {Object} settings - The settings for the calendar, containing properties such as epiphany, ascension, and corpus_christi.
+     * @param {Object} metadata - Additional metadata about the calendar, such as the diocese name, diocese id, nation, supported locales, etc.
+     *
+     * @returns {Proxy} - A proxy to control access to properties and prevent adding new ones.
+     *
+     * The constructor initializes the payload with the provided liturgical calendar, settings, and metadata.
+     * It also returns a Proxy that restricts access to only allowed properties and supports JSON serialization.
+     */
     constructor( litcal, settings, metadata ) {
         const allowedProps = new Set(['litcal', 'settings', 'metadata']);
         this.litcal = litcal;
         this.settings = settings;
         this.metadata = metadata;
-        return new Proxy( this, {
+        return new Proxy(this, {
             get: (target, prop) => {
                 // Allow JSON.stringify
                 if (prop === 'toJSON') {
@@ -31,15 +44,15 @@ class DiocesanCalendarPayload {
 
             set( target, prop, value ) {
                 if ( allowedProps.has( prop ) ) {
-                    //TODO: Add validations
+                    // Theoretically we could add validations here against calendars metadata
+                    // But that would probably be more feasible with a dedicated metadata class...
                     return Reflect.set(target, prop, value);
                 }
                 throw new Error( `Cannot add new property "${prop}".` );
             }
-        } );
+        });
     }
 }
-
 
 export {
     DiocesanCalendarPayload

--- a/assets/js/DiocesanCalendarPayload.js
+++ b/assets/js/DiocesanCalendarPayload.js
@@ -15,20 +15,26 @@ class DiocesanCalendarPayload {
         this.metadata = metadata;
         return new Proxy( this, {
             get: (target, prop) => {
+                // Allow JSON.stringify
+                if (prop === 'toJSON') {
+                    return () => ({
+                        litcal: this.litcal,
+                        settings: this.settings,
+                        metadata: this.metadata
+                    });
+                }
                 if ( allowedProps.has( prop ) ) {
                     return Reflect.get(target, prop);
-                } else {
-                    throw new Error( `Cannot access invalid property "${prop}".` );
                 }
+                throw new Error( `Cannot access invalid property "${prop}".` );
             },
 
             set( target, prop, value ) {
                 if ( allowedProps.has( prop ) ) {
                     //TODO: Add validations
                     return Reflect.set(target, prop, value);
-                } else {
-                    throw new Error( `Cannot add new property "${prop}".` );
                 }
+                throw new Error( `Cannot add new property "${prop}".` );
             }
         } );
     }
@@ -54,26 +60,25 @@ class DiocesanCalendarDELETEPayload {
 
         return new Proxy( this, {
             get: (target, prop) => {
-                if ( allowedProps.has( prop ) || (prop === 'toJSON' && typeof target[prop] === 'function') ) {
-                    if (prop === 'toJSON') {
-                        return () => ({
-                            diocese: this.diocese,
-                            nation: this.nation
-                        });
-                    }
-                    return Reflect.get(target, prop);
-                } else {
-                    throw new Error( `Cannot access invalid property "${prop}".` );
+                // Allow JSON.stringify
+                if (prop === 'toJSON') {
+                    return () => ({
+                        diocese: this.diocese,
+                        nation: this.nation
+                    });
                 }
+                if ( allowedProps.has( prop ) ) {
+                    return Reflect.get(target, prop);
+                }
+                throw new Error( `Cannot access invalid property "${prop}".` );
             },
 
             set( target, prop, value ) {
                 if ( allowedProps.has( prop ) ) {
                     //TODO: Add validation for diocese and nation
                     return Reflect.set(target, prop, value);
-                } else {
-                    throw new Error( `Cannot add new property "${prop}".` );
                 }
+                throw new Error( `Cannot add new property "${prop}".` );
             }
         } );
     }

--- a/assets/js/DiocesanCalendarPayload.js
+++ b/assets/js/DiocesanCalendarPayload.js
@@ -51,9 +51,16 @@ class DiocesanCalendarDELETEPayload {
         const allowedProps = new Set(['diocese', 'nation']);
         this.diocese = diocese;
         this.nation = nation;
+
         return new Proxy( this, {
             get: (target, prop) => {
                 if ( allowedProps.has( prop ) || (prop === 'toJSON' && typeof target[prop] === 'function') ) {
+                    if (prop === 'toJSON') {
+                        return () => ({
+                            diocese: this.diocese,
+                            nation: this.nation
+                        });
+                    }
                     return Reflect.get(target, prop);
                 } else {
                     throw new Error( `Cannot access invalid property "${prop}".` );

--- a/assets/js/FormControls.js
+++ b/assets/js/FormControls.js
@@ -275,8 +275,8 @@ class FormControls {
 
         if (FormControls.settings.monthField) {
             formRow += `<div class="form-group col-sm-2">
-            <label for="onTheFly${FormControls.uniqid}Month"><span class="month-label">${Messages[ "Month" ]}</span><div class="form-check form-check-inline form-switch ms-2 ps-5 border border-secondary bg-light align-bottom" title="switch on for mobile celebration as opposed to fixed date">
-                <label class="form-check-label me-1" for="onTheFly${FormControls.uniqid}StrtotimeSwitch">Mobile</label>
+            <label for="onTheFly${FormControls.uniqid}Month" class="d-flex justify-content-between align-items-end"><span class="month-label">${Messages[ "Month" ]}</span><div class="form-check form-check-inline form-switch me-0 ps-5 pe-2 border border-2 border-secondary rounded bg-light" title="switch on for mobile celebration as opposed to fixed date">
+                <label class="form-check-label" for="onTheFly${FormControls.uniqid}StrtotimeSwitch">Mobile</label>
                 <input class="form-check-input litEvent litEventStrtotimeSwitch" type="checkbox" data-bs-toggle="toggle" data-bs-size="xs" data-bs-onstyle="info" data-bs-offstyle="dark" role="switch" id="onTheFly${FormControls.uniqid}StrtotimeSwitch">
             </div></label>
             <select class="form-select litEvent litEventMonth" id="onTheFly${FormControls.uniqid}Month">`;
@@ -293,8 +293,8 @@ class FormControls {
 
         if(FormControls.settings.strtotimeField) {
             formRow += `<div class="form-group col-sm-3">
-            <label for="onTheFly${FormControls.uniqid}Strtotime"><span class="month-label">Relative date</span><div class="form-check form-check-inline form-switch ms-2 ps-5 border border-secondary bg-light align-bottom" title="switch on for mobile celebration as opposed to fixed date">
-                <label class="form-check-label me-1" for="onTheFly${FormControls.uniqid}StrtotimeSwitch">Mobile</label>
+            <label for="onTheFly${FormControls.uniqid}Strtotime" class="d-flex justify-content-between align-items-end"><span class="month-label">Relative date</span><div class="form-check form-check-inline form-switch me-0 ps-5 pe-2 border border-2 border-secondary rounded bg-light" title="switch on for mobile celebration as opposed to fixed date">
+                <label class="form-check-label" for="onTheFly${FormControls.uniqid}StrtotimeSwitch">Mobile</label>
                 <input class="form-check-input litEvent litEventStrtotimeSwitch" type="checkbox" data-bs-toggle="toggle" data-bs-size="xs" data-bs-onstyle="info" data-bs-offstyle="dark" role="switch" id="onTheFly${FormControls.uniqid}StrtotimeSwitch">
             </div></label>
             <input type="text" class="form-control litEvent litEventStrtotime" id="onTheFly${FormControls.uniqid}Strtotime" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" />
@@ -403,7 +403,7 @@ class FormControls {
         formRow += `<div class="row gx-2 align-items-baseline">`;
 
         formRow += `<div class="form-group col-sm-6">`;
-        if(FormControls.settings.tagField === false){
+        if(FormControls.settings.tagField === false) {
             formRow += `<input type="hidden" class="litEventEvent_key" id="onTheFly${FormControls.uniqid}Tag" value="${festivity !== null ? festivity.event_key : ''}" />`;
         }
         formRow += `<label for="onTheFly${FormControls.uniqid}Name">${Messages[ "Name" ]}</label>
@@ -464,7 +464,7 @@ class FormControls {
         if (FormControls.settings.tagField) {
             formRow += `<div class="form-group col-sm-2">
             <label for="onTheFly${FormControls.uniqid}Tag">${Messages[ "Tag" ]}</label>
-            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventTag" id="onTheFly${FormControls.uniqid}Tag" />
+            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventEvent_key" id="onTheFly${FormControls.uniqid}Tag" />
             </div>`;
         }
 
@@ -661,7 +661,7 @@ class FormControls {
         if (FormControls.settings.tagField) {
             formRow += `<div class="form-group col-sm-2">
             <label for="onTheFly${FormControls.uniqid}Tag">${Messages[ "Tag" ]}</label>
-            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventTag" id="onTheFly${FormControls.uniqid}Tag" />
+            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventEvent_key" id="onTheFly${FormControls.uniqid}Tag" />
             </div>`;
         }
 

--- a/assets/js/FormControls.js
+++ b/assets/js/FormControls.js
@@ -275,7 +275,7 @@ class FormControls {
 
         if (FormControls.settings.monthField) {
             formRow += `<div class="form-group col-sm-2">
-            <label for="onTheFly${FormControls.uniqid}Month"><span class="month-label">${Messages[ "Month" ]}</span><div class="form-check form-check-inline form-switch ms-2 ps-5 border border-secondary bg-light" title="switch on for mobile celebration as opposed to fixed date">
+            <label for="onTheFly${FormControls.uniqid}Month"><span class="month-label">${Messages[ "Month" ]}</span><div class="form-check form-check-inline form-switch ms-2 ps-5 border border-secondary bg-light align-bottom" title="switch on for mobile celebration as opposed to fixed date">
                 <label class="form-check-label me-1" for="onTheFly${FormControls.uniqid}StrtotimeSwitch">Mobile</label>
                 <input class="form-check-input litEvent litEventStrtotimeSwitch" type="checkbox" data-bs-toggle="toggle" data-bs-size="xs" data-bs-onstyle="info" data-bs-offstyle="dark" role="switch" id="onTheFly${FormControls.uniqid}StrtotimeSwitch">
             </div></label>
@@ -293,7 +293,7 @@ class FormControls {
 
         if(FormControls.settings.strtotimeField) {
             formRow += `<div class="form-group col-sm-3">
-            <label for="onTheFly${FormControls.uniqid}Strtotime"><span class="month-label">Relative date</span><div class="form-check form-check-inline form-switch ms-2 ps-5 border border-secondary bg-light" title="switch on for mobile celebration as opposed to fixed date">
+            <label for="onTheFly${FormControls.uniqid}Strtotime"><span class="month-label">Relative date</span><div class="form-check form-check-inline form-switch ms-2 ps-5 border border-secondary bg-light align-bottom" title="switch on for mobile celebration as opposed to fixed date">
                 <label class="form-check-label me-1" for="onTheFly${FormControls.uniqid}StrtotimeSwitch">Mobile</label>
                 <input class="form-check-input litEvent litEventStrtotimeSwitch" type="checkbox" data-bs-toggle="toggle" data-bs-size="xs" data-bs-onstyle="info" data-bs-offstyle="dark" role="switch" id="onTheFly${FormControls.uniqid}StrtotimeSwitch">
             </div></label>
@@ -877,17 +877,17 @@ class LitEvent {
 
 /**
  * Configures the multiselect for the liturgical common field of a festivity / liturgical event row.
- * @param {jQuery} $row - The jQuery object of the row to configure the multiselect for. If null, the function will configure all rows.
+ * @param {HTMLElement} row - The HTMLElement representing the row to configure the multiselect for. If null, the function will configure all rows.
  * @param {Array<string>} common - The values to select in the multiselect. If null, the function will select all values.
  */
-const setCommonMultiselect = ($row=null,common=null) => {
-    let $litEventCommon;
-    if( $row !== null ) {
-        $litEventCommon = $row.find('.litEventCommon');
+const setCommonMultiselect = (row=null, common=null) => {
+    let litEventCommon;
+    if( row !== null ) {
+        litEventCommon = row.querySelector('.litEventCommon');
     } else {
-        $litEventCommon = $('.litEventCommon');
+        litEventCommon = document.querySelectorAll('.litEventCommon');
     }
-    $litEventCommon.multiselect({
+    $(litEventCommon).multiselect({
         buttonWidth: '100%',
         buttonClass: 'form-select',
         templates: {
@@ -896,23 +896,27 @@ const setCommonMultiselect = ($row=null,common=null) => {
         maxHeight: 200,
         enableCaseInsensitiveFiltering: true,
         onChange: (option, checked) => {
-            if (($(option).val() !== 'Proper' && checked === true && $(option).parent().val().includes('Proper')) || checked === false ) {
-                $(option).parent().multiselect('deselect', 'Proper');
-                $row = $(option).closest('.row');
-                if( $row.find('.litEventReadings').length ) {
-                    $row.find('.litEventReadings').prop('disabled',true);
+            const selectEl = option.parentElement;
+            const selectedOptions = Array.from(selectEl.selectedOptions).map(({value}) => value);
+            if ((option.value !== 'Proper' && checked === true && selectedOptions.includes('Proper')) || checked === false ) {
+                $(selectEl).multiselect('deselect', 'Proper');
+                row = option.closest('.row');
+                const litEventReadingsEl = row.querySelector('.litEventReadings');
+                if( litEventReadingsEl ) {
+                    litEventReadingsEl.disabled = true;
                 }
-            } else if ($(option).val() === 'Proper' && checked === true) {
-                $(option).parent().multiselect('deselectAll', false).multiselect('select', 'Proper');
-                $row = $(option).closest('.row');
-                if( $row.find('.litEventReadings').length ) {
-                    $row.find('.litEventReadings').prop('disabled',false);
+            } else if (option.value === 'Proper' && checked === true) {
+                $(selectEl).multiselect('deselectAll', false).multiselect('select', 'Proper');
+                row = option.closest('.row');
+                const litEventReadingsEl = row.querySelector('.litEventReadings');
+                if( litEventReadingsEl ) {
+                    litEventReadingsEl.disabled = false;
                 }
             }
         }
     }).multiselect('deselectAll', false);
     if( common !== null ) {
-        $litEventCommon.multiselect('select', common);
+        $(litEventCommon).multiselect('select', common);
     }
 }
 

--- a/assets/js/FormControls.js
+++ b/assets/js/FormControls.js
@@ -404,7 +404,7 @@ class FormControls {
 
         formRow += `<div class="form-group col-sm-6">`;
         if(FormControls.settings.tagField === false) {
-            formRow += `<input type="hidden" class="litEventEvent_key" id="onTheFly${FormControls.uniqid}Tag" value="${festivity !== null ? festivity.event_key : ''}" />`;
+            formRow += `<input type="hidden" class="litEventEventKey" id="onTheFly${FormControls.uniqid}Tag" value="${festivity !== null ? festivity.event_key : ''}" />`;
         }
         formRow += `<label for="onTheFly${FormControls.uniqid}Name">${Messages[ "Name" ]}</label>
         <input type="text" class="form-control litEvent litEventName${festivity !== null && typeof festivity.name==='undefined' ? ` is-invalid` : ``}" id="onTheFly${FormControls.uniqid}Name" value="${festivity !== null ? festivity.name : ''}"${FormControls.settings.nameField === false ? ' readonly' : ''} />
@@ -464,7 +464,7 @@ class FormControls {
         if (FormControls.settings.tagField) {
             formRow += `<div class="form-group col-sm-2">
             <label for="onTheFly${FormControls.uniqid}Tag">${Messages[ "Tag" ]}</label>
-            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventEvent_key" id="onTheFly${FormControls.uniqid}Tag" />
+            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventEventKey" id="onTheFly${FormControls.uniqid}Tag" />
             </div>`;
         }
 
@@ -591,7 +591,7 @@ class FormControls {
 
         formRow += `<div class="form-group col-sm-6">`;
         if(FormControls.settings.tagField === false){
-            formRow += `<input type="hidden" class="litEventEvent_key" id="onTheFly${FormControls.uniqid}Tag" value="${festivity !== null ? festivity.event_key : ''}" />`;
+            formRow += `<input type="hidden" class="litEventEventKey" id="onTheFly${FormControls.uniqid}Tag" value="${festivity !== null ? festivity.event_key : ''}" />`;
         }
         formRow += `<label for="onTheFly${FormControls.uniqid}Name">${Messages[ "Name" ]}</label>
         <input type="text" class="form-control litEvent litEventName${festivity !== null && typeof festivity.name==='undefined' ? ` is-invalid` : ``}" id="onTheFly${FormControls.uniqid}Name" value="${festivity !== null ? festivity.name : ''}"${FormControls.settings.nameField === false ? ' readonly' : ''} />
@@ -661,7 +661,7 @@ class FormControls {
         if (FormControls.settings.tagField) {
             formRow += `<div class="form-group col-sm-2">
             <label for="onTheFly${FormControls.uniqid}Tag">${Messages[ "Tag" ]}</label>
-            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventEvent_key" id="onTheFly${FormControls.uniqid}Tag" />
+            <input type="text" value="${festivity !== null ? festivity.event_key : ''}" class="form-control litEvent litEventEventKey" id="onTheFly${FormControls.uniqid}Tag" />
             </div>`;
         }
 
@@ -877,8 +877,8 @@ class LitEvent {
 
 /**
  * Configures the multiselect for the liturgical common field of a festivity / liturgical event row.
- * @param {HTMLElement} row - The HTMLElement representing the row to configure the multiselect for. If null, the function will configure all rows.
- * @param {Array<string>} common - The values to select in the multiselect. If null, the function will select all values.
+ * @param {?HTMLElement} row - The HTMLElement representing the row to configure the multiselect for. If null, the function will configure all rows.
+ * @param {?Array<string>} common - The values to select in the multiselect. If null, the function will select all values.
  */
 const setCommonMultiselect = (row=null, common=null) => {
     let litEventCommon;
@@ -895,17 +895,28 @@ const setCommonMultiselect = (row=null, common=null) => {
         },
         maxHeight: 200,
         enableCaseInsensitiveFiltering: true,
+        /**
+         * Triggered when the selected values of the multiselect for the liturgical common field change.
+         * @param {HTMLOptionElement} option - The option that was selected or deselected.
+         * @param {boolean} checked - Whether the option was selected or deselected.
+         * @fires CustomEvent#change
+         */
         onChange: (option, checked) => {
             const selectEl = option[0].parentElement;
             const selectedOptions = Array.from(selectEl.selectedOptions).map(({value}) => value);
-            if ((option.value !== 'Proper' && checked === true && selectedOptions.includes('Proper')) || checked === false ) {
+            console.log('setCommonMultiselect: litEventCommon has changed, new value is: ', selectedOptions);
+            if (option[0].value !== 'Proper' && checked === true && selectedOptions.includes('Proper')) {
+                console.log('setCommonMultiselect: option[0].value:', option[0].value, 'checked:', checked, 'selectedOptions.includes(\'Proper\'):', selectedOptions.includes('Proper'));
+                console.log('setCommonMultiselect: deselecting Proper');
                 $(selectEl).multiselect('deselect', 'Proper');
                 row = option[0].closest('.row');
                 const litEventReadingsEl = row.querySelector('.litEventReadings');
                 if( litEventReadingsEl ) {
                     litEventReadingsEl.disabled = true;
                 }
-            } else if (option.value === 'Proper' && checked === true) {
+            } else if (option[0].value === 'Proper' && checked === true) {
+                console.log('setCommonMultiselect: option[0].value:', option[0].value, 'checked:', checked);
+                console.log('setCommonMultiselect: selecting Proper');
                 $(selectEl).multiselect('deselectAll', false).multiselect('select', 'Proper');
                 row = option[0].closest('.row');
                 const litEventReadingsEl = row.querySelector('.litEventReadings');
@@ -913,8 +924,13 @@ const setCommonMultiselect = (row=null, common=null) => {
                     litEventReadingsEl.disabled = false;
                 }
             }
+            selectEl.dispatchEvent(new CustomEvent('change', {
+                bubbles: true,
+                cancelable: true
+              }));
         }
     }).multiselect('deselectAll', false);
+
     if( common !== null ) {
         $(litEventCommon).multiselect('select', common);
     }

--- a/assets/js/FormControls.js
+++ b/assets/js/FormControls.js
@@ -896,18 +896,18 @@ const setCommonMultiselect = (row=null, common=null) => {
         maxHeight: 200,
         enableCaseInsensitiveFiltering: true,
         onChange: (option, checked) => {
-            const selectEl = option.parentElement;
+            const selectEl = option[0].parentElement;
             const selectedOptions = Array.from(selectEl.selectedOptions).map(({value}) => value);
             if ((option.value !== 'Proper' && checked === true && selectedOptions.includes('Proper')) || checked === false ) {
                 $(selectEl).multiselect('deselect', 'Proper');
-                row = option.closest('.row');
+                row = option[0].closest('.row');
                 const litEventReadingsEl = row.querySelector('.litEventReadings');
                 if( litEventReadingsEl ) {
                     litEventReadingsEl.disabled = true;
                 }
             } else if (option.value === 'Proper' && checked === true) {
                 $(selectEl).multiselect('deselectAll', false).multiselect('select', 'Proper');
-                row = option.closest('.row');
+                row = option[0].closest('.row');
                 const litEventReadingsEl = row.querySelector('.litEventReadings');
                 if( litEventReadingsEl ) {
                     litEventReadingsEl.disabled = false;

--- a/assets/js/Payload.js
+++ b/assets/js/Payload.js
@@ -1,10 +1,9 @@
 import { NationalCalendarPayload } from "./NationalCalendarPayload.js";
-import { DiocesanCalendarPayload, DiocesanCalendarDELETEPayload } from "./DiocesanCalendarPayload.js";
+import { DiocesanCalendarPayload } from "./DiocesanCalendarPayload.js";
 import { WiderRegionPayload } from "./WiderRegionPayload.js";
 
 export {
     WiderRegionPayload,
     NationalCalendarPayload,
-    DiocesanCalendarPayload,
-    DiocesanCalendarDELETEPayload
+    DiocesanCalendarPayload
 }

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -2651,8 +2651,16 @@ document.addEventListener('change', (ev) => {
         document.querySelector('#addLanguageEditionRomanMissal').disabled = false;
     }
     if (ev.target.id === 'currentLocalization') {
-        if (API.category === 'diocese' && API.method === 'PATCH') {
-            loadDiocesanCalendarData();
+        if (API.category === 'diocese') {
+            if (API.method === 'PATCH') {
+                loadDiocesanCalendarData();
+            }
+            if (API.method === 'PUT') {
+                const currentLocalization = document.querySelector('#currentLocalization').value;
+                const otherLocalizations = Array.from(document.querySelector('.calendarLocales').selectedOptions).filter(({ value }) => value !== currentLocalization).map(({ value }) => value);
+                resetOtherLocalizationInputs();
+                refreshOtherLocalizationInputs(otherLocalizations);
+            }
         }
         else if (API.method === 'PATCH') {
             if (API.category === 'widerregion') {

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -27,6 +27,12 @@ import {
     DiocesanCalendarDELETEPayload
 } from './Payload.js';
 
+// the Messages global is set in extending.php
+const { LOCALE, AvailableLocales, AvailableLocalesWithRegion, CountriesWithCatholicDioceses } = Messages;
+const jsLocale = LOCALE.replace('_', '-');
+FormControls.jsLocale = jsLocale;
+FormControls.weekdayFormatter = new Intl.DateTimeFormat(jsLocale, { weekday: "long" });
+FormControls.index = LitCalMetadata;
 
 toastr.options = {
     "closeButton": true,
@@ -46,11 +52,60 @@ toastr.options = {
     "hideMethod": "fadeOut"
 }
 
-// the Messages global is set in extending.php
-const { LOCALE, LOCALE_WITH_REGION, AvailableLocales, AvailableLocalesWithRegion, CountriesWithCatholicDioceses } = Messages;
-const jsLocale = LOCALE.replace('_', '-');
-FormControls.jsLocale = jsLocale;
-FormControls.weekdayFormatter = new Intl.DateTimeFormat(jsLocale, { weekday: "long" });
+let DiocesesList = null;
+let CalendarData = { litcal: [], i18n: {} };
+let MissalsIndex = null;
+let tzdata;
+let translationData = {};
+
+Promise.all([
+    fetch('./assets/data/WorldDiocesesByNation.json', {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json'
+        }
+    }),
+    fetch(MissalsURL, {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json'
+        }
+    }),
+    fetch('https://raw.githubusercontent.com/vvo/tzdb/refs/heads/main/raw-time-zones.json', {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json'
+        }
+    })
+]).then(responses => {
+    return Promise.all(responses.map((response) => {
+        if (response.ok) {
+            return response.json();
+        }
+        else {
+            throw new Error(response.status + ': ' + response.text);
+        }
+    }));
+}).then(data => {
+    DiocesesList = data[0].catholic_dioceses_latin_rite;
+
+    if (data[1].hasOwnProperty('litcal_missals')) {
+        console.log('retrieved /missals metadata:');
+        console.log(data[1]);
+        MissalsIndex = data[1].litcal_missals;
+        FormControls.missals = data[1].litcal_missals;
+        const publishedRomanMissalsStr = MissalsIndex.map(({missal_id, name}) => !missal_id.startsWith('EDITIO_TYPICA_') ? `<option class="list-group-item" value="${missal_id}">${name}</option>` : null).join('')
+        document.querySelector('#languageEditionRomanMissalList').insertAdjacentHTML('beforeend', publishedRomanMissalsStr);
+        toastr["success"]('Successfully retrieved data from /missals path', "Success");
+    }
+
+    tzdata = data[2];
+    toastr["success"]('Successfully retrieved time zone data', "Success");
+}).catch(error => {
+    console.error(error);
+    toastr["error"](error, "Error");
+});
+
 
 /**
  * Proxy sanitizer for the proxied API object. Sanitizes the values assigned to properties of the proxied API object.
@@ -76,16 +131,36 @@ const sanitizeProxiedAPI = {
         }
         switch (prop) {
             case 'path':
-                // the path will be set based on the category and key parameters
-                value = (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') ? `${RegionalDataURL}/${target['category']}/${target['key']}` : '';
+                // the path will be set based on the method, category and key parameters
+                if (target.hasOwnProperty('method') && target['method'] === 'PUT') {
+                    if (target.hasOwnProperty('category') && target['category'] !== '') {
+                        value = `${RegionalDataURL}/${target['category']}`;
+                    } else {
+                        value = `${RegionalDataURL}`;
+                    }
+                } else {
+                    if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
+                        value = `${RegionalDataURL}/${target['category']}/${target['key']}`;
+                    }
+                    else if (target.hasOwnProperty('category') && target['category'] !== '') {
+                        value = `${RegionalDataURL}/${target['category']}`;
+                    }
+                }
                 break;
             case 'category':
                 if (false === ['widerregion', 'nation', 'diocese'].includes(value)) {
-                    console.warn(`property 'category' of this object must be one of the values 'widerregion', 'nation', or 'diocese'`);
+                    console.error(`property 'category' of this object must be one of the values 'widerregion', 'nation', or 'diocese'`);
                     return;
                 }
-                if (target.hasOwnProperty('key') && target['key'] !== '') {
-                    target['path'] = `${RegionalDataURL}/${value}/${target['key']}`;
+                if (target.hasOwnProperty('method') && target['method'] === 'PUT') {
+                    target['path'] = `${RegionalDataURL}/${value}`;
+                } else {
+                    if (target.hasOwnProperty('key') && target['key'] !== '') {
+                        target['path'] = `${RegionalDataURL}/${value}/${target['key']}`;
+                    }
+                    else {
+                        target['path'] = `${RegionalDataURL}/${value}`;
+                    }
                 }
                 break;
             case 'key':
@@ -94,42 +169,63 @@ const sanitizeProxiedAPI = {
                         ([value, target['locale']] = value.split(' - '));
                     }
                     if (false === ['Americas', 'Europe', 'Africa', 'Oceania', 'Asia', 'Antarctica'].includes(value)) {
-                        console.warn(`property 'key' of this object must be one of the values 'Americas', 'Europe', 'Africa', 'Oceania', or 'Asia'`);
+                        console.error(`property 'key=${value}' of this object is not a valid value, valid values are: 'Americas', 'Europe', 'Africa', 'Oceania', 'Asia' and 'Antarctica'`);
                         return;
                     }
                 }
                 else if (target['category'] === 'nation') {
                     if (false === Object.keys(CountriesWithCatholicDioceses).includes(value)) {
-                        console.warn(`property 'key' of this object is not a valid value, possible values are: ${Object.keys(CountriesWithCatholicDioceses).join(', ')}`);
+                        console.error(`property 'key=${value}' of this object is not a valid value, possible values are: ${Object.keys(CountriesWithCatholicDioceses).join(', ')}`);
                         return;
                     }
                     if (false === LitCalMetadata.national_calendars_keys.includes(value)) {
-                        console.warn(`property 'key' of this object is not yet defined, defined values are: ${LitCalMetadata.national_calendars_keys.join(', ')}`);
+                        console.warn(`property 'key=${value}' of this object is not yet defined, defined values are: ${LitCalMetadata.national_calendars_keys.join(', ')}`);
                     }
                 }
                 else if (target['category'] === 'diocese') {
                     if (false === LitCalMetadata.diocesan_calendars_keys.includes(value)) {
-                        console.warn(`property 'key' of this object is not yet defined, defined values are: ${LitCalMetadata.diocesan_calendars_keys.join(', ')}`);
+                        console.warn(`property 'key=${value}' is not yet defined, defined values are: ${LitCalMetadata.diocesan_calendars_keys.join(', ')}; no worries, let's go ahead and create it! We just have to make sure that API.method is set to 'PUT', currently it is set to '${target['method']}'`);
+                    } else {
+                        console.info(`property 'key=${value}' seems to be defined, defined values are: ${LitCalMetadata.diocesan_calendars_keys.join(', ')}`);
                     }
+                } else {
+                    console.error(`property 'category=${target['category']}' of this object is not a valid value, possible values are: 'widerregion', 'nation' or 'diocese'`);
+                    return;
                 }
                 if (target.hasOwnProperty('category') && target['category'] !== '') {
-                    target['path'] = `${RegionalDataURL}/${target['category']}/${value}`;
+                    if (target.hasOwnProperty('method') && target['method'] === 'PUT') {
+                        target['path'] = `${RegionalDataURL}/${target['category']}`;
+                    } else {
+                        target['path'] = `${RegionalDataURL}/${target['category']}/${value}`;
+                    }
                 }
                 break;
             case 'locale':
                 if (false === Object.keys(AvailableLocales).includes(value) && false === Object.keys(AvailableLocalesWithRegion).includes(value)) {
-                    console.warn(`property 'locale' of this object must be one of the values ${Object.keys(AvailableLocales).join(', ')}, ${Object.keys(AvailableLocalesWithRegion).join(', ')}`);
+                    console.error(`property 'locale=${value}' of this object is not a valid value, possible values are: ${Object.keys(AvailableLocales).join(', ')}, ${Object.keys(AvailableLocalesWithRegion).join(', ')}`);
                     return;
                 }
                 break;
             case 'method':
                 if (false === ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(value)) {
-                    console.warn(`property 'method' of this object must be one of the values 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'`);
+                    console.error(`property 'method=${value}' of this object is not a valid value, possible values are: 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'`);
                     return;
+                }
+                if (value === 'PUT') {
+                    if (target.hasOwnProperty('category') && target['category'] !== '') {
+                        target['path'] = `${RegionalDataURL}/${target['category']}`;
+                    }
+                } else {
+                    if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
+                        target['path'] = `${RegionalDataURL}/${target['category']}/${target['key']}`;
+                    }
+                    else if (target.hasOwnProperty('category') && target['category'] !== '') {
+                        target['path'] = `${RegionalDataURL}/${target['category']}`;
+                    }
                 }
                 break;
             default:
-                console.warn('unexpected property ' + prop + ' of type ' + typeof prop + ' on target of type ' + typeof target);
+                console.error('unexpected property ' + prop + ' of type ' + typeof prop + ' on target of type ' + typeof target);
                 return;
         }
         return Reflect.set(target, prop, value);
@@ -157,179 +253,130 @@ const API = new Proxy({
     method: ''
 }, sanitizeProxiedAPI);
 
-
-let DiocesesList = null;
-let CalendarData = { litcal: [] };
-let CalendarsIndex = null;
-let MissalsIndex = null;
-
-Promise.all([
-    fetch('./assets/data/WorldDiocesesByNation.json', {
-        method: 'GET',
-        headers: {
-            'Accept': 'application/json'
-        }
-    }),
-    fetch(MetadataURL, {
-        method: 'GET',
-        headers: {
-            'Accept': 'application/json'
-        }
-    }),
-    fetch(MissalsURL, {
-        method: 'GET',
-        headers: {
-            'Accept': 'application/json'
-        }
-    })
-]).then(responses => {
-    return Promise.all(responses.map((response) => {
-        if(response.ok) {
-            return response.json();
-        }
-        else {
-            throw new Error(response.status + ': ' + response.text);
-        }
-    }));
-}).then(data => {
-    DiocesesList = data[0].catholic_dioceses_latin_rite;
-
-    if(data[1].hasOwnProperty('litcal_metadata')) {
-        console.log('retrieved /calendars metadata:');
-        console.log(data[1]);
-        CalendarsIndex = data[1].litcal_metadata;
-        FormControls.index = data[1].litcal_metadata;
-        toastr["success"]('Successfully retrieved data from /calendars path', "Success");
-    }
-
-    if (data[2].hasOwnProperty('litcal_missals')) {
-        console.log('retrieved /missals metadata:');
-        console.log(data[2]);
-        MissalsIndex = data[2].litcal_missals;
-        FormControls.missals = data[2].litcal_missals;
-        const publishedRomanMissalsStr = MissalsIndex.map(({missal_id,name}) => !missal_id.startsWith('EDITIO_TYPICA_') ? `<option class="list-group-item" value="${missal_id}">${name}</option>` : null).join('')
-        $('#languageEditionRomanMissalList').append(publishedRomanMissalsStr);
-        toastr["success"]('Successfully retrieved data from /missals path', "Success");
-    }
-}).catch(error => {
-    console.error(error);
-    toastr["error"](error, "Error");
-});
+const translationTemplate = (locale, el) => {
+    const localeStr = locale.replace(/_/g, '-');
+    const localeObj = new Intl.Locale(localeStr);
+    const lang = localeObj.language.toUpperCase();
+    const langWithRegion = AvailableLocalesWithRegion[locale];
+    const eventKeyEl = el.parentElement.querySelector('.litEventEvent_key');
+    const eventKey = eventKeyEl ? eventKeyEl.value : (el.dataset.hasOwnProperty('valuewas') ? el.dataset.valuewas : '');
+    const value = translationData[locale].hasOwnProperty(eventKey) ? ` value="${translationData[locale][eventKey]}"` : '';
+    return `<div class="input-group input-group-sm mt-1">
+            <label class="input-group-text font-monospace" for="${el.id}_${locale}" title="${langWithRegion}">${lang}</label>
+            <input type="text" class="form-control litEvent litEventName_${lang}" id="${el.id}_${locale}" data-locale="${locale}"${value}>
+        </div>`;
+}
 
 /**
  * All Calendars interactions
  */
 
 $(document).on('change', '.litEvent', ev => {
-    let $row = $(ev.currentTarget).closest('.row');
-    let $card = $(ev.currentTarget).closest('.card-body');
-    if ($(ev.currentTarget).hasClass('litEventName')) {
+    let row = ev.target.closest('.row');
+    let card = ev.target.closest('.card-body');
+
+    if (ev.target.classList.contains('litEventName')) {
         //console.log('LitEvent name has changed');
-        if ($(ev.currentTarget).val() == '') {
+        if (ev.target.value === '') {
             //empty value probably means we are trying to delete an already defined event
             //so let's find the key and remove it
-            let oldEventKey = $(ev.currentTarget).attr('data-valuewas');
+            const oldEventKey = ev.target.dataset.valuewas;
             console.log('seems we are trying to delete the object key ' + oldEventKey);
             CalendarData.litcal = CalendarData.litcal.filter(item => item.festivity.event_key !== oldEventKey);
-            $(ev.currentTarget).attr('data-valuewas', '');
+            ev.target.setAttribute('data-valuewas', '');
         } else {
-            let eventKey = $(ev.currentTarget).val().replace(/[^a-zA-Z]/gi, '');
+            const eventKey = ev.target.value.replace(/[^a-zA-Z]/gi, '');
             console.log('new LitEvent name identifier is ' + eventKey);
-            console.log('festivity name is ' + $(ev.currentTarget).val());
-            if ($(ev.currentTarget).attr('data-valuewas') == '' && CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length === 0) {
+            console.log('festivity name is ' + ev.target.value);
+            console.log(CalendarData);
+            if (ev.target.dataset.valuewas === '' && CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length === 0) {
                 console.log('there was no data-valuewas attribute or it was empty, so we are creating ex-novo a new LitEvent');
-                let newEvent = { festivity: {}, metadata: {} };
+                const newEvent = { festivity: {}, metadata: {} };
+                const colorSelectedOptions = Array.from(row.querySelector('.litEventColor').selectedOptions);
+                const commonSelectedOptions = Array.from(row.querySelector('.litEventCommon').selectedOptions);
                 newEvent.festivity = new LitEvent(
                     eventKey,
-                    $(ev.currentTarget).val(), //name
-                    $row.find('.litEventColor').val(), //color
+                    ev.target.value, //name
+                    colorSelectedOptions.map(({ value }) => value), //color
                     null,
-                    $row.find('.litEventCommon').val(), //common
-                    parseInt($row.find('.litEventDay').val()), //day
-                    parseInt($row.find('.litEventMonth').val()), //month
+                    commonSelectedOptions.map(({ value }) => value), //common
+                    parseInt(row.querySelector('.litEventDay').value), //day
+                    parseInt(row.querySelector('.litEventMonth').value), //month
                 );
                 //let's initialize defaults just in case the default input values happen to be correct, so no change events are fired
-                newEvent.metadata.since_year = parseInt($row.find('.litEventSinceYear').val());
-                if( $row.find('.litEventUntilYear').val() !== '' ) {
-                    newEvent.metadata.until_year = parseInt($row.find('.litEventUntilYear').val());
+                newEvent.metadata.since_year = parseInt(row.querySelector('.litEventSinceYear').value);
+                if ( row.querySelector('.litEventUntilYear').value !== '' ) {
+                    newEvent.metadata.until_year = parseInt(row.querySelector('.litEventUntilYear').value);
                 }
-                let formRowIndex = $card.find('.row').index($row);
+                const formRowIndex = Array.from(card.querySelectorAll('.row')).indexOf(row);
                 newEvent.metadata.form_rownum = formRowIndex;
                 console.log('form row index is ' + formRowIndex);
-                $(ev.currentTarget).attr('data-valuewas', eventKey);
-                $(ev.currentTarget).removeClass('is-invalid');
+                ev.target.setAttribute('data-valuewas', eventKey);
+                ev.target.classList.remove('is-invalid');
                 console.log('adding new event to CalendarData.litcal:');
                 console.log( newEvent );
+                if (document.querySelector('.calendarLocales').selectedOptions.length > 1) {
+                    const currentLocalization = document.querySelector('#currentLocalization').value;
+                    const otherLocalizations = Array.from(document.querySelector('.calendarLocales').selectedOptions).filter(({ value }) => value !== currentLocalization).map(({ value }) => value);
+                    const otherLocalizationsInputs = otherLocalizations.map(localization => translationTemplate(localization, ev.target));
+                    ev.target.insertAdjacentHTML('afterend', otherLocalizationsInputs.join(''));
+                }
                 CalendarData.litcal.push(newEvent);
-            } else if ($(ev.currentTarget).attr('data-valuewas') != '') {
-                let oldEventKey = $(ev.currentTarget).attr('data-valuewas');
+            } else if (ev.target.dataset.valuewas !== '') {
+                const oldEventKey = ev.target.dataset.valuewas;
                 console.log('the preceding value here was ' + oldEventKey);
                 if (CalendarData.litcal.filter(item => item.festivity.event_key === oldEventKey).length > 0) {
                     if (oldEventKey !== eventKey) {
-                        if( /_2$/.test(eventKey) ) {
-                            console.log('oh geez, we are dealing with a second festivity that has the same name as a first festivity, because it continues where the previous untilYear left off...');
-                            eventKey = oldEventKey;
-                            console.log('but wait, why would you be changing the name of the second festivity? it will no longer match the first festivity!');
-                            console.log('this is becoming a big mess, arghhhh... results can start to be unpredictable');
-                            CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.name = $(ev.currentTarget).val();
-                            $(ev.currentTarget).attr('data-valuewas', eventKey);
-                            $(ev.currentTarget).removeClass('is-invalid');
-                        } else {
-                            console.log('I see you are trying to change the name of a festivity that was already defined. This will effectively change the relative key also, so here is what we are going to do:');
-                            console.log('will now attempt to copy the values from <' + oldEventKey + '> to <' + eventKey + '> and then remove <' + oldEventKey + '>');
-                            let copiedEvent = CalendarData.litcal.filter(item => item.festivity.event_key === oldEventKey)[0];
-                            copiedEvent.festivity.event_key = eventKey;
-                            copiedEvent.festivity.name = $(ev.currentTarget).val();
-                            CalendarData.litcal.push(copiedEvent);
-                            CalendarData.litcal = CalendarData.litcal.filter(item => item.festivity.event_key !== oldEventKey);
-                            $(ev.currentTarget).attr('data-valuewas', eventKey);
-                            $(ev.currentTarget).removeClass('is-invalid');
-                        }
+                        console.log('I see you are trying to change the name of a festivity that was already defined. This will effectively change the relative key also, so here is what we are going to do:');
+                        console.log('will now attempt to copy the values from <' + oldEventKey + '> to <' + eventKey + '> and then remove <' + oldEventKey + '>');
+                        const copiedEvent = CalendarData.litcal.filter(item => item.festivity.event_key === oldEventKey)[0];
+                        copiedEvent.festivity.event_key = eventKey;
+                        copiedEvent.festivity.name = ev.target.value;
+                        CalendarData.litcal.push(copiedEvent);
+                        CalendarData.litcal = CalendarData.litcal.filter(item => item.festivity.event_key !== oldEventKey);
+                        ev.target.setAttribute('data-valuewas', eventKey);
+                        ev.target.classList.remove('is-invalid');
                     }
                 }
             } else if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                if( false === CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.hasOwnProperty('until_year') ) {
+                if ( false === CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.hasOwnProperty('until_year') ) {
                     console.log('exact same festivity name was already defined elsewhere! key ' + eventKey + ' already exists! and the untilYear property was not defined!');
-                    $(ev.currentTarget).val('');
-                    $(ev.currentTarget).addClass('is-invalid');
+                    ev.target.value = '';
+                    ev.target.classList.add('is-invalid');
                 } else {
-                    let confrm = confirm('The same festivity name was already defined elsewhere. However an untilYear property was also defined, so perhaps you are wanting to define again for the years following. If this is the case, press OK, otherwise Cancel');
-                    if(confrm) {
+                    const confrm = confirm('The same festivity name was already defined elsewhere. However an untilYear property was also defined, so perhaps you are wanting to define again for the years following. If this is the case, press OK, otherwise Cancel');
+                    if (confrm) {
+                        ev.target.classList.remove('is-invalid');
                         //retrieve untilYear from the previous festivity with the same name
-                        let untilYear = CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.until_year;
+                        const untilYear = CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.until_year;
                         //set the sinceYear field on this row to the previous untilYear plus one
-                        $row.find('.litEventSinceYear').val(untilYear+1);
+                        row.querySelector('.litEventSinceYear').value = (untilYear + 1);
+                        row.querySelector('.litEventUntilYear').min = (untilYear + 2);
                         //update our eventKey to be distinct from the previous festivity
-                        eventKey = eventKey+'_2';
-                        $(ev.currentTarget).attr('data-valuewas', eventKey);
-                        let newEvent = { festivity: {}, metadata: {} };
+                        ev.target.setAttribute('data-valuewas', eventKey);
+                        const newEvent = { festivity: {}, metadata: {} };
+                        const colorSelectedOptions = Array.from(row.querySelector('.litEventColor').selectedOptions);
+                        const commonSelectedOptions = Array.from(row.querySelector('.litEventCommon').selectedOptions);
                         newEvent.festivity = new LitEvent(
                             eventKey,
-                            $(ev.currentTarget).val(), //name
-                            $row.find('.litEventColor').val(), //color
+                            ev.target.value, //name
+                            colorSelectedOptions.map(({ value }) => value), //color
                             null,
-                            $row.find('.litEventCommon').val(), //common
-                            parseInt($row.find('.litEventDay').val()), //day
-                            parseInt($row.find('.litEventMonth').val()), //month
+                            commonSelectedOptions.map(({ value }) => value), //common
+                            parseInt(row.querySelector('.litEventDay').value), //day
+                            parseInt(row.querySelector('.litEventMonth').value), //month
                         );
                         newEvent.metadata.since_year = untilYear + 1;
-                        let formRowIndex = $card.find('.row').index($row);
+                        const formRowIndex = Array.from(card.querySelectorAll('.row')).indexOf(row);
                         newEvent.metadata.form_rownum = formRowIndex;
                         console.log('form row index is ' + formRowIndex);
                         CalendarData.litcal.push(newEvent);
                     }
                 }
             }
-            switch ($(ev.currentTarget).closest('.carousel-item').attr('id')) {
+            switch (ev.target.closest('.carousel-item').id) {
                 case 'carouselItemSolemnities':
                     CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.grade = 6;
-                    if ($(ev.currentTarget).val().match(/(martyr|martir|mártir|märtyr)/i) !== null) {
-                        $row.find('.litEventColor').multiselect('deselectAll', false).multiselect('select', 'red');
-                        CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.color = [ 'red' ];
-                    } else {
-                        $row.find('.litEventColor').multiselect('deselectAll', false).multiselect('select', 'white');
-                        CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.color = [ 'white' ];
-                    }
                     break;
                 case 'carouselItemFeasts':
                     CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.grade = 4;
@@ -341,31 +388,39 @@ $(document).on('change', '.litEvent', ev => {
                     CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.grade = 2;
                     break;
             }
-        }
-    } else if ($(ev.currentTarget).hasClass('litEventDay')) {
-        if ($row.find('.litEventName').val() != "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
-            if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.day = parseInt($(ev.currentTarget).val());
+            if (ev.target.value.match(/(martyr|martir|mártir|märtyr)/i) !== null) {
+                $(row.querySelector('.litEventColor')).multiselect('deselectAll', false).multiselect('select', 'red');
+                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.color = [ 'red' ];
+            } else {
+                $(row.querySelector('.litEventColor')).multiselect('deselectAll', false).multiselect('select', 'white');
+                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.color = [ 'white' ];
             }
         }
-    } else if ($(ev.currentTarget).hasClass('litEventMonth')) {
-        let selcdMonth = parseInt($(ev.currentTarget).val());
-        if ($row.find('.litEventName').val() != "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
+    } else if (ev.target.classList.contains('litEventDay')) {
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
+            if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
+                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.day = parseInt(ev.target.value);
+            }
+        }
+    } else if (ev.target.classList.contains('litEventMonth')) {
+        const selcdMonth = parseInt(ev.target.value);
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
             if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
                 CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.month = selcdMonth;
             }
         }
-        $row.find('.litEventDay').attr('max', selcdMonth === Month.FEBRUARY ? "28" : (MonthsOfThirty.includes(selcdMonth) ? "30" : "31"));
-        if (parseInt($row.find('.litEventDay').val()) > parseInt($row.find('.litEventDay').attr('max'))) {
-            $row.find('.litEventDay').val($row.find('.litEventDay').attr('max'));
+        row.querySelector('.litEventDay').max = selcdMonth === Month.FEBRUARY ? 28 : (MonthsOfThirty.includes(selcdMonth) ? 30 : 31);
+        if (parseInt(row.querySelector('.litEventDay').value) > parseInt(row.querySelector('.litEventDay').max)) {
+            row.querySelector('.litEventDay').value = parseInt(row.querySelector('.litEventDay').max);
         }
-    } else if ($(ev.currentTarget).hasClass('litEventCommon')) {
-        if ($row.find('.litEventName').val() !== "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
+    } else if (ev.target.classList.contains('litEventCommon')) {
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
             if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.common = $(ev.currentTarget).val();
+                const selectedOptions = Array.from(ev.target.selectedOptions);
+                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.common = selectedOptions.map(({ value }) => value);
                 let eventColors = [];
                 if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.common.some( m => /Martyrs/.test(m) )) {
                     eventColors.push('red');
@@ -373,135 +428,144 @@ $(document).on('change', '.litEvent', ev => {
                 if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.common.some( m => /(Blessed Virgin Mary|Pastors|Doctors|Virgins|Holy Men and Women|Dedication of a Church)/.test(m) ) ) {
                     eventColors.push('white');
                 }
-                $row.find('.litEventColor').multiselect('deselectAll', false).multiselect('select', eventColors);
+                $(row.querySelector('.litEventColor')).multiselect('deselectAll', false).multiselect('select', eventColors);
                 CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.color = eventColors;
             }
         }
-    } else if ($(ev.currentTarget).hasClass('litEventColor')) {
-        if ($row.find('.litEventName').val() != "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
+    } else if (ev.target.classList.contains('litEventColor')) {
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
             if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.color = $(ev.currentTarget).val();
+                const selectedOptions = Array.from(ev.target.selectedOptions);
+                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.color = selectedOptions.map(({ value }) => value);;
             }
         }
-    } else if ($(ev.currentTarget).hasClass('litEventSinceYear')) {
-        if ($row.find('.litEventName').val() != "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
+    } else if (ev.target.classList.contains('litEventSinceYear')) {
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
             if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.since_year = parseInt($(ev.currentTarget).val());
+                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.since_year = parseInt(ev.target.value);
             }
         }
-    } else if ($(ev.currentTarget).hasClass('litEventUntilYear')) {
-        if ($row.find('.litEventName').val() != "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
+        row.querySelector('.litEventUntilYear').min = parseInt(ev.target.value) + 1;
+    } else if (ev.target.classList.contains('litEventUntilYear')) {
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
             if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                if($(ev.currentTarget).val() !== '') {
-                    CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.until_year = parseInt($(ev.currentTarget).val());
+                if (ev.target.value !== '') {
+                    CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.until_year = parseInt(ev.target.value);
                 } else {
                     delete CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].metadata.until_year;
                 }
             }
         }
-    } else if ($(ev.currentTarget).hasClass('litEventStrtotimeSwitch')) {
-        if ($row.find('.litEventName').val() != "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
+    } else if (ev.target.classList.contains('litEventStrtotimeSwitch')) {
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
             if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                if(false === $(ev.currentTarget).prop('checked')) {
+                if (false === ev.target.checked) {
                     delete CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.strtotime;
                     CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.day = 1;
                     CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.month = 1;
-                    let $strToTimeFormGroup = $(ev.currentTarget).closest('.form-group');
-                    $strToTimeFormGroup.removeClass('col-sm-3').addClass('col-sm-2');
-                    let $litEventStrtotime = $strToTimeFormGroup.find('.litEventStrtotime');
-                    let dayId = $litEventStrtotime.attr('id').replace('Strtotime', 'Day');
-                    let monthId = $litEventStrtotime.attr('id').replace('Strtotime', 'Month');
-                    $strToTimeFormGroup.before(`<div class="form-group col-sm-1">
+                    const strToTimeFormGroup = ev.target.closest('.form-group');
+                    strToTimeFormGroup.classList.remove('col-sm-3');
+                    strToTimeFormGroup.classList.add('col-sm-2');
+                    const litEventStrtotime = strToTimeFormGroup.querySelector('.litEventStrtotime');
+                    const dayId = litEventStrtotime.id.replace('Strtotime', 'Day');
+                    const monthId = litEventStrtotime.id.replace('Strtotime', 'Month');
+                    strToTimeFormGroup.insertAdjacentHTML('beforebegin', `<div class="form-group col-sm-1">
                     <label for="${dayId}">${Messages[ "Day" ]}</label><input type="number" min="1" max="31" value="1" class="form-control litEvent litEventDay" id="${dayId}" />
                     </div>`);
-                    $litEventStrtotime.remove();
+                    litEventStrtotime.remove();
                     let formRow = `<select class="form-select litEvent litEventMonth" id="${monthId}">`;
-                    let formatter = new Intl.DateTimeFormat(jsLocale, { month: 'long' });
+                    const formatter = new Intl.DateTimeFormat(jsLocale, { month: 'long' });
                     for (let i = 0; i < 12; i++) {
-                        let month = new Date(Date.UTC(0, i, 2, 0, 0, 0));
+                        const month = new Date(Date.UTC(0, i, 2, 0, 0, 0));
                         formRow += `<option value=${i + 1}>${formatter.format(month)}</option>`;
                     }
                     formRow += `</select>`;
-                    $strToTimeFormGroup.append(formRow);
-                    $strToTimeFormGroup.find('.month-label').text(Messages[ 'Month' ]).attr('for',monthId);
+                    strToTimeFormGroup.insertAdjacentHTML('beforeend', formRow);
+                    strToTimeFormGroup.querySelector('.month-label').textContent = Messages[ 'Month' ];
+                    strToTimeFormGroup.querySelector('.month-label').setAttribute('for', monthId);
                 } else {
                     delete CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.day;
                     delete CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.month;
                     CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.strtotime = '';
-                    $row.find('.litEventDay').closest('.form-group').remove();
-                    let $litEventMonthFormGrp = $(ev.currentTarget).closest('.form-group');
-                    let $litEventMonth = $litEventMonthFormGrp.find('.litEventMonth');
-                    let strtotimeId = $litEventMonth.attr('id').replace('Month','Strtotime');
-                    $litEventMonthFormGrp.removeClass('col-sm-2').addClass('col-sm-3');
-                    $litEventMonth.remove();
-                    $litEventMonthFormGrp.find('.month-label').text('Relative date').attr('for',strtotimeId);
-                    $litEventMonthFormGrp.append(`<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" />`);
+
+                    const dayFormGroup = row.querySelector('.litEventDay').closest('.form-group');
+                    dayFormGroup.remove();
+
+                    const litEventMonthFormGrp = ev.target.closest('.form-group');
+                    const litEventMonth = litEventMonthFormGrp.querySelector('.litEventMonth');
+                    const strtotimeId = litEventMonth.id.replace('Month', 'Strtotime');
+                    litEventMonthFormGrp.classList.remove('col-sm-2');
+                    litEventMonthFormGrp.classList.add('col-sm-3');
+                    litEventMonth.remove();
+                    litEventMonthFormGrp.querySelector('.month-label').textContent = 'Relative date';
+                    litEventMonthFormGrp.querySelector('.month-label').setAttribute('for', strtotimeId);
+                    litEventMonthFormGrp.insertAdjacentHTML('beforeend', `<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" />`);
                 }
             }
         } else {
             alert('this switch is disabled as long as the festivity row does not have a festivity name!');
             //ev.preventDefault();
-            if( false === $(ev.currentTarget).prop('checked') ) {
-                $(ev.currentTarget).prop('checked', true);
-            } else {
-                $(ev.currentTarget).prop('checked', false);
-            }
+            ev.target.checked = !ev.target.checked;
         }
-    } else if ($(ev.currentTarget).hasClass('litEventStrtotime')) {
-        if ($row.find('.litEventName').val() != "") {
-            let eventKey = $row.find('.litEventName').attr('data-valuewas');
+    } else if (ev.target.classList.contains('litEventStrtotime')) {
+        if (row.querySelector('.litEventName').value !== '') {
+            const eventKey = row.querySelector('.litEventName').dataset.valuewas;
             if (CalendarData.litcal.filter(item => item.festivity.event_key === eventKey).length > 0) {
-                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.strtotime = $(ev.currentTarget).val();
+                CalendarData.litcal.filter(item => item.festivity.event_key === eventKey)[0].festivity.strtotime = ev.target.value;
             }
         }
     }
 });
 
 $(document).on('click', '.onTheFlyEventRow', ev => {
-    let $row;
-    switch (ev.currentTarget.id) {
+    let row;
+    let form;
+    switch (ev.target.id) {
         case "addSolemnity":
             FormControls.title = Messages['Other Solemnity'];
-            $row = $(FormControls.CreateFestivityRow());
-            $('.carousel-item').first().find('form').append($row);
+            row = FormControls.CreateFestivityRow();
+            form = document.querySelector('.carousel-item:nth-child(1) form');
+            form.insertAdjacentHTML('beforeend', row);
             break;
         case "addFeast":
             FormControls.title = Messages['Other Feast'];
-            $row = $(FormControls.CreateFestivityRow());
-            $('.carousel-item').eq(1).find('form').append($row);
+            row = FormControls.CreateFestivityRow();
+            form = document.querySelector('.carousel-item:nth-child(2) form');
+            form.insertAdjacentHTML('beforeend', row);
             break;
         case "addMemorial":
             FormControls.title = Messages['Other Memorial'];
-            $row = $(FormControls.CreateFestivityRow());
-            $('.carousel-item').eq(2).find('form').append($row);
+            row = FormControls.CreateFestivityRow();
+            form = document.querySelector('.carousel-item:nth-child(3) form');
+            form.insertAdjacentHTML('beforeend', row);
             break;
         case "addOptionalMemorial":
             FormControls.title = Messages['Other Optional Memorial'];
-            $row = $(FormControls.CreateFestivityRow());
-            $('.carousel-item').eq(3).find('form').append($row);
+            row = FormControls.CreateFestivityRow();
+            form = document.querySelector('.carousel-item:nth-child(4) form');
+            form.insertAdjacentHTML('beforeend', row);
             break;
     }
 
-    setCommonMultiselect( $row, null );
-    $row.find('.litEventColor').multiselect({
+    setCommonMultiselect( form.lastElementChild, null );
+    $(form.lastElementChild.querySelector('.litEventColor')).multiselect({
         buttonWidth: '100%',
         buttonClass: 'form-select',
         templates: {
             button: '<button type="button" class="multiselect dropdown-toggle" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span></button>'
         }
     });
-    //$row.find('.litEventStrtotimeSwitch').bootstrapToggle();
 });
 
 
 $(document).on('change', '.calendarLocales', ev => {
-    const updatedLocales = $(ev.currentTarget).val();
-    console.log('updatedLocales:');
-    console.log(updatedLocales);
+    const calendarLocalesEl = document.querySelector('.calendarLocales');
+    const updatedLocales = Array.from(calendarLocalesEl.selectedOptions).map(({ value }) => value);
+    console.log('updatedLocales:', updatedLocales);
     const updatedLocalizationChoices = Object.entries(AvailableLocalesWithRegion).filter(([localeIso, ]) => {
         return updatedLocales.includes(localeIso);
     });
@@ -511,22 +575,26 @@ $(document).on('change', '.calendarLocales', ev => {
 });
 
 jQuery(document).ready(() => {
-    let $carousel = $('.carousel').carousel();
-
-    $carousel.on('slide.bs.carousel', event => {
-        $('#diocesanCalendarDefinitionCardLinks li').removeClass('active');
-        if (event.to == 0) {
-            $('#diocesanCalendarDefinitionCardLinks li:first-child').addClass('disabled');
-            $('#diocesanCalendarDefinitionCardLinks li:last-child').removeClass('disabled');
-        } else if (event.to == 3) {
-            $('#diocesanCalendarDefinitionCardLinks li:last-child').addClass('disabled');
-            $('#diocesanCalendarDefinitionCardLinks li:first-child').removeClass('disabled');
-        } else {
-            $('#diocesanCalendarDefinitionCardLinks li:first-child').removeClass('disabled');
-            $('#diocesanCalendarDefinitionCardLinks li:last-child').removeClass('disabled');
-        }
-        $('#diocesanCalendarDefinitionCardLinks li').find('[data-bs-slide-to=' + event.to + ']').parent('li').addClass('active');
-    });
+    const carouselElement = document.querySelector('.carousel');
+    if (carouselElement) {
+        new bootstrap.Carousel(carouselElement);
+        carouselElement.addEventListener('slide.bs.carousel', event => {
+            const navLinks = document.querySelectorAll('#diocesanCalendarDefinitionCardLinks li');
+            navLinks.forEach(link => link.classList.remove('active'));
+            if (event.to === 0) {
+                navLinks[0].classList.add('disabled');
+                navLinks[navLinks.length - 1].classList.remove('disabled');
+            } else if (event.to === 3) {
+                navLinks[navLinks.length - 1].classList.add('disabled');
+                navLinks[0].classList.remove('disabled');
+            } else {
+                navLinks[0].classList.remove('disabled');
+                navLinks[navLinks.length - 1].classList.remove('disabled');
+            }
+            const targetLink = document.querySelector(`#diocesanCalendarDefinitionCardLinks li [data-bs-slide-to="${event.to}"]`);
+            targetLink.parentElement.classList.add('active');
+        });
+    }
 
     $('.calendarLocales').multiselect({
         buttonWidth: '100%',
@@ -547,7 +615,6 @@ jQuery(document).ready(() => {
             button: '<button type="button" class="multiselect dropdown-toggle" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span></button>'
         }
     });
-
 });
 
 /**
@@ -555,9 +622,9 @@ jQuery(document).ready(() => {
  */
 
 $(document).on('change', '.regionalNationalCalendarName', ev => {
-    API.category = ev.currentTarget.dataset.category;
+    API.category = ev.target.dataset.category;
     // our proxy will take care of splitting locale from wider region, when we are setting a wider region key
-    API.key = ev.currentTarget.value;
+    API.key = ev.target.value;
     let nationalCalendarNotExists = true;
 
     const headers = {
@@ -565,7 +632,7 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
     };
 
     if ( API.category === 'nation' ) {
-        const selectedNationalCalendar = CalendarsIndex.national_calendars.filter(item => item.calendar_id === API.key);
+        const selectedNationalCalendar = LitCalMetadata.national_calendars.filter(item => item.calendar_id === API.key);
         if (selectedNationalCalendar.length > 0) {
             API.locale = selectedNationalCalendar[0].locales[0];
             headers['Accept-Language'] = API.locale.replaceAll('_', '-');
@@ -603,17 +670,17 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
         }).then(response => {
             if (response.ok) {
                 document.querySelector('#removeExistingCalendarDataBtn').disabled = false;
-                $('body').append(removeCalendarModal(`${API.category}/${API.key}`, Messages));
+                document.querySelector('body').insertAdjacentHTML('beforeend', removeCalendarModal(`${API.category}/${API.key}`, Messages));
                 return response.json();
             } else {
                 document.querySelector('#removeExistingCalendarDataBtn').disabled = true;
-                $('body').find('#removeCalendarPrompt').remove();
+                document.querySelector('#removeCalendarPrompt').remove();
                 const localeOptions = Object.entries(AvailableLocalesWithRegion).map(([localeIso, localeDisplayName]) => {
                     return `<option value="${localeIso}">${localeDisplayName}</option>`;
                 });
                 if (API.category === 'nation') {
-                    $('form#nationalCalendarSettingsForm')[0].reset();
-                    $('#publishedRomanMissalList').empty();
+                    document.querySelector('#nationalCalendarSettingsForm').reset();
+                    document.querySelector('#publishedRomanMissalList').innerHTML = '';
                     document.querySelector('#nationalCalendarLocales').innerHTML = localeOptions.join('\n');
                     document.querySelector('#currentLocalization').innerHTML = localeOptions.join('\n');
                     $('#nationalCalendarLocales').multiselect('rebuild');
@@ -622,8 +689,10 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
                     document.querySelector('#currentLocalization').innerHTML = localeOptions.join('\n');
                     $('#widerRegionLocales').multiselect('rebuild');
                 }
-                $('.regionalNationalSettingsForm .form-select').not('[multiple]').each(function() {
-                    $(this).val('').trigger('change');
+
+                document.querySelectorAll('.regionalNationalSettingsForm .form-select:not([multiple])').forEach(formSelect => {
+                    formSelect.value = '';
+                    formSelect.dispatchEvent(new Event('change'));
                 });
 
                 return Promise.reject(response);
@@ -650,17 +719,23 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
                     FormControls.settings.decreeURLField = true;
                     FormControls.settings.decreeLangMapField = false;
                     const { settings, metadata } = data;
-                    $('#nationalCalendarSettingEpiphany').val( settings.epiphany );
-                    $('#nationalCalendarSettingAscension').val( settings.ascension );
-                    $('#nationalCalendarSettingCorpusChristi').val( settings.corpus_christi );
+
+                    document.querySelector('#nationalCalendarSettingEpiphany').value = settings.epiphany;
+                    document.querySelector('#nationalCalendarSettingAscension').value = settings.ascension;
+                    document.querySelector('#nationalCalendarSettingCorpusChristi').value = settings.corpus_christi;
+
                     const localesForNation = Object.entries(AvailableLocalesWithRegion).filter(([localeIso, ]) => {
                         return localeIso.split('_').pop() === API.key;
                     });
-                    document.querySelector('#nationalCalendarLocales').innerHTML = localesForNation.map(([localeIso, localeDisplayName]) => {
-                        return `<option value="${localeIso}">${localeDisplayName}</option>\n`;
+
+                    // Rebuild the #nationalCalendarLocales select
+                    const nationalCalendarLocalesSelect = document.querySelector('#nationalCalendarLocales');
+                    nationalCalendarLocalesSelect.innerHTML = localesForNation.map(([localeIso, localeDisplayName]) => {
+                        return `<option value="${localeIso}"${metadata.locales.includes(localeIso) ? ' selected' : ''}>${localeDisplayName}</option>\n`;
                     });
-                    $('#nationalCalendarLocales').val(metadata.locales);
                     $('#nationalCalendarLocales').multiselect('rebuild');
+
+                    // Rebuild the .currentLocalizationChoices select (same as #currentLocalization)
                     const currentLocalizationChoices = Object.entries(AvailableLocalesWithRegion).filter(([localeIso, ]) => {
                         return metadata.locales.includes(localeIso);
                     });
@@ -668,58 +743,62 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
                         return `<option value="${localeIso}">${localeDisplayName}</option>\n`;
                     });
                     document.querySelector('#currentLocalization').value = API.locale !== '' ? API.locale : metadata.locales[0];
-                    $('#publishedRomanMissalList').empty().append( '<li class="list-group-item">' + metadata.missals.join('</li><li class="list-group-item">') + '</li>' );
-                    $('#associatedWiderRegion').val( metadata.wider_region );
-                    $('#nationalCalendarSettingHighPriest').prop('checked', settings.eternal_high_priest );
+
+                    // Rebuild the #publishedRomanMissalList
+                    const publishedRomanMissalList = document.querySelector('#publishedRomanMissalList');
+                    publishedRomanMissalList.innerHTML = metadata.missals.map(missal => `<li class="list-group-item">${missal}</li>`).join('');
+
+                    document.querySelector('#associatedWiderRegion').value = metadata.wider_region;
+                    document.querySelector('#nationalCalendarSettingHighPriest').checked = settings.eternal_high_priest;
                 }
             }
-            $('.regionalNationalDataForm').empty();
+            document.querySelector('.regionalNationalDataForm').innerHTML = '';
             data.litcal.forEach((el) => {
                 let currentUniqid = FormControls.uniqid;
                 let existingFestivityTag = el.festivity.event_key ?? null;
-                if( el.metadata.action === RowAction.CreateNew && FestivityCollectionKeys.includes( existingFestivityTag ) ) {
+                if ( el.metadata.action === RowAction.CreateNew && FestivityCollectionKeys.includes( existingFestivityTag ) ) {
                     el.metadata.action = RowAction.CreateNewFromExisting;
                 }
                 setFormSettings( el.metadata.action );
-                if( el.metadata.action === RowAction.SetProperty ) {
+                if ( el.metadata.action === RowAction.SetProperty ) {
                     setFormSettingsForProperty( el.metadata.property );
                 }
                 /*
                 if (FestivityCollectionKeys.includes( existingFestivityTag ) ) {
-                    if( el.festivity.hasOwnProperty( 'name' ) === false ) {
+                    if ( el.festivity.hasOwnProperty( 'name' ) === false ) {
                         el.festivity.name = FestivityCollection.filter(el => el.event_key === existingFestivityTag)[0].name;
                     }
-                    if( el.festivity.hasOwnProperty( 'day' ) === false ) {
+                    if ( el.festivity.hasOwnProperty( 'day' ) === false ) {
                         el.festivity.day = FestivityCollection.filter(el => el.event_key === existingFestivityTag)[0].day;
                     }
-                    if( el.festivity.hasOwnProperty( 'month' ) === false ) {
+                    if ( el.festivity.hasOwnProperty( 'month' ) === false ) {
                         el.festivity.month = FestivityCollection.filter(el => el.event_key === existingFestivityTag)[0].month;
                     }
-                    if( el.festivity.hasOwnProperty( 'grade' ) === false ) {
+                    if ( el.festivity.hasOwnProperty( 'grade' ) === false ) {
                         el.festivity.grade = FestivityCollection.filter(el => el.event_key === existingFestivityTag)[0].grade;
                     }
                 }*/
                 let rowStr = FormControls.CreatePatronRow( el );
                 let rowEls = $.parseHTML(rowStr);
-                let $row = $(rowEls);
-                $('.regionalNationalDataForm').append($row);
+                document.querySelector('.regionalNationalDataForm').append(...rowEls);
 
-                let $formrow = $row.find('.form-group').closest('.row');
-                $formrow.data('action', el.metadata.action).attr('data-action', el.metadata.action);
+                let formrow = rowEls[1].querySelector('.form-group').closest('.row');
+                formrow.setAttribute('data-action', el.metadata.action);
 
-                if( el.metadata.action === RowAction.SetProperty ) {
-                    $formrow.data('prop', el.metadata.property).attr('data-prop', el.metadata.property);
+                if ( el.metadata.action === RowAction.SetProperty ) {
+                    formrow.setAttribute('data-prop', el.metadata.property);
                 }
 
-                if( el.festivity.hasOwnProperty('common') && el.festivity.common.includes('Proper') ) {
-                    $formrow.find('.litEventReadings').prop('disabled', false);
+                if ( el.festivity.hasOwnProperty('common') && el.festivity.common.includes('Proper') ) {
+                    formrow.querySelector('.litEventReadings').disabled = false;
                 }
 
-                if( FormControls.settings.missalField && existingFestivityTag !== null ) {
+                if ( FormControls.settings.missalField && existingFestivityTag !== null ) {
                     const { missal } = FestivityCollection.filter(el => el.event_key === existingFestivityTag)[0];
-                    $row.find(`#onTheFly${currentUniqid}Missal`).val(missal); //.prop('disabled', true);
+                    formrow.querySelector(`#onTheFly${currentUniqid}Missal`).value = missal;
                 }
-                $row.find('.litEventColor').multiselect({
+
+                $(formrow.querySelector('.litEventColor')).multiselect({
                     buttonWidth: '100%',
                     buttonClass: 'form-select',
                     templates: {
@@ -727,43 +806,62 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
                     }
                 }).multiselect('deselectAll', false);
 
-                if( el.festivity.hasOwnProperty( 'color' ) === false && existingFestivityTag !== null ) {
+                if ( el.festivity.hasOwnProperty( 'color' ) === false && existingFestivityTag !== null ) {
                     console.log( 'retrieving default festivity info for ' + existingFestivityTag );
                     console.log( FestivityCollection.filter( el => el.event_key === existingFestivityTag )[0] );
                     el.festivity.color = FestivityCollection.filter( el => el.event_key === existingFestivityTag )[0].color;
                 }
 
-                $row.find('.litEventColor').multiselect('select', el.festivity.color);
+                $(formrow.querySelector('.litEventColor')).multiselect('select', el.festivity.color);
 
-                if(FormControls.settings.colorField === false) {
-                    $row.find('.litEventColor').multiselect('disable');
+                if (FormControls.settings.colorField === false) {
+                    $(formrow.querySelector('.litEventColor')).multiselect('disable');
                 }
 
-                if( el.festivity.hasOwnProperty( 'common' ) ) {
-                    if(FormControls.settings.commonFieldShow) {
-                        setCommonMultiselect( $row, el.festivity.common );
-                        if(FormControls.settings.commonField === false) {
-                            $row.find(`#onTheFly${currentUniqid}Common`).multiselect('disable');
+                if ( el.festivity.hasOwnProperty( 'common' ) ) {
+                    if (FormControls.settings.commonFieldShow) {
+                        setCommonMultiselect( formrow, el.festivity.common );
+                        if (FormControls.settings.commonField === false) {
+                            $(formrow.querySelector(`#onTheFly${currentUniqid}Common`)).multiselect('disable');
                         }
                     }
                 }
 
-                if(FormControls.settings.gradeFieldShow) {
-                    $row.find(`#onTheFly${currentUniqid}Grade`).val(el.festivity.grade);
-                    if(FormControls.settings.gradeField === false) {
-                        $row.find(`#onTheFly${currentUniqid}Grade`).prop('disabled', true);
+                if (FormControls.settings.gradeFieldShow) {
+                    formrow.querySelector(`#onTheFly${currentUniqid}Grade`).value = el.festivity.grade;
+                    if (FormControls.settings.gradeField === false) {
+                        formrow.querySelector(`#onTheFly${currentUniqid}Grade`).disabled = true;
                     }
                 }
 
-                if(FormControls.settings.missalField && el.metadata.hasOwnProperty('missal') ) {
-                    $row.find(`#onTheFly${currentUniqid}Missal`).val(el.metadata.missal);
+                if (FormControls.settings.missalField && el.metadata.hasOwnProperty('missal') ) {
+                    formrow.querySelector(`#onTheFly${currentUniqid}Missal`).value = el.metadata.missal;
                 }
 
-                if(FormControls.settings.monthField === false) {
-                    $row.find(`#onTheFly${currentUniqid}Month > option[value]:not([value=${el.festivity.month}])`).prop('disabled',true);
+                if (FormControls.settings.monthField === false) {
+                    formrow.querySelectorAll(`#onTheFly${currentUniqid}Month > option[value]:not([value="${el.festivity.month}"])`).forEach(el => { el.disabled = true; });
                 }
             });
-            $('.serializeRegionalNationalData').prop('disabled', false);
+            if (document.querySelector('.calendarLocales').selectedOptions.length > 1) {
+                const currentLocalization = document.querySelector('#currentLocalization').value;
+                const otherLocalizations = Array.from(document.querySelector('.calendarLocales').selectedOptions).filter(({ value }) => value !== currentLocalization).map(({ value }) => value);
+                Promise.all(otherLocalizations.map(localization => fetch(API.path + '/' + localization).then(response => response.json()))).then(data => {
+                    toastr["success"]("Calendar translation data was retrieved successfully", "Success");
+                    data.forEach((localizationData, i) => {
+                        translationData[otherLocalizations[i]] = localizationData;
+                    });
+                    console.log('translationData:', translationData);
+                    Array.from(document.querySelectorAll('.litEventName')).filter(el => el.dataset.valuewas !== '').forEach(el => {
+                        while (el.nextSibling) {
+                            el.nextSibling.remove();
+                        }
+                        const otherLocalizationsInputs = otherLocalizations.map(localization => translationTemplate(localization, el));
+                        el.insertAdjacentHTML('afterend', otherLocalizationsInputs.join(''));
+                    });
+                });
+            }
+
+            document.querySelector('.serializeRegionalNationalData').disabled = false;
         }).catch(error => {
             if (404 === error.status || 400 === error.status) {
                 API.method = 'PUT';
@@ -777,8 +875,8 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
                         $('#widerRegionLocales').multiselect('deselectAll', false);
                         break;
                     case 'nation': {
-                        $('form#nationalCalendarSettingsForm')[0].reset();
-                        $('#publishedRomanMissalList').empty();
+                        document.querySelector('#nationalCalendarSettingsForm').reset();
+                        document.querySelector('#publishedRomanMissalList').innerHTML = '';
                         const LocalesForRegion = Object.entries(AvailableLocalesWithRegion).filter(([localeIso, ]) => {
                             const jsLocaleStr = localeIso.replaceAll('_', '-');
                             const locale = new Intl.Locale(jsLocaleStr);
@@ -791,7 +889,7 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
                         break;
                     }
                 }
-                $('form.regionalNationalDataForm').empty();
+                document.querySelector('.regionalNationalDataForm').innerHTML = '';
             } else {
                 console.error(error);
                 /*error.json().then(json => {
@@ -802,89 +900,94 @@ $(document).on('change', '.regionalNationalCalendarName', ev => {
             }
         });
     });
-
 });
 
 $(document).on('click', '.datetype-toggle-btn', ev => {
-    const uniqid = parseInt( $(ev.currentTarget).attr('data-row-uniqid') );
-    if( $(ev.currentTarget).hasClass('strtotime') ) {
-        const monthVal = $(`#onTheFly${uniqid}Month`).val();
-        const dayVal = $(`#onTheFly${uniqid}Day`).val();
-        $(`#onTheFly${uniqid}Month`).closest('.form-group').remove();
-        let $dayFormGroup = $(`#onTheFly${uniqid}Day`).closest('.form-group');
-        const valueWas = $dayFormGroup.attr('data-valuewas');
-        let strToTimeTemplate = `<label for="onTheFly${uniqid}Strtotime">Relative date</label>
+    const uniqid = parseInt( ev.target.dataset.rowUniqid);
+    if ( ev.target.classList.contains('strtotime') ) {
+        const monthVal = document.querySelector(`#onTheFly${uniqid}Month`).value;
+        const dayVal = document.querySelector(`#onTheFly${uniqid}Day`).value;
+        document.querySelector(`#onTheFly${uniqid}Month`).closest('.form-group').remove();
+        const dayFormGroup = document.querySelector(`#onTheFly${uniqid}Day`).closest('.form-group');
+        const valueWas = dayFormGroup.dataset.valuewas;
+        const strToTimeTemplate = `<label for="onTheFly${uniqid}Strtotime">Relative date</label>
             <input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!"
                 value="${valueWas}" class="form-control litEvent litEventStrtotime" id="onTheFly${uniqid}Strtotime"
             />`;
-        $dayFormGroup.empty().removeClass('col-sm-1').addClass('col-sm-2').attr('data-valuewas', `${dayVal}-${monthVal}`) .append(strToTimeTemplate);
+        dayFormGroup.innerHTML = '';
+        dayFormGroup.classList.remove('col-sm-1');
+        dayFormGroup.classList.add('col-sm-2');
+        dayFormGroup.setAttribute('data-valuewas', `${dayVal}-${monthVal}`);
+        dayFormGroup.insertAdjacentHTML('beforeend', strToTimeTemplate);
     } else {
-        const strToTimeVal = $(`#onTheFly${uniqid}Strtotime`).val();
-        let $strToTimeFormGroup = $(`#onTheFly${uniqid}Strtotime`).closest('.form-group');
-        const valueWas = $strToTimeFormGroup.attr('data-valuewas');
+        const strToTimeVal = document.querySelector(`#onTheFly${uniqid}Strtotime`).value;
+        const strToTimeFormGroup = document.querySelector(`#onTheFly${uniqid}Strtotime`).closest('.form-group');
+        const valueWas = strToTimeFormGroup.dataset.valuewas;
         const dayMonthWasVal = valueWas.split('-');
         const dayWasVal = dayMonthWasVal[0] !== '' ? dayMonthWasVal[0] : '1';
         const monthWasVal = dayMonthWasVal[1] ?? '';
-        let dayTemplate = `<label for="onTheFly${uniqid}Day">Day</label>
+        const dayTemplate = `<label for="onTheFly${uniqid}Day">Day</label>
             <input type="number" min="1" max="31" value=${parseInt(dayWasVal)} class="form-control litEvent litEventDay" id="onTheFly${uniqid}Day" />`;
-        $strToTimeFormGroup.empty().removeClass('col-sm-2').addClass('col-sm-1').attr('data-valuewas', strToTimeVal).append(dayTemplate);
+        strToTimeFormGroup.innerHTML = '';
+        strToTimeFormGroup.classList.remove('col-sm-2');
+        strToTimeFormGroup.classList.add('col-sm-1');
+        strToTimeFormGroup.setAttribute('data-valuewas', strToTimeVal);
+        strToTimeFormGroup.insertAdjacentHTML('beforeend', dayTemplate);
         let monthFormGroupTemplate = `<div class="form-group col-sm-1">
         <label for="onTheFly${uniqid}Month">${Messages[ "Month" ]}</label>
-        <select class="form-select litEvent litEventMonth" id="onTheFly${uniqid}Month" >`;
-        let formatter = new Intl.DateTimeFormat(jsLocale, { month: 'long' });
+        <select class="form-select litEvent litEventMonth" id="onTheFly${uniqid}Month">`;
+        const formatter = new Intl.DateTimeFormat(jsLocale, { month: 'long' });
         for (let i = 0; i < 12; i++) {
             let month = new Date(Date.UTC(0, i, 2, 0, 0, 0));
             monthFormGroupTemplate += `<option value=${i + 1}${monthWasVal === i + 1 ? ' selected' : ''}>${formatter.format(month)}</option>`;
         }
-        monthFormGroupTemplate += `</select>
-        </div>`;
-        $strToTimeFormGroup.after(monthFormGroupTemplate);
+        monthFormGroupTemplate += `</select></div>`;
+        strToTimeFormGroup.insertAdjacentHTML('afterend', monthFormGroupTemplate);
     }
 });
 
 $(document).on('click', '.actionPromptButton', ev => {
     const currentUniqid = FormControls.uniqid;
-    const $modal = $(ev.currentTarget).closest('.actionPromptModal');
-    const $modalForm = $modal.find('form');
-    const existingFestivityTag = sanitizeInput( $modalForm.find('.existingFestivityName').val() );
+    const modal = ev.target.closest('.actionPromptModal');
+    const modalForm = modal.querySelector('form');
+    const existingFestivityTag = sanitizeInput( modalForm.querySelector('.existingFestivityName').value );
     let existingFestivity = FestivityCollection.filter(festivity => festivity.event_key === existingFestivityTag)[0] ?? null;
     let propertyToChange;
     let rowStr;
     let rowEls;
-    let $row;
-    //let buttonId = ev.currentTarget.id;
+    let formrow;
+    //let buttonId = ev.target.id;
     //console.log(buttonId + ' button was clicked');
     FormControls.settings.decreeURLField = true;
     FormControls.settings.decreeLangMapField = document.querySelector('.regionalNationalCalendarName').id === 'widerRegionCalendarName';
-    setFormSettings( ev.currentTarget.id );
-    console.log(`FormControls.action = ${FormControls.action}, ev.currentTarget.id = ${ev.currentTarget.id}`);
-    if( ev.currentTarget.id === 'setPropertyButton' ) {
-        propertyToChange = $('#propertyToChange').val();
+    setFormSettings( ev.target.id );
+    console.log(`FormControls.action = ${FormControls.action}, ev.target.id = ${ev.target.id}`);
+    if ( ev.target.id === 'setPropertyButton' ) {
+        propertyToChange = document.querySelector('#propertyToChange').value;
         setFormSettingsForProperty( propertyToChange );
     }
 
-    if( existingFestivityTag !== '' ) {
+    if ( existingFestivityTag !== '' ) {
         rowStr = FormControls.CreatePatronRow( existingFestivityTag );
         rowEls = $.parseHTML(rowStr);
-        $row = $( rowEls );
-        console.log($row);
-        if( FormControls.settings.missalField ) {
+        formrow = rowEls[1].querySelector('.form-group').closest('.row');
+        if ( FormControls.settings.missalField ) {
             const { missal } = existingFestivity;
-            $row.find(`#onTheFly${currentUniqid}Missal`).val(missal); //.prop('disabled', true);
+            formrow.querySelector(`#onTheFly${currentUniqid}Missal`).value = missal; //.prop('disabled', true);
         }
     } else {
         rowStr = FormControls.CreatePatronRow();
         rowEls = $.parseHTML( rowStr );
-        $row = $( rowEls );
+        formrow = rowEls[1].querySelector('.form-group').closest('.row');
     }
-    $('.regionalNationalDataForm').append($row);
-    $modal.modal('hide');
-    $row.find('.form-group').closest('.row').data('action', FormControls.action).attr('data-action', FormControls.action);
-    if( FormControls.action === RowAction.SetProperty ) {
+    document.querySelector('.regionalNationalDataForm').append(...rowEls);
+    bootstrap.Modal.getInstance(modal).hide();
+    formrow.setAttribute('data-action', FormControls.action);
+    if ( FormControls.action === RowAction.SetProperty ) {
         console.log('propertyToChange is of type ' + typeof propertyToChange + ' and has a value of ' + propertyToChange);
-        $row.find('.form-group').closest('.row').data('prop', propertyToChange).attr('data-prop', propertyToChange);
+        formrow.setAttribute('data-prop', propertyToChange);
     }
-    $row.find('.litEventColor').multiselect({
+    $(formrow.querySelector('.litEventColor')).multiselect({
         buttonWidth: '100%',
         buttonClass: 'form-select',
         templates: {
@@ -892,50 +995,52 @@ $(document).on('click', '.actionPromptButton', ev => {
         }
     }).multiselect('deselectAll', false);
 
-    if(FormControls.settings.colorField === false) {
-        $row.find('.litEventColor').multiselect('disable');
+    if (FormControls.settings.colorField === false) {
+        $(formrow.querySelector('.litEventColor')).multiselect('disable');
     }
 
-    if(FormControls.settings.commonFieldShow) {
-        setCommonMultiselect( $row, null );
-        if(FormControls.settings.commonField === false) {
-            $row.find(`#onTheFly${currentUniqid}Common`).multiselect('disable');
+    if (FormControls.settings.commonFieldShow) {
+        setCommonMultiselect( formrow, null );
+        if (FormControls.settings.commonField === false) {
+            $(formrow.querySelector(`#onTheFly${currentUniqid}Common`)).multiselect('disable');
         }
     }
 
-    if(FormControls.settings.gradeFieldShow && FormControls.settings.gradeField === false) {
-        $row.find(`#onTheFly${currentUniqid}Grade`).prop('disabled', true);
+    if (FormControls.settings.gradeFieldShow) {
+        formrow.querySelector(`#onTheFly${currentUniqid}Grade`).disabled = !FormControls.settings.gradeField;
     }
 
-    if( existingFestivityTag !== '' ) {
+    if ( existingFestivityTag !== '' ) {
         const litevent = FestivityCollection.filter(el => el.event_key === existingFestivityTag)[0];
 
-        $row.find(`#onTheFly${currentUniqid}Grade`).val(litevent.grade);
-        $row.find(`#onTheFly${currentUniqid}Common`).multiselect('select', litevent.common)
+        if (FormControls.settings.gradeFieldShow) {
+            formrow.querySelector(`#onTheFly${currentUniqid}Grade`).value = litevent.grade;
+        }
+        $(formrow.querySelector(`#onTheFly${currentUniqid}Common`)).multiselect('select', litevent.common);
         const colorVal = Array.isArray( litevent.color ) ? litevent.color : litevent.color.split(',');
-        $row.find(`.litEventColor`).multiselect('select', colorVal);
+        $(formrow.querySelector(`.litEventColor`)).multiselect('select', colorVal);
 
-        if(FormControls.settings.monthField === false) {
-            $row.find(`#onTheFly${currentUniqid}Month > option[value]:not([value=${litevent.month}])`).prop('disabled',true);
+        if (FormControls.settings.monthField === false) {
+            formrow.querySelectorAll(`#onTheFly${currentUniqid}Month > option[value]:not([value="${litevent.month}"])`).forEach(el => { el.disabled = true; });
         }
     }
 
-    if( $('.serializeRegionalNationalData').prop('disabled') ) {
-        $('.serializeRegionalNationalData').prop('disabled', false);
-    }
-
+    document.querySelector('.serializeRegionalNationalData').disabled = false;
 });
 
-$(document).on('click', '#removeExistingCalendarDataBtn', evt => {
+$(document).on('click', '#removeExistingCalendarDataBtn', ev => {
     // We don't want any forms to submit, so we prevent the default action
-    evt.preventDefault();
+    ev.preventDefault();
 });
 
 $(document).on('click', '#deleteCalendarConfirm', () => {
-    $('#deleteCalendarConfirm').blur(); // Remove focus from the button
-    $('#removeCalendarDataPrompt').modal('hide');
-    API.key = $('.regionalNationalCalendarName').val();
-    API.category = $('.regionalNationalCalendarName').data('category');
+
+    document.querySelector('#deleteCalendarConfirm').blur(); // Remove focus from the button
+
+    const removeCalendarDataPrompt = document.querySelector('#removeCalendarDataPrompt');
+    bootstrap.Modal.getInstance(removeCalendarDataPrompt).hide();
+    API.key = document.querySelector('.regionalNationalCalendarName').value;
+    API.category = document.querySelector('.regionalNationalCalendarName').dataset.category;
     fetch(API.path, {
         method: 'DELETE',
         headers: {
@@ -945,31 +1050,34 @@ $(document).on('click', '#deleteCalendarConfirm', () => {
         if (response.ok) {
             switch ( API.category ) {
                 case 'widerregion':
-                    CalendarsIndex.wider_regions = CalendarsIndex.wider_regions.filter(el => el.name !== API.key);
-                    CalendarsIndex.wider_regions_keys = CalendarsIndex.wider_regions_keys.filter(el => el !== API.key);
+                    LitCalMetadata.wider_regions = LitCalMetadata.wider_regions.filter(el => el.name !== API.key);
+                    LitCalMetadata.wider_regions_keys = LitCalMetadata.wider_regions_keys.filter(el => el !== API.key);
                     break;
                 case 'nation': {
-                    CalendarsIndex.national_calendars = CalendarsIndex.national_calendars.filter(el => el.calendar_id !== API.key);
-                    CalendarsIndex.national_calendars_keys = CalendarsIndex.national_calendars_keys.filter(el => el !== API.key);
-                    $('form#nationalCalendarSettingsForm')[0].reset();
-                    $('#publishedRomanMissalList').empty();
+                    LitCalMetadata.national_calendars = LitCalMetadata.national_calendars.filter(el => el.calendar_id !== API.key);
+                    LitCalMetadata.national_calendars_keys = LitCalMetadata.national_calendars_keys.filter(el => el !== API.key);
+                    document.querySelector('#nationalCalendarSettingsForm').reset();
+                    document.querySelector('#publishedRomanMissalList').innerHTML = '';
                     const localeOptions = Object.entries(AvailableLocalesWithRegion).map(([localeIso, localeDisplayName]) => {
                         return `<option value="${localeIso}">${localeDisplayName}</option>`;
                     });
                     document.querySelector('#nationalCalendarLocales').innerHTML = localeOptions.join('\n');
                     document.querySelector('#currentLocalization').innerHTML = localeOptions.join('\n');
                     $('#nationalCalendarLocales').multiselect('rebuild');
-                    $('.regionalNationalSettingsForm .form-select').not('[multiple]').each(function() {
-                        $(this).val('').trigger('change');
+
+                    document.querySelectorAll('.regionalNationalSettingsForm .form-select:not([multiple])').forEach(formSelect => {
+                        formSelect.value = '';
+                        formSelect.dispatchEvent(new Event('change'));
                     });
                     break;
                 }
             }
-            $('#removeExistingCalendarDataBtn').prop('disabled', true);
-            $('#removeCalendarDataPrompt').remove();
-            $('.regionalNationalCalendarName').val('');
-            $('.regionalNationalDataForm').empty();
-            //$('.regionalNationalSettingsForm')[0].reset();
+
+            document.querySelector('#removeExistingCalendarDataBtn').disabled = true;
+            document.querySelector('#removeCalendarDataPrompt').remove();
+            document.querySelector('.regionalNationalCalendarName').value = '';
+            document.querySelector('.regionalNationalDataForm').innerHTML = '';
+
             toastr["success"](`Calendar '${API.category}/${API.key}' was deleted successfully`, "Success");
             response.json().then(json => {
                 console.log(json);
@@ -1094,7 +1202,7 @@ $(document).on('click', '#deleteCalendarConfirm', () => {
  *          - metadata.url_lang_map
 */
 $(document).on('click', '.serializeRegionalNationalData', ev => {
-    API.category = $(ev.currentTarget).data('category');
+    API.category = ev.target.dataset.category;
     /**
      * @type {NationalCalendarPayload|WiderRegionPayload}
      */
@@ -1109,13 +1217,14 @@ $(document).on('click', '.serializeRegionalNationalData', ev => {
                 epiphany:            document.querySelector('#nationalCalendarSettingEpiphany').value,
                 ascension:           document.querySelector('#nationalCalendarSettingAscension').value,
                 corpus_christi:      document.querySelector('#nationalCalendarSettingCorpusChristi').value,
-                eternal_high_priest: document.querySelector('#nationalCalendarSettingHighPriest').checked,
+                eternal_high_priest: document.querySelector('#nationalCalendarSettingHighPriest').checked
             };
+            const selectedLocales = document.querySelector('#nationalCalendarLocales').selectedOptions;
             payload.metadata  = {
                 nation:       API.key,
                 wider_region: widerRegion,
-                missals:      $.map( $('#publishedRomanMissalList li'), el => { return $(el).text() }),
-                locales:      $('#nationalCalendarLocales').val()
+                missals:      Array.from(document.querySelectorAll('#publishedRomanMissalList li')).map(el => el.textContent),
+                locales:      Array.from(selectedLocales).map(({ value }) => value)
             };
             break;
         }
@@ -1123,13 +1232,14 @@ $(document).on('click', '.serializeRegionalNationalData', ev => {
             // our proxy will take care of splitting locale from wider region
             API.key = document.querySelector('#widerRegionCalendarName').value;
             const regionNamesLocalizedEng = new Intl.DisplayNames(['en'], { type: 'region' });
-            let nationalCalendars = $('#widerRegionLocales').val().reduce((prev, curr) => {
+            const selectedLocales = document.querySelector('#widerRegionLocales').selectedOptions;
+            const nationalCalendars =  Array.from(selectedLocales).map(({ value }) => value).reduce((prev, curr) => {
                 curr = curr.replaceAll('_', '-');
                 // We have already exluded non-regional languages from the select list,
                 // so we know we will always have a region associated with each of the selected languages.
                 // Should we also define the language-region locale in the RomanMissal enum itself, on the API backend?
                 // In that case we should try to get an exhaustive list of all printed Roman Missals since Vatican II.
-                let locale = new Intl.Locale( curr );
+                const locale = new Intl.Locale( curr );
                 console.log( `curr = ${curr}, nation = ${locale.region}` );
                 prev[ regionNamesLocalizedEng.of( locale.region ) ] = locale.region;
                 return prev;
@@ -1137,15 +1247,15 @@ $(document).on('click', '.serializeRegionalNationalData', ev => {
             payload.litcal = [];
             payload.national_calendars = nationalCalendars;
             payload.metadata = {
-                locales: $('#widerRegionLocales').val(),
-                wider_region: $('#widerRegionCalendarName').val()
+                locales: Array.from(selectedLocales).map(({ value }) => value),
+                wider_region: document.querySelector('#widerRegionCalendarName').value
             };
             break;
         }
     }
-    let action;
-    $('.regionalNationalDataForm .row').each((idx, el) => {
-        action = $(el).data('action');
+
+    Array.from(document.querySelectorAll('.regionalNationalDataForm .row')).forEach(el => {
+        const { action } = el.dataset;
         console.log(`action = ${action}`);
         /**
          * @type RowData
@@ -1156,70 +1266,76 @@ $(document).on('click', '.serializeRegionalNationalData', ev => {
                 action
             }
         }
-        if( action === RowAction.SetProperty ) {
-            rowData.metadata.property = $(el).data('prop');
+        if ( action === RowAction.SetProperty ) {
+            rowData.metadata.property = el.dataset.prop;
         }
         payloadProperties[action].forEach(prop => {
-            let propClass = '.litEvent' + prop.charAt(0).toUpperCase() + prop.substring(1).toLowerCase();
-            if( $(el).find(propClass).length ) {
-                let val = $(el).find(propClass).val();
-                if( integerProperties.includes(prop) ) {
+            const propClass = '.litEvent' + prop.charAt(0).toUpperCase() + prop.substring(1).toLowerCase();
+            const propEl = el.querySelector(propClass);
+            if ( propEl ) {
+                let val = propEl.value;
+                if ( integerProperties.includes(prop) ) {
                     val = parseInt( val );
                 }
-                if( metadataProperties.includes(prop) ) {
+                if ( metadataProperties.includes(prop) ) {
                     rowData.metadata[prop] = val;
                 } else {
                     rowData.festivity[prop] = val;
                 }
             }
         });
-        if( action === RowAction.CreateNew && rowData.festivity.common.includes( 'Proper' ) ) {
+        if ( action === RowAction.CreateNew && rowData.festivity.common.includes( 'Proper' ) ) {
             rowData.festivity.readings = {
-                first_reading: $(el).find('.litEventReadings_FIRST_READING').val(),
-                responsorial_psalm: $(el).find('.litEventReadings_RESPONSORIAL_PSALM').val(),
-                alleluia_verse: $(el).find('.litEventReadings_ALLELUIA_VERSE').val(),
-                gospel: $(el).find('.litEventReadings_GOSPEL').val()
+                first_reading: el.querySelector('.litEventReadings_FIRST_READING').value,
+                responsorial_psalm: el.querySelector('.litEventReadings_RESPONSORIAL_PSALM').value,
+                alleluia_verse: el.querySelector('.litEventReadings_ALLELUIA_VERSE').value,
+                gospel: el.querySelector('.litEventReadings_GOSPEL').value
             };
-            if( $(el).find('.litEventReadings_SECOND_READING').val() !== "" ) {
-                rowData.festivity.readings.second_reading = $(el).find('.litEventReadings_SECOND_READING').val();
+            if ( el.querySelector('.litEventReadings_SECOND_READING').value !== '' ) {
+                rowData.festivity.readings.second_reading = el.querySelector('.litEventReadings_SECOND_READING').value;
             }
         }
 
-        if( $(el).find('.litEventSinceYear').length ) {
-            let sinceYear = parseInt($(el).find('.litEventSinceYear').val());
-            if( sinceYear > 1582 && sinceYear <= 9999 ) {
+        const litEventSinceYearEl = el.querySelector('.litEventSinceYear');
+        if ( litEventSinceYearEl ) {
+            const sinceYear = parseInt(litEventSinceYearEl.value);
+            if ( sinceYear > 1582 && sinceYear <= 9999 ) {
                 rowData.metadata.since_year = sinceYear;
             }
         }
-        if( $(el).find('.litEventUntilYear').length ) {
-            let untilYear = parseInt($(el).find('.litEventUntilYear').val());
-            if( untilYear >= 1970 && untilYear <= 9999 ) {
+
+        const litEventUntilYearEl = el.querySelector('.litEventUntilYear');
+        if ( litEventUntilYearEl ) {
+            const untilYear = parseInt(litEventUntilYearEl.value);
+            if ( untilYear >= 1970 && untilYear <= 9999 ) {
                 rowData.metadata.until_year = untilYear;
             }
         }
-        if( $(el).find('.litEventDecreeURL').length ) {
-            let decreeURL = $(el).find('.litEventDecreeURL').val();
-            if( decreeURL !== '' ) {
+
+        const litEventDecreeUrlEl = el.querySelector('.litEventDecreeURL');
+        if ( litEventDecreeUrlEl ) {
+            const decreeURL = litEventDecreeUrlEl.value;
+            if ( decreeURL !== '' ) {
                 rowData.metadata.url = decreeURL;
             }
         }
-        if( $(el).find('.litEventDecreeLangs').length ) {
-            let decreeLangs = $(el).find('.litEventDecreeLangs').val();
-            if( decreeLangs !== '' ) {
-                rowData.metadata.url_lang_map = decreeLangs.split(',').reduce((prevVal, curVal) => { let assoc = curVal.split('='); prevVal[assoc[0]] = assoc[1]; return prevVal; }, {}) ;
+
+        const litEventDecreeLangsEl = el.querySelector('.litEventDecreeLangs');
+        if ( litEventDecreeLangsEl ) {
+            const decreeLangs = litEventDecreeLangsEl.value;
+            if ( decreeLangs !== '' ) {
+                rowData.metadata.url_lang_map = decreeLangs.split(',').reduce((prevVal, curVal) => {
+                    let assoc = curVal.split('=');
+                    prevVal[assoc[0]] = assoc[1];
+                    return prevVal;
+                }, {}) ;
             }
         }
         payload.litcal.push(rowData);
     });
-    //console.log(payload);
+
     const finalPayload = Object.freeze(new NationalCalendarPayload(payload.litcal, payload.settings, payload.metadata));
-    //console.log(finalPayload);
-    //console.log(JSON.stringify(finalPayload))
-    //console.log(`API.method = ${API.method}`);
-    //console.log(`API.path = ${API.path}`);
-    //console.log(`API.category = ${API.category}`);
-    //console.log(`API.key = ${API.key}`);
-    //console.log(`API.locale = ${API.locale}`);
+
     const headers = {
         'Content-Type': 'application/json',
         'Accept': 'application/json'
@@ -1227,6 +1343,7 @@ $(document).on('click', '.serializeRegionalNationalData', ev => {
     if ( API.locale !== '' ) {
         headers['Accept-Language'] = API.locale;
     }
+
     fetch(API.path, {
         method: API.method,
         headers,
@@ -1262,17 +1379,15 @@ $(document).on('click', '.serializeRegionalNationalData', ev => {
  * @function setFocusFirstTabWithData
  */
 const setFocusFirstTabWithData = () => {
-    let $firstInputWithNonEmptyValue = $('.carousel-item form .litEventName')
-        .filter(function() {
-            return $(this).val() !== "";
-        })
-        .first();
-    let $parentCarouselItem = $firstInputWithNonEmptyValue.parents('.carousel-item');
-    let itemIndex = $('.carousel-item').index( $parentCarouselItem );
-    $('#diocesanCalendarDefinitionCardLinks li').removeClass('active');
-    $('.carousel').carousel(itemIndex);
-    $(`#diocesanCalendarDefinitionCardLinks li:nth-child(${itemIndex+2})`).addClass('active');
-};
+    document.querySelectorAll('#diocesanCalendarDefinitionCardLinks li').forEach(el => el.classList.remove('active'));
+    const firstInputWithNonEmptyValue = Array.from(document.querySelectorAll('.carousel-item form .litEventName')).filter(el => el.dataset.valuewas !== '')[0];
+    const parentCarouselItem = firstInputWithNonEmptyValue.closest('.carousel-item');
+    const itemIndex = Array.from(document.querySelectorAll('.carousel-item')).indexOf(parentCarouselItem);
+    const carouselElement = document.querySelector('.carousel');
+    const carousel = bootstrap.Carousel.getInstance(carouselElement);
+    carousel.to(itemIndex);
+    document.querySelector(`#diocesanCalendarDefinitionCardLinks li:nth-child(${itemIndex+2})`).classList.add('active');
+}
 
 /**
  * @description Retrieves the data for the Diocesan Calendar associated with the currently selected diocese, and populates the edit form with the retrieved data.
@@ -1280,10 +1395,15 @@ const setFocusFirstTabWithData = () => {
  */
 const loadDiocesanCalendarData = () => {
     API.category = 'diocese';
-    let diocese = $('#diocesanCalendarDioceseName').val();
-    API.key = $('#DiocesesList').find('option[value="' + diocese + '"]').attr('data-value');
-    let dioceseMetadata = CalendarsIndex.diocesan_calendars.filter(item => item.calendar_id === API.key)[0];
-    API.locale = dioceseMetadata.locales[0];
+
+    const dioceseSelect = document.getElementById('diocesanCalendarDioceseName');
+    const diocese = dioceseSelect.value;
+    const dioceseOption = document.querySelector(`#DiocesesList > option[value="${diocese}"]`);
+    const dioceseKey = dioceseOption ? dioceseOption.dataset.value : null;
+    API.key = dioceseKey;
+
+    //let dioceseMetadata = LitCalMetadata.diocesan_calendars.filter(item => item.calendar_id === API.key)[0];
+    API.locale = document.querySelector('#currentLocalization').value;
     const headers = {
         'Accept': 'application/json',
         'Accept-Language': API.locale
@@ -1292,9 +1412,9 @@ const loadDiocesanCalendarData = () => {
         method: 'GET',
         headers
     }).then(response => {
-        if(response.ok) {
+        if (response.ok) {
             return response.json();
-        } else if(response.status === 404) {
+        } else if (response.status === 404) {
             toastr["warning"](response.status + ' ' + response.statusText + ': ' + response.url + '<br />The Diocesan Calendar for ' + diocese + ' does not exist yet.', "Warning");
             console.log(response.status + ' ' + response.statusText + ': ' + response.url + 'The Diocesan Calendar for ' + diocese + ' does not exist yet.');
             API.method = 'PUT';
@@ -1304,25 +1424,43 @@ const loadDiocesanCalendarData = () => {
         }
     }).then(data => {
         API.method = 'PATCH';
-        console.log('retrieved diocesan data:');
-        console.log(data);
+        console.log('retrieved diocesan data:', data);
         toastr["success"]("Diocesan Calendar was retrieved successfully", "Success");
         CalendarData = data;
-        if( data.hasOwnProperty('settings') ) {
-            if( data.settings.hasOwnProperty('epiphany') ) {
-                $('#diocesanCalendarOverrideEpiphany').val( data.settings.epiphany );
+        if (data.hasOwnProperty('settings')) {
+            if (data.settings.hasOwnProperty('epiphany')) {
+                document.getElementById('diocesanCalendarOverrideEpiphany').value = data.settings.epiphany;
             }
-            if( data.settings.hasOwnProperty('ascension') ) {
-                $('#diocesanCalendarOverrideAscension').val( data.settings.ascension );
+            if (data.settings.hasOwnProperty('ascension')) {
+                document.getElementById('diocesanCalendarOverrideAscension').value = data.settings.ascension;
             }
-            if( data.settings.hasOwnProperty('corpus_christi') ) {
-                $('#diocesanCalendarOverrideCorpusChristi').val( data.settings.corpus_christi );
+            if (data.settings.hasOwnProperty('corpus_christi')) {
+                document.getElementById('diocesanCalendarOverrideCorpusChristi').value = data.settings.corpus_christi;
             }
         }
         fillDiocesanFormWithData(data);
+        if (document.querySelector('.calendarLocales').selectedOptions.length > 1) {
+            const currentLocalization = document.querySelector('#currentLocalization').value;
+            const otherLocalizations = Array.from(document.querySelector('.calendarLocales').selectedOptions).filter(({ value }) => value !== currentLocalization).map(({ value }) => value);
+            Promise.all(otherLocalizations.map(localization => fetch(API.path + '/' + localization).then(response => response.json()))).then(data => {
+                toastr["success"]("Diocesan Calendar translation data was retrieved successfully", "Success");
+                data.forEach((localizationData, i) => {
+                    translationData[otherLocalizations[i]] = localizationData;
+                });
+                console.log('translationData:', translationData);
+                Array.from(document.querySelectorAll('.litEventName')).filter(el => el.dataset.valuewas !== '').forEach(el => {
+                    while (el.nextSibling) {
+                        el.nextSibling.remove();
+                    }
+                    const otherLocalizationsInputs = otherLocalizations.map(localization => translationTemplate(localization, el));
+                    el.insertAdjacentHTML('afterend', otherLocalizationsInputs.join(''));
+                });
+            });
+        }
+
         setFocusFirstTabWithData();
     }).catch(error => {
-        if( error instanceof Error && error.message.startsWith('404') ) { //we have already handled 404 Not Found above
+        if ( error instanceof Error && error.message.startsWith('404') ) { //we have already handled 404 Not Found above
             return;
         }
         toastr["error"](error.message, "Error");
@@ -1331,20 +1469,23 @@ const loadDiocesanCalendarData = () => {
 
 /**
  * Replaces the day input and month select with a text input for strtotime.
- * @param {jQuery} $row - The containing row of the form.
+ * @param {HTMLElement} row - The containing row of the form.
  * @param {Object} Metadata - The metadata object from the JSON payload.
  */
-const switcheroo = ( $row, Metadata ) => {
-    $row.find('.litEventDay').closest('.form-group').remove();
-    let $litEventMonth = $row.find('.litEventMonth');
-    let $litEventMonthFormGrp = $litEventMonth.closest('.form-group');
-    console.log($litEventMonth.attr('id'));
-    let strtotimeId = $litEventMonth.attr('id').replace('Month', 'Strtotime');
+const switcheroo = ( row, Metadata ) => {
+    row.querySelector('.litEventDay').closest('.form-group').remove();
+    const litEventMonth = row.querySelector('.litEventMonth');
+    console.log(litEventMonth.id);
+    const strtotimeId = litEventMonth.id.replace('Month', 'Strtotime');
     console.log(strtotimeId);
-    $litEventMonthFormGrp.removeClass('col-sm-2').addClass('col-sm-3');
-    $litEventMonth.remove();
-    $litEventMonthFormGrp.find('.month-label').text('Relative date').attr('for', strtotimeId);
-    $litEventMonthFormGrp.append(`<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" value="${Metadata.strtotime}" />`);
+    const litEventMonthFormGrp = litEventMonth.closest('.form-group');
+    litEventMonthFormGrp.classList.remove('col-sm-2');
+    litEventMonthFormGrp.classList.add('col-sm-3');
+    litEventMonth.remove();
+    const monthLabel = litEventMonthFormGrp.querySelector('.month-label');
+    monthLabel.textContent = 'Relative date';
+    monthLabel.setAttribute('for', strtotimeId);
+    litEventMonthFormGrp.insertAdjacentHTML('beforeend', `<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" value="${Metadata.strtotime}" />`);
 }
 
 /**
@@ -1352,38 +1493,40 @@ const switcheroo = ( $row, Metadata ) => {
  * Adjusts the form group classes to accommodate the change.
  * Inserts a day input and month select dropdown based on the provided festivity data.
  *
- * @param {jQuery} $row - The containing row of the form.
+ * @param {HTMLElement} row - The containing row of the form.
  * @param {Object} Festivity - The festivity data object containing day and month information.
  */
-const unswitcheroo = ( $row, Festivity ) => {
-    let $litEventStrtotime = $row.find('.litEventStrtotime');
-    let $strToTimeFormGroup = $litEventStrtotime.closest('.form-group');
-    $strToTimeFormGroup.removeClass('col-sm-3').addClass('col-sm-2');
-    let dayId = $litEventStrtotime.attr('id').replace('Strtotime', 'Day');
-    let monthId = $litEventStrtotime.attr('id').replace('Strtotime', 'Month');
-    $strToTimeFormGroup.before(`<div class="form-group col-sm-1">
+const unswitcheroo = ( row, Festivity ) => {
+    const litEventStrtotime = row.querySelector('.litEventStrtotime');
+    const strToTimeFormGroup = litEventStrtotime.closest('.form-group');
+    strToTimeFormGroup.classList.remove('col-sm-3');
+    strToTimeFormGroup.classList.add('col-sm-2');
+    const dayId = litEventStrtotime.id.replace('Strtotime', 'Day');
+    const monthId = litEventStrtotime.id.replace('Strtotime', 'Month');
+    strToTimeFormGroup.insertAdjacentHTML('beforestart', `<div class="form-group col-sm-1">
     <label for="${dayId}">${Messages[ "Day" ]}</label><input type="number" min="1" max="31" value="1" class="form-control litEvent litEventDay" id="${dayId}" value="${Festivity.day}" />
     </div>`);
-    $litEventStrtotime.remove();
+    litEventStrtotime.remove();
     let formRow = `<select class="form-select litEvent litEventMonth" id="${monthId}">`;
-    let formatter = new Intl.DateTimeFormat(jsLocale, { month: 'long' });
+    const formatter = new Intl.DateTimeFormat(jsLocale, { month: 'long' });
     for (let i = 0; i < 12; i++) {
-        let month = new Date(Date.UTC(0, i, 2, 0, 0, 0));
+        const month = new Date(Date.UTC(0, i, 2, 0, 0, 0));
         formRow += `<option value=${i + 1}${(i+1)===Festivity.month ? ' selected' : ''}>${formatter.format(month)}</option>`;
     }
     formRow += `</select>`;
-    $strToTimeFormGroup.append(formRow);
-    $strToTimeFormGroup.find('.month-label').text(Messages[ 'Month' ]).attr('for',monthId);
+    strToTimeFormGroup.insertAdjacentHTML('beforeend', formRow);
+    const monthLabel = strToTimeFormGroup.querySelector('.month-label');
+    monthLabel.textContent = Messages[ 'Month' ];
+    monthLabel.setAttribute('for', monthId);
 }
 
 const fillDiocesanFormWithData = (data) => {
     for (const entry of data.litcal) {
         const { festivity, metadata } = entry;
-        let $form;
-        let $row;
+        let row;
         let numLastRow;
         let numMissingRows;
-        if(festivity.hasOwnProperty('strtotime')) {
+        if (festivity.hasOwnProperty('strtotime')) {
             FormControls.settings.dayField = false;
             FormControls.settings.monthField = false;
             FormControls.settings.strtotimeField = true;
@@ -1394,82 +1537,84 @@ const fillDiocesanFormWithData = (data) => {
         }
         switch (festivity.grade) {
             case Rank.SOLEMNITY:
-                $form = $('#carouselItemSolemnities form');
-                numLastRow = $form.find('.row').length - 1;
+                numLastRow = document.querySelectorAll('#carouselItemSolemnities form .row').length - 1;
                 if (metadata.form_rownum > numLastRow) {
                     numMissingRows = metadata.form_rownum - numLastRow;
                     FormControls.title = Messages['Other Solemnity'];
                     FormControls.settings.commonField = true;
                     while (numMissingRows-- > 0) {
-                        $form.append($(FormControls.CreateFestivityRow()));
+                        document.querySelector('#carouselItemSolemnities form').insertAdjacentHTML('beforeend', FormControls.CreateFestivityRow());
                     }
                 }
-                $row = $('#carouselItemSolemnities form .row').eq(metadata.form_rownum);
+                row = document.querySelectorAll('#carouselItemSolemnities form .row')[metadata.form_rownum];
                 break;
             case Rank.FEAST:
-                numLastRow = $('#carouselItemFeasts form .row').length - 1;
+                numLastRow = document.querySelectorAll('#carouselItemFeasts form .row').length - 1;
                 if (metadata.form_rownum > numLastRow) {
                     numMissingRows = metadata.form_rownum - numLastRow;
                     FormControls.title = Messages['Other Feast'];
                     FormControls.settings.commonField = true;
                     while (numMissingRows-- > 0) {
-                        $('.carousel-item').eq(1).find('form').append($(FormControls.CreateFestivityRow()));
+                         document.querySelector('#carouselItemFeasts form').insertAdjacentHTML('beforeend', FormControls.CreateFestivityRow());
                     }
                 }
-                $row = $('#carouselItemFeasts form .row').eq(metadata.form_rownum);
+                row = document.querySelectorAll('#carouselItemFeasts form .row')[metadata.form_rownum];
                 break;
             case Rank.MEMORIAL:
-                numLastRow = $('#carouselItemMemorials form .row').length - 1;
+                numLastRow = document.querySelectorAll('#carouselItemMemorials form .row').length - 1;
                 if (metadata.form_rownum > numLastRow) {
                     numMissingRows = metadata.form_rownum - numLastRow;
                     FormControls.title = Messages['Other Memorial'];
                     FormControls.settings.commonField = true;
                     while (numMissingRows-- > 0) {
-                        $('.carousel-item').eq(2).find('form').append($(FormControls.CreateFestivityRow()));
+                        document.querySelector('#carouselItemMemorials form').insertAdjacentHTML('beforeend', FormControls.CreateFestivityRow());
                     }
                 }
-                $row = $('#carouselItemMemorials form .row').eq(metadata.form_rownum);
+                row = document.querySelectorAll('#carouselItemMemorials form .row')[metadata.form_rownum];
                 break;
             case Rank.OPTIONALMEMORIAL:
-                numLastRow = $('#carouselItemOptionalMemorials form .row').length - 1;
+                numLastRow = document.querySelectorAll('#carouselItemOptionalMemorials form .row').length - 1;
                 if (metadata.form_rownum > numLastRow) {
                     numMissingRows = metadata.form_rownum - numLastRow;
                     FormControls.title = Messages['Other Optional Memorial'];
                     FormControls.settings.commonField = true;
                     while (numMissingRows-- > 0) {
-                        $('.carousel-item').eq(3).find('form').append($(FormControls.CreateFestivityRow()));
+                        document.querySelector('#carouselItemOptionalMemorials form').insertAdjacentHTML('beforeend', FormControls.CreateFestivityRow());
                     }
                 }
-                $row = $('#carouselItemOptionalMemorials form .row').eq(metadata.form_rownum);
+                row = document.querySelectorAll('#carouselItemOptionalMemorials form .row')[metadata.form_rownum];
                 break;
         }
-        $row.find('.litEventName').val(festivity.name).attr('data-valuewas', festivity.event_key);
-        //if(metadata.form_rownum > 2) {
+        row.querySelector('.litEventName').value = festivity.name;
+        row.querySelector('.litEventName').setAttribute('data-valuewas', festivity.event_key);
+        //if (metadata.form_rownum > 2) {
         //    $row.find('.litEventStrtotimeSwitch').bootstrapToggle();
         //}
-        if( festivity.hasOwnProperty('strtotime') ) {
-            if( $row.find('.litEventStrtotime').length === 0 ) {
-                switcheroo( $row, metadata );
+        if ( festivity.hasOwnProperty('strtotime') ) {
+            if ( row.querySelectorAll('.litEventStrtotime').length === 0 ) {
+                switcheroo( row, metadata );
             }
-            $row.find('.litEventStrtotime').val(festivity.strtotime);
+            row.querySelector('.litEventStrtotime').value = festivity.strtotime;
         } else {
-            if( $row.find('.litEventStrtotime').length > 0 ) {
-                unswitcheroo( $row, festivity );
+            if ( row.querySelectorAll('.litEventStrtotime').length > 0 ) {
+                unswitcheroo( row, festivity );
             }
-            $row.find('.litEventDay').val(festivity.day);
-            $row.find('.litEventMonth').val(festivity.month);
+            row.querySelector('.litEventDay').value = festivity.day;
+            row.querySelector('.litEventMonth').value = festivity.month;
         }
-        setCommonMultiselect( $row, festivity.common );
-        $row.find('.litEventColor').multiselect({
+        setCommonMultiselect( row, festivity.common );
+        $(row.querySelector('.litEventColor')).multiselect({
             buttonWidth: '100%',
             buttonClass: 'form-select',
             templates: {
                 button: '<button type="button" class="multiselect dropdown-toggle" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span></button>'
             }
         }).multiselect('deselectAll', false).multiselect('select', festivity.color);
-        $row.find('.litEventSinceYear').val(metadata.since_year);
-        if( metadata.hasOwnProperty('until_year') ) {
-            $row.find('.litEventUntilYear').val(metadata.until_year);
+        row.querySelector('.litEventSinceYear').value = metadata.since_year;
+        if ( metadata.hasOwnProperty('until_year') ) {
+            row.querySelector('.litEventUntilYear').value = metadata.until_year;
+        } else {
+            row.querySelector('.litEventUntilYear').min = metadata.since_year + 1;
         }
     };
 }
@@ -1480,87 +1625,158 @@ const fillDiocesanFormWithData = (data) => {
  * @returns {boolean}
  */
 const diocesanOvveridesDefined = () => {
-    return ( $('#diocesanCalendarOverrideEpiphany').val() !== "" || $('#diocesanCalendarOverrideAscension').val() !== "" || $('#diocesanCalendarOverrideCorpusChristi').val() !== "" );
+    return (
+        document.querySelector('#diocesanCalendarOverrideEpiphany').value !== ''
+        || document.querySelector('#diocesanCalendarOverrideAscension').value !== ''
+        || document.querySelector('#diocesanCalendarOverrideCorpusChristi').value !== ''
+    );
 }
 
-$(document).on('change', '#diocesanCalendarNationalDependency', ev => {
-    $('#diocesanCalendarDioceseName').val('');
-    $('#removeExistingDiocesanDataBtn').prop('disabled', true);
-    $('body').find('#removeDiocesanCalendarPrompt').remove();
-    const currentSelectedNation = $(ev.currentTarget).val();
-    const DiocesesForNation = Object.freeze(DiocesesList.filter(item => item.country_iso.toUpperCase() === currentSelectedNation)[0].dioceses);
-    const LocalesForNation = Object.freeze(Object.entries(AvailableLocalesWithRegion).filter(([key, ]) => {
-        return key.split('_' ).pop() === currentSelectedNation;
-    }));
-    $('#DiocesesList').empty();
-    if (currentSelectedNation === 'US') {
-        DiocesesForNation.forEach(item => $('#DiocesesList').append(`<option data-value="${item.diocese_id}" value="${item.diocese_name} (${item.province})">`));
-    } else {
-        DiocesesForNation.forEach(item => $('#DiocesesList').append('<option data-value="' + item.diocese_id + '" value="' + item.diocese_name + '">'));
-    }
-    if (LocalesForNation.length > 0) {
-        document.querySelector('#diocesanCalendarLocales').innerHTML = LocalesForNation.map(item => `<option value="${item[0]}">${item[1]}</option>`).join('');
-        $('#diocesanCalendarLocales').multiselect('rebuild');
-        document.querySelector('#currentLocalization').innerHTML = LocalesForNation.map(item => `<option value="${item[0]}">${item[1]}</option>`).join('');
-        document.querySelector('#currentLocalization').value = '';
-    }
-    document.querySelector('#diocesanCalendarGroup').value = '';
-});
 
-$(document).on('change', '#diocesanCalendarDioceseName', ev => {
-    const currentVal = sanitizeInput( $(ev.currentTarget).val() );
-    CalendarData = { litcal: {} };
-    $('.carousel-item form').each((idx, el) => {
-        el.reset();
-        $(el).find('.row').slice(3).remove();
-        $(el).find('div.data-group-title').remove();
-        $(el).find('.litEventCommon').multiselect('deselectAll', false).multiselect('select', 'Proper');
-        $(el).find('.litEventColor').multiselect('deselectAll', false).multiselect('select', 'white');
-        $(el).find('.litEventName').attr('data-valuewas', '');
-    });
-    $('form').each((idx, el) => { $(el).removeClass('was-validated') });
-    //first we'll enforce only values from the current datalist
-    if ($('#DiocesesList').find('option[value="' + currentVal + '"]').length > 0) {
-        $(ev.currentTarget).removeClass('is-invalid');
-        API.key = $('#DiocesesList').find('option[value="' + currentVal + '"]').attr('data-value');
-        //console.log('selected diocese with key = ' + API.key);
-        if (CalendarsIndex.diocesan_calendars_keys.includes(API.key)) {
-            const diocesan_calendar = CalendarsIndex.diocesan_calendars.filter(el => el.calendar_id === API.key)[0];
-            $('#removeExistingDiocesanDataBtn').prop('disabled', false);
-            $('body').append(removeDiocesanCalendarModal(currentVal, Messages));
-            if(diocesan_calendar.hasOwnProperty('group')){
-                $('#diocesanCalendarGroup').val(diocesan_calendar.group);
+/**
+ * Event handlers for the calendar forms
+ */
+
+const diocesanCalendarNationalDependencyChanged = (ev) => {
+    const currentSelectedNation = ev.target.value;
+
+    // Disable "Remove diocesan data" button
+    document.getElementById('removeExistingDiocesanDataBtn').disabled = true;
+
+    // The diocese remove prompt is created when existing Diocesan data is loaded
+    const removePrompt = document.getElementById('removeDiocesanCalendarPrompt');
+    if (removePrompt) {
+        removePrompt.remove();
+    }
+
+    // Reset selected diocese
+    document.getElementById('diocesanCalendarDioceseName').value = '';
+
+    // Reset the list of dioceses for the current selected nation
+    const diocesesForNation = Object.freeze(DiocesesList.find(item => item.country_iso.toUpperCase() === currentSelectedNation)?.dioceses ?? null);
+    const diocesesListElement = document.getElementById('DiocesesList');
+    diocesesListElement.innerHTML = '';
+    if (currentSelectedNation === '') {
+        diocesesListElement.innerHTML = '<option value=""></option>';
+    }
+    else if (currentSelectedNation === 'US') {
+        diocesesForNation.forEach(item => {
+            diocesesListElement.insertAdjacentHTML('beforeend', `<option data-value="${item.diocese_id}" value="${item.diocese_name} (${item.province})">`);
+        });
+    } else {
+        diocesesForNation.forEach(item => {
+            diocesesListElement.insertAdjacentHTML('beforeend', `<option data-value="${item.diocese_id}" value="${item.diocese_name}">`);
+        });
+    }
+
+    // Reset the diocesanCalendarGroup
+    document.getElementById('diocesanCalendarGroup').value = '';
+
+    // Reset the list of locales for the current selected nation
+    let localesForNation;
+    if (LitCalMetadata.national_calendars_keys.includes(currentSelectedNation)) {
+        localesForNation = Object.freeze(Object.entries(AvailableLocalesWithRegion).filter(([key, ]) => {
+            return LitCalMetadata.national_calendars.find(item => item.calendar_id === currentSelectedNation).locales.includes(key);
+        }));
+    } else {
+        localesForNation = currentSelectedNation !== ''
+        ? Object.freeze(Object.entries(AvailableLocalesWithRegion).filter(([key, ]) => {
+                return key.split('_').pop() === currentSelectedNation;
+            }))
+        : Object.freeze(Object.entries(AvailableLocalesWithRegion));
+    }
+    if (localesForNation.length > 0) {
+        const diocesanCalendarLocales = document.getElementById('diocesanCalendarLocales');
+        diocesanCalendarLocales.innerHTML = localesForNation.map(item => `<option value="${item[0]}">${item[1]}</option>`).join('');
+        $(diocesanCalendarLocales).multiselect('rebuild');
+        const currentLocalization = document.getElementById('currentLocalization');
+        currentLocalization.innerHTML = localesForNation.map(item => `<option value="${item[0]}">${item[1]}</option>`).join('');
+        //currentLocalization.value = '';
+    } else {
+        // this should never be the case?
+    }
+
+    // Reset the list of timezones for the current selected nation
+    const timezonesForCountry = tzdata.filter(tz => tz.countryCode === currentSelectedNation);
+    console.log('timezonesForCountry = ', timezonesForCountry);
+    const timezonesOptions = timezonesForCountry.map(tz => `<option value="${tz.name}" title="${tz.alternativeName} (${tz.mainCities.join(' - ')})">${tz.name} (${tz.abbreviation})</option>`);
+    document.querySelector('#diocesanCalendarTimezone').innerHTML = timezonesOptions.length ? timezonesOptions.join('') : '<option value=""></option>';
+}
+
+const diocesanCalendarDioceseNameChanged = (ev) => {
+    const currentVal = sanitizeInput( ev.target.value );
+    CalendarData = { litcal: [] };
+    document.querySelectorAll('.carousel-item form').forEach(form => {
+        form.reset();
+        form.querySelectorAll('.row').forEach((row, idx) => {
+            if (idx >= 3) {
+                row.remove();
             }
-            loadDiocesanCalendarData();
+        });
+        form.querySelectorAll('.data-group-title').forEach(el => el.remove());
+        form.querySelectorAll('.litEventCommon').forEach(el => $(el).multiselect('deselectAll', false).multiselect('select', 'Proper'));
+        form.querySelectorAll('.litEventColor').forEach(el => $(el).multiselect('deselectAll', false).multiselect('select', 'white'));
+        form.querySelectorAll('.litEventName').forEach(el => el.setAttribute('data-valuewas', ''));
+    });
+    const forms = document.querySelectorAll('form');
+    forms.forEach(form => form.classList.remove('was-validated'));
+    const selectedOption = document.querySelector(`#DiocesesList > option[value="${currentVal}"]`);
+    if (selectedOption) {
+        ev.target.classList.remove('is-invalid');
+        API.category = 'diocese';
+        API.key = selectedOption.getAttribute('data-value');
+        console.log('selected diocese with key = ' + API.key);
+        if (LitCalMetadata.diocesan_calendars_keys.includes(API.key)) {
+            API.method = 'PATCH';
+            const diocesan_calendar = LitCalMetadata.diocesan_calendars.filter(el => el.calendar_id === API.key)[0];
+
+            // Enable "Remove diocesan data" button
+            document.querySelector('#removeExistingDiocesanDataBtn').disabled = false;
+
+            // Create "Remove diocesan data" modal
+            document.body.insertAdjacentHTML('beforeend', removeDiocesanCalendarModal(currentVal, Messages));
+
+            // Set diocesan group if applicable
+            if (diocesan_calendar.hasOwnProperty('group')){
+                document.querySelector('#diocesanCalendarGroup').value = diocesan_calendar.group;
+            }
+
+            // Set the list of locales for the current selected diocese
             document.querySelector('#diocesanCalendarLocales').value = diocesan_calendar.locales;
             const LocalesForDiocese = Object.entries(AvailableLocalesWithRegion).filter(([localeIso, ]) => {
                 return diocesan_calendar.locales.includes(localeIso);
             });
             document.querySelector('#currentLocalization').innerHTML = LocalesForDiocese.map(item => `<option value="${item[0]}">${item[1]}</option>`).join('');
-            document.querySelector('#currentLocalization').value = API.locale;
             $('#diocesanCalendarLocales').multiselect('deselectAll', false).multiselect('select', diocesan_calendar.locales);
-            //console.log('we have an existing entry for this diocese!');
+
+            // Set the timezone for the current selected diocese
+            document.querySelector('#diocesanCalendarTimezone').value = diocesan_calendar.timezone;
+
+            loadDiocesanCalendarData();
         } else {
-            $('#removeExistingDiocesanDataBtn').prop('disabled', true);
-            $('body').find('#removeDiocesanCalendarPrompt').remove();
+            API.method = 'PUT';
+            console.log(`API.method set to '${API.method}'`);
+            document.querySelector('#removeExistingDiocesanDataBtn').disabled = true;
+            const removePrompt = document.getElementById('removeDiocesanCalendarPrompt');
+            if (removePrompt) {
+                removePrompt.remove();
+            }
             //console.log('no existing entry for this diocese');
         }
     } else {
-        $(ev.currentTarget).addClass('is-invalid');
+        ev.target.classList.add('is-invalid');
     }
-});
+}
 
-$(document).on('click', '#removeExistingDiocesanDataBtn', evt => {
-    // We don't want any forms to submit, so we prevent the default action
-    evt.preventDefault();
-});
-
-$(document).on('click', '#deleteDiocesanCalendarConfirm', () => {
+const deleteDiocesanCalendarConfirmClicked = () => {
     API.category = 'diocese';
-    $('#removeDiocesanCalendarPrompt').modal('toggle');
-    const diocese = $('#diocesanCalendarDioceseName').val();
-    API.key = $('#DiocesesList').find('option[value="' + diocese + '"]').attr('data-value');
-    let nation = $('#diocesanCalendarNationalDependency').val();
+    const modalElement = document.getElementById('removeDiocesanCalendarPrompt');
+    const modal = bootstrap.Modal.getInstance(modalElement);
+    console.log(modal);
+    modal.toggle();
+    const diocese = document.querySelector('#diocesanCalendarDioceseName').value;
+    API.key = document.querySelector('#DiocesesList option[value="' + diocese + '"]').dataset.value;
+    const nation = document.querySelector('#diocesanCalendarNationalDependency').value;
     /** @type {DiocesanCalendarDELETEPayload} */
     const payload = new DiocesanCalendarDELETEPayload(diocese, nation);
     fetch(API.path, {
@@ -1572,21 +1788,42 @@ $(document).on('click', '#deleteDiocesanCalendarConfirm', () => {
         body: JSON.stringify( payload )
     }).then(response => {
         if (response.ok) {
-            CalendarsIndex.diocesan_calendars = CalendarsIndex.diocesan_calendars.filter(el => el.calendar_id !== API.key);
-            CalendarsIndex.diocesan_calendars_keys = CalendarsIndex.diocesan_calendars_keys.filter(el => el !== API.key);
-            $('#removeExistingDiocesanDataBtn').prop('disabled', true);
-            $('#removeDiocesanCalendarPrompt').remove();
-            $('#diocesanCalendarDioceseName').val('');
-            $('#diocesanCalendarNationalDependency').val('');
-            $('#diocesanCalendarGroup').val('');
-            $('.carousel-item form').each((idx, el) => {
-                el.reset();
-                $(el).find('.row').slice(3).remove();
-                $(el).find('div.data-group-title').remove();
-                $(el).find('.litEventCommon').multiselect('deselectAll', false).multiselect('select', 'Proper');
-                $(el).find('.litEventColor').multiselect('deselectAll', false).multiselect('select', 'white');
-                $(el).find('.litEventName').attr('data-valuewas', '');
+            LitCalMetadata.diocesan_calendars = LitCalMetadata.diocesan_calendars.filter(el => el.calendar_id !== API.key);
+            LitCalMetadata.diocesan_calendars_keys = LitCalMetadata.diocesan_calendars_keys.filter(el => el !== API.key);
+
+            document.getElementById('removeExistingDiocesanDataBtn').disabled = true;
+            const removePromptElement = document.getElementById('removeDiocesanCalendarPrompt');
+            if (removePromptElement) {
+                removePromptElement.remove();
+            }
+            document.getElementById('diocesanCalendarDioceseName').value = '';
+            document.getElementById('diocesanCalendarNationalDependency').value = '';
+            document.getElementById('diocesanCalendarGroup').value = '';
+
+            document.querySelectorAll('.carousel-item form').forEach(form => {
+                form.reset();
+                const rows = form.querySelectorAll('.row');
+                for (let i = 3; i < rows.length; i++) {
+                    rows[i].remove();
+                }
+                const dataGroupTitles = form.querySelectorAll('div.data-group-title');
+                for (let i = 0; i < dataGroupTitles.length; i++) {
+                    dataGroupTitles[i].remove();
+                }
+                const litEventCommons = form.querySelectorAll('.litEventCommon');
+                for (let i = 0; i < litEventCommons.length; i++) {
+                    $(litEventCommons[i]).multiselect('deselectAll', false).multiselect('select', 'Proper');
+                }
+                const litEventColors = form.querySelectorAll('.litEventColor');
+                for (let i = 0; i < litEventColors.length; i++) {
+                    $(litEventColors[i]).multiselect('deselectAll', false).multiselect('select', 'white');
+                }
+                const litEventNames = form.querySelectorAll('.litEventName');
+                for (let i = 0; i < litEventNames.length; i++) {
+                    litEventNames[i].setAttribute('data-valuewas', '');
+                }
             });
+
             toastr["success"](`Diocesan Calendar '${API.key}' was deleted successfully`, "Success");
             response.json().then(json => {
                 console.log(json);
@@ -1599,10 +1836,10 @@ $(document).on('click', '#deleteDiocesanCalendarConfirm', () => {
             console.error(`${error.status} ${json.response}: ${json.description}`);
             toastr["error"](`${error.status} ${json.response}: ${json.description}`, "Error");
         })
-    })
-});
+    });
+}
 
-$(document).on('click', '#saveDiocesanCalendar_btn', () => {
+const saveDiocesanCalendar_btnClicked = () => {
     //const nation = document.querySelector('#diocesanCalendarNationalDependency').value;
     const diocese = document.querySelector('#diocesanCalendarDioceseName').value;
     const option = document.querySelector('#DiocesesList option[value="' + diocese + '"]');
@@ -1615,31 +1852,37 @@ $(document).on('click', '#saveDiocesanCalendar_btn', () => {
     API.locale = document.querySelector('#currentLocalization').value;
 
     // if the diocese overrides Epiphany, Ascension and Corpus Christi settings compared to the national calendar, add the settings to the payload
-    if( diocesanOvveridesDefined() ) {
+    if ( diocesanOvveridesDefined() ) {
         saveObj.payload.settings = {};
-        if( $('#diocesanCalendarOverrideEpiphany').val() !== "" ) {
-            saveObj.payload.settings.epiphany = $('#diocesanCalendarOverrideEpiphany').val();
+        const epiphanyValue = document.querySelector('#diocesanCalendarOverrideEpiphany').value;
+        if (epiphanyValue !== '') {
+            saveObj.payload.settings.epiphany = epiphanyValue;
         }
-        if( $('#diocesanCalendarOverrideAscension').val() !== "" ) {
-            saveObj.payload.settings.ascension = $('#diocesanCalendarOverrideAscension').val();
+        const ascensionValue = document.querySelector('#diocesanCalendarOverrideAscension').value;
+        if (ascensionValue !== '') {
+            saveObj.payload.settings.ascension = ascensionValue;
         }
-        if( $('#diocesanCalendarOverrideCorpusChristi').val() !== "" ) {
-            saveObj.payload.settings.corpus_christi = $('#diocesanCalendarOverrideCorpusChristi').val();
+        const corpusChristiValue = document.querySelector('#diocesanCalendarOverrideCorpusChristi').value;
+        if (corpusChristiValue !== '') {
+            saveObj.payload.settings.corpus_christi = corpusChristiValue;
         }
     }
 
     let formsValid = true;
-    $('form').find('.row').each((idx,row) => {
-        if( $(row).find('.litEventName').val() !== '' ) {
-            $(row).find('input,select').each((idx, el) => {
+
+    document.querySelectorAll('.carousel-item form .row').forEach(row => {
+        if (row.querySelector('.litEventName').value !== '') {
+            row.querySelectorAll('input,select').forEach(el => {
                 if (el.checkValidity() === false) {
                     formsValid = false;
                     alert(el.validationMessage);
                 }
-                $(el).addClass('was-validated');
+                el.classList.add('was-validated');
             });
+            console.log(`row`, row, `has eventName`, eventName, `with value`, eventName.value);
         }
     });
+
     if ( formsValid ) {
         const headers = {
             'Content-Type': 'application/json',
@@ -1648,8 +1891,27 @@ $(document).on('click', '#saveDiocesanCalendar_btn', () => {
         if (API.locale !== '') {
             headers['Accept-Language'] = API.locale;
         }
-        const body = JSON.stringify(saveObj.payload);
-
+        if (API.method === 'PUT') {
+            const selectedOptions = document.querySelector('#diocesanCalendarLocales').selectedOptions;
+            saveObj.payload.metadata = {
+                locales: Array.from(selectedOptions).map(({ value }) => value),
+                nation: document.querySelector('#diocesanCalendarNationalDependency').value,
+                diocese_id: diocese_key,
+                diocese_name: document.querySelector('#diocesanCalendarDioceseName').value,
+                timezone: document.querySelector('#diocesanCalendarTimezone').value
+            };
+        }
+        const body = API.method === 'PATCH'
+            ? JSON.stringify(saveObj.payload)
+            : (
+                API.method === 'PUT'
+                    ? JSON.stringify(saveObj)
+                    : null
+            );
+        console.log('path: ', API.path);
+        console.log('method: ', API.method);
+        console.log('headers: ', headers);
+        console.log('body: ', body);
         fetch(API.path, {
             method: API.method,
             headers,
@@ -1670,62 +1932,89 @@ $(document).on('click', '#saveDiocesanCalendar_btn', () => {
             toastr["error"](error.status + ' ' + error.message, "Error");
         });
     }
-});
+}
 
-$(document).on('click', '#diocesanCalendarDefinitionCardLinks a.page-link', ev => {
+const diocesanCalendarDefinitionsCardLinksClicked = ev => {
     ev.preventDefault();
-    $('#diocesanCalendarDefinitionCardLinks li').removeClass('active');
-    //console.log("you clicked " + $(ev.currentTarget).text());
-    if ($(ev.currentTarget).hasClass('diocesan-carousel-next')) {
-        $('.carousel').carousel('next');
-    } else if ($(ev.currentTarget).hasClass('diocesan-carousel-prev')) {
-        $('.carousel').carousel('prev');
+    const carousel = document.querySelector('.carousel');
+    const carouselInstance = bootstrap.Carousel.getInstance(carousel);
+
+    if (ev.target.classList.contains('diocesan-carousel-next') || ev.target.parentElement.classList.contains('diocesan-carousel-next')) {
+        carouselInstance.next();
+    } else if (ev.target.classList.contains('diocesan-carousel-prev') || ev.target.parentElement.classList.contains('diocesan-carousel-prev')) {
+        carouselInstance.prev();
     } else {
-        $(ev.currentTarget).parent('li').addClass('active');
-        $('.carousel').carousel(parseInt($(ev.currentTarget).attr('data-bs-slide-to')));
+        const slideTo = parseInt(ev.target.getAttribute('data-bs-slide-to'));
+        carouselInstance.to(slideTo);
     }
-});
+}
 
-$(document).on('change', '.existingFestivityName', ev => {
-    const $modal = $(ev.currentTarget).closest('.actionPromptModal');
-    const $form = $modal.find('form');
-    $form.each((idx, el) => { $(el).removeClass('was-validated') });
-    let disabledState;
-    if ($('#existingFestivitiesList').find('option[value="' + $(ev.currentTarget).val() + '"]').length > 0) {
-        disabledState = false;
-        if( $(ev.currentTarget).prop('required') ) {
-            $(ev.currentTarget).removeClass('is-invalid');
+const existingFestivityNameChanged = ev => {
+    const modal = ev.target.closest('.actionPromptModal');
+    const form = modal.querySelectorAll('form');
+    form.forEach(el => { el.classList.remove('was-validated') });
+
+    const option = document.querySelector(`#existingFestivitiesList option[value="${ev.target.value}"]`);
+    const disabledState = !option;
+    if (ev.target.required) {
+        ev.target.classList.toggle('is-invalid', disabledState);
+    }
+
+    const modalId = modal.id;
+    const disableButtons = {
+        makePatronActionPrompt: () => document.querySelector('#designatePatronButton').disabled = disabledState,
+        setPropertyActionPrompt: () => document.querySelector('#setPropertyButton').disabled = disabledState,
+        moveFestivityActionPrompt: () => document.querySelector('#moveFestivityButton').disabled = disabledState,
+        newFestivityActionPrompt: () => {
+            document.querySelector('#newFestivityFromExistingButton').disabled = disabledState;
+            document.querySelector('#newFestivityExNovoButton').disabled = !disabledState;
         }
-    } else {
-        disabledState = true;
-        if( $(ev.currentTarget).prop('required') ) {
-            $(ev.currentTarget).addClass('is-invalid');
+    };
+    (disableButtons[modalId] || function () {})();
+}
+
+const addLanguageEditionRomanMissalClicked = (ev) => {
+    const languageEditionRomanMissal = sanitizeInput( document.querySelector('#languageEditionRomanMissalName').value );
+    document.querySelector('#publishedRomanMissalList').insertAdjacentHTML('beforeend', `<li class="list-group-item">${languageEditionRomanMissal}</li>`);
+    const modal = ev.target.closest('.modal.show');
+    bootstrap.Modal.getInstance(modal).hide();
+}
+
+document.addEventListener('change', ev => {
+    if (ev.target.id === 'diocesanCalendarNationalDependency') {
+        diocesanCalendarNationalDependencyChanged(ev);
+    }
+    if (ev.target.id === 'diocesanCalendarDioceseName') {
+        diocesanCalendarDioceseNameChanged(ev);
+    }
+    if (ev.target.classList.contains('existingFestivityName')) {
+        existingFestivityNameChanged(ev);
+    }
+    if (ev.target.id === 'languageEditionRomanMissalName') {
+        document.querySelector('#addLanguageEditionRomanMissal').disabled = false;
+    }
+    if (ev.target.id === 'currentLocalization') {
+        if (API.category === 'diocese' && API.method === 'PATCH') {
+            loadDiocesanCalendarData();
         }
     }
-    switch( $modal.attr("id") ) {
-        case 'makePatronActionPrompt':
-            $('#designatePatronButton').prop('disabled', disabledState);
-            break;
-        case 'setPropertyActionPrompt':
-            $('#setPropertyButton').prop('disabled', disabledState);
-            break;
-        case 'moveFestivityActionPrompt':
-            $('#moveFestivityButton').prop('disabled', disabledState);
-            break;
-        case 'newFestivityActionPrompt':
-            $('#newFestivityFromExistingButton').prop('disabled', disabledState);
-            $('#newFestivityExNovoButton').prop('disabled', !disabledState);
-            break;
+});
+
+document.addEventListener('click', ev => {
+    if (ev.target.id === 'removeExistingDiocesanDataBtn') {
+        // We don't want any forms to submit, so we prevent the default action
+        ev.preventDefault();
     }
-});
-
-$(document).on('change', '#languageEditionRomanMissalName', () => {
-    $('#addLanguageEditionRomanMissal').prop('disabled', false);
-});
-
-$(document).on('click', '#addLanguageEditionRomanMissal', () => {
-    let languageEditionRomanMissal = sanitizeInput( $('#languageEditionRomanMissalName').val() );
-    $('#publishedRomanMissalList').append(`<li class="list-group-item">${languageEditionRomanMissal}</li>`);
-    let $modal = $(ev.currentTarget).closest('.modal');
-    $modal.modal('hide');
+    if (ev.target.id === 'deleteDiocesanCalendarConfirm') {
+        deleteDiocesanCalendarConfirmClicked();
+    }
+    if (ev.target.id === 'saveDiocesanCalendar_btn') {
+        saveDiocesanCalendar_btnClicked();
+    }
+    if (ev.target.closest('#diocesanCalendarDefinitionCardLinks a.page-link')) {
+        diocesanCalendarDefinitionsCardLinksClicked(ev);
+    }
+    if (ev.target.id === 'addLanguageEditionRomanMissal') {
+        addLanguageEditionRomanMissalClicked(ev);
+    }
 });

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -280,7 +280,7 @@ const translationTemplate = (path, locale, el) => {
     const langWithRegion = AvailableLocalesWithRegion[locale];
     const eventKeyEl = el.parentElement.querySelector('.litEventEvent_key');
     const eventKey = eventKeyEl ? eventKeyEl.value : (el.dataset.hasOwnProperty('valuewas') ? el.dataset.valuewas : '');
-    const value = translationData[path][locale].hasOwnProperty(eventKey) ? ` value="${translationData[path][locale][eventKey]}"` : '';
+    const value = translationData?.[path]?.[locale]?.hasOwnProperty(eventKey) ? ` value="${translationData[path][locale][eventKey]}"` : '';
     return `<div class="input-group input-group-sm mt-1">
             <label class="input-group-text font-monospace" for="${el.id}_${locale}" title="${langWithRegion}">${lang}</label>
             <input type="text" class="form-control litEvent litEventName_${lang}" id="${el.id}_${locale}" data-locale="${locale}"${value}>
@@ -1803,7 +1803,7 @@ const diocesanCalendarNationalDependencyChanged = (ev) => {
     }
     if (localesForNation.length > 0) {
         const diocesanCalendarLocales = document.getElementById('diocesanCalendarLocales');
-        diocesanCalendarLocales.innerHTML = localesForNation.map(item => `<option value="${item[0]}">${item[1]}</option>`).join('');
+        diocesanCalendarLocales.innerHTML = localesForNation.map(item => `<option value="${item[0]}" selected>${item[1]}</option>`).join('');
         $(diocesanCalendarLocales).multiselect('rebuild');
         const currentLocalization = document.getElementById('currentLocalization');
         currentLocalization.innerHTML = localesForNation.map(item => `<option value="${item[0]}">${item[1]}</option>`).join('');
@@ -1999,7 +1999,6 @@ const saveDiocesanCalendar_btnClicked = () => {
                 }
                 el.classList.add('was-validated');
             });
-            console.log(`row`, row, `has eventName`, eventName, `with value`, eventName.value);
         }
     });
 

--- a/extending.php
+++ b/extending.php
@@ -126,7 +126,8 @@ $messages = [
     "LOCALE_WITH_REGION" => $i18n->LOCALE_WITH_REGION,
     "AvailableLocales"   => $SystemLocalesWithoutRegion,
     "AvailableLocalesWithRegion"    => $SystemLocalesWithRegion,
-    "CountriesWithCatholicDioceses" => $CountriesWithCatholicDioceses
+    "CountriesWithCatholicDioceses" => $CountriesWithCatholicDioceses,
+    "DiocesesList"       => $CatholicDiocesesByNation
 ];
 
 $buttonGroup = "<hr><div class=\"d-flex justify-content-around\">
@@ -210,7 +211,10 @@ if (isset($_GET["choice"])) {
                             <?php echo $buttonGroup ?>
                         </div>
                         <div class="card-footer text-center">
-                            <button class="btn btn-lg btn-primary m-2 serializeRegionalNationalData" id="serializeWiderRegionData" data-category="widerregion" disabled><i class="fas fa-save me-2"></i><?php echo _("Save Wider Region Calendar Data") ?></button>
+                            <button class="btn btn-lg btn-primary m-2 serializeRegionalNationalData" id="serializeWiderRegionData" data-category="widerregion" disabled>
+                                <i class="fas fa-save me-2"></i>
+                                <?php echo _("Save Wider Region Calendar Data") ?>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -327,7 +331,10 @@ if (isset($_GET["choice"])) {
                             <?php echo $buttonGroup ?>
                         </div>
                         <div class="card-footer text-center">
-                            <button class="btn btn-lg btn-primary m-2 serializeRegionalNationalData" id="serializeNationalCalendarData" data-category="nation" disabled><i class="fas fa-save me-2"></i><?php echo _("Save National Calendar Data") ?></button>
+                            <button class="btn btn-lg btn-primary m-2 serializeRegionalNationalData" id="serializeNationalCalendarData" data-category="nation" disabled>
+                                <i class="fas fa-save me-2"></i>
+                                <?php echo _("Save National Calendar Data") ?>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -400,7 +407,10 @@ if (isset($_GET["choice"])) {
                                 </select>
                             </div>
                             <div class="col col-md-3 text-center align-self-end">
-                                <button class="btn btn-danger" id="removeExistingDiocesanDataBtn" disabled data-bs-toggle="modal" data-bs-target="#removeDiocesanCalendarPrompt"><?php echo _("Remove existing data"); ?></button>
+                                <button class="btn btn-danger" id="removeExistingDiocesanDataBtn" disabled data-bs-toggle="modal" data-bs-target="#removeDiocesanCalendarPrompt">
+                                    <i class="far fa-trash-alt me-2"></i>
+                                    <?php echo _("Remove existing data"); ?>
+                                </button>
                             </div>
                         </div>
                     </form>
@@ -557,7 +567,10 @@ if (isset($_GET["choice"])) {
                 <div class="container">
                     <div class="row">
                         <div class="col text-center">
-                            <button class="btn btn-lg btn-primary m-1" id="saveDiocesanCalendar_btn"><?php echo _("SAVE DIOCESAN CALENDAR") ?></button>
+                            <button class="btn btn-lg btn-primary m-1" id="saveDiocesanCalendar_btn">
+                                <i class="fas fa-save me-2"></i>
+                                <?php echo _("SAVE DIOCESAN CALENDAR") ?>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/extending.php
+++ b/extending.php
@@ -97,6 +97,7 @@ $messages = [
     "Other Memorial"     => _("Other Memorial"),
     "Other Optional Memorial"   => _("Other Optional Memorial"),
     "Delete calendar"    => _("Delete calendar"),
+    "Delete diocesan calendar" => _("Delete diocesan calendar"),
     "If you choose"      => _("If you choose to delete this calendar, the liturgical events defined for the calendar and the corresponding index entries will be removed and no longer available in the client applications."),
     "Liturgical color"   => _("Liturgical color"),
     "white"              => _("white"),

--- a/extending.php
+++ b/extending.php
@@ -335,7 +335,7 @@ if (isset($_GET["choice"])) {
         case "diocesan":
             FormControls::$settings["untilYearField"] = true;
             ?>
-                <div class="container">
+                <div class="container mb-5">
                     <form class="needs-validation" novalidate>
                         <div class="row justify-content-center align-items-baseline ">
                             <div class="form-group col col-md-3">
@@ -384,12 +384,18 @@ if (isset($_GET["choice"])) {
                             <div class="form-group col col-md-3">
                                 <label for="currentLocalization" class="fw-bold"><?php echo _("Current localization"); ?>:</label>
                                 <select class="form-select currentLocalizationChoices" id="currentLocalization">
+                                    <option value=""></option>
                                     <?php
-                                    echo "<option value=\"\"></option>";
                                     foreach ($SystemLocalesWithRegion as $AvlLOCALE => $AvlLANGUAGE) {
                                         echo "<option value=\"{$AvlLOCALE}\">{$AvlLANGUAGE}</option>";
                                     }
                                     ?>
+                                </select>
+                            </div>
+                            <div class="form-group col col-md-3">
+                                <label for="diocesanCalendarTimezone" class="fw-bold"><?php echo _("Timezone"); ?></label>
+                                <select class="form-select" id="diocesanCalendarTimezone">
+                                    <option value=""></option>
                                 </select>
                             </div>
                             <div class="col col-md-3 text-center align-self-end">

--- a/src/FormControls.php
+++ b/src/FormControls.php
@@ -62,8 +62,8 @@ class FormControls
 
         if (self::$settings["monthField"]) {
             $formRow .= "<div class=\"form-group col-sm-2\">" .
-            "<label for=\"{$uniqid}Month\"><span class=\"month-label\">" . _("Month") . "</span><div class=\"form-check form-check-inline form-switch ms-2 ps-5 border border-secondary rounded bg-light align-bottom\" title=\"switch on for mobile celebration as opposed to fixed date\">" .
-            "<label class=\"form-check-label me-1\" for=\"{$uniqid}Strtotime\">Mobile</label>" .
+            "<label for=\"{$uniqid}Month\" class=\"d-flex justify-content-between align-items-end\"><span class=\"month-label\">" . _("Month") . "</span><div class=\"form-check form-check-inline form-switch me-0 ps-5 pe-2 border border-2 border-secondary rounded bg-light\" title=\"switch on for mobile celebration as opposed to fixed date\">" .
+            "<label class=\"form-check-label\" for=\"{$uniqid}Strtotime\">Mobile</label>" .
             "<input class=\"form-check-input litEvent litEventStrtotimeSwitch\" type=\"checkbox\" data-bs-toggle=\"toggle\" data-bs-size=\"xs\" data-bs-onstyle=\"info\" data-bs-offstyle=\"dark\" role=\"switch\" id=\"{$uniqid}Strtotime\">" .
             "</div></label>" .
             "<select class=\"form-select litEvent litEventMonth\" id=\"{$uniqid}Month\">";

--- a/src/FormControls.php
+++ b/src/FormControls.php
@@ -62,7 +62,7 @@ class FormControls
 
         if (self::$settings["monthField"]) {
             $formRow .= "<div class=\"form-group col-sm-2\">" .
-            "<label for=\"{$uniqid}Month\"><span class=\"month-label\">" . _("Month") . "</span><div class=\"form-check form-check-inline form-switch ms-2 ps-5 border border-secondary rounded bg-light\" title=\"switch on for mobile celebration as opposed to fixed date\">" .
+            "<label for=\"{$uniqid}Month\"><span class=\"month-label\">" . _("Month") . "</span><div class=\"form-check form-check-inline form-switch ms-2 ps-5 border border-secondary rounded bg-light align-bottom\" title=\"switch on for mobile celebration as opposed to fixed date\">" .
             "<label class=\"form-check-label me-1\" for=\"{$uniqid}Strtotime\">Mobile</label>" .
             "<input class=\"form-check-input litEvent litEventStrtotimeSwitch\" type=\"checkbox\" data-bs-toggle=\"toggle\" data-bs-size=\"xs\" data-bs-onstyle=\"info\" data-bs-offstyle=\"dark\" role=\"switch\" id=\"{$uniqid}Strtotime\">" .
             "</div></label>" .


### PR DESCRIPTION
# Issue being worked on
#161

# Summary of changes
With the new backend API functionality being worked on in Liturgical-Calendar/LiturgicalCalendarAPI/issues/284 / Liturgical-Calendar/LiturgicalCalendarAPI/pull/285, we load i18n data for the current calendar so as to be able to PUT / PATCH i18n data from the frontend interfaces.

While working on these implementations, I also took the opportunity to refactor a lot of the code from jQuery to native javascript, considering that native javascript can do pretty much everything that jQuery has offered up until now. Even bootstrap no longer requires jQuery. The only bootstrap plugin that is still a jQuery plugin is the `multiselect`, so we still need to use jQuery for this.