### PR TITLE
fix: add size="1" to multiselect inputs to prevent FOUC

### DIFF
--- a/assets/js/FormControls.js
+++ b/assets/js/FormControls.js
@@ -397,7 +397,7 @@ class FormControls {
         if (FormControls.settings.colorField) {
             formRow += `<div class="form-group col-sm-1">
             <label for="onTheFly${FormControls.uniqid}Color">${Messages[ "Liturgical color" ]}</label>
-            <select class="form-select litEvent litEventColor" id="onTheFly${FormControls.uniqid}Color" multiple="multiple" />${FormControls.generateColorOptionsHtml(['white'])}</select>
+            <select class="form-select litEvent litEventColor" id="onTheFly${FormControls.uniqid}Color" multiple="multiple" size="1" />${FormControls.generateColorOptionsHtml(['white'])}</select>
             </div>`;
         }
 
@@ -991,7 +991,7 @@ class FormControls {
         const selectedColors = liturgical_event?.color ?? [];
         formRow += `<div class="form-group col-sm-2">
         <label for="onTheFly${FormControls.uniqid}Color">${Messages[ "Liturgical color" ]}</label>
-        <select class="form-select litEvent litEventColor" id="onTheFly${FormControls.uniqid}Color" multiple="multiple"${FormControls.settings.colorField === false ? ' disabled' : ''} />${FormControls.generateColorOptionsHtml(selectedColors)}</select>
+        <select class="form-select litEvent litEventColor" id="onTheFly${FormControls.uniqid}Color" multiple="multiple" size="1"${FormControls.settings.colorField === false ? ' disabled' : ''} />${FormControls.generateColorOptionsHtml(selectedColors)}</select>
         </div>`;
 
         if( 'strtotime' in liturgical_event ) {

--- a/extending.php
+++ b/extending.php
@@ -188,7 +188,7 @@ if (isset($_GET['choice'])) {
                         <div class="col col-md-3">
                             <div>
                                 <label for="widerRegionLocales" class="fw-bold"><?php echo $messages['Locales']; ?></label>
-                                <select class="form-select calendarLocales" id="widerRegionLocales" data-requires-auth="true" disabled multiple="multiple">
+                                <select class="form-select calendarLocales" id="widerRegionLocales" data-requires-auth="true" disabled multiple="multiple" size="1">
                                 <?php foreach ($SystemLocalesWithRegion as $locale => $lang_region) {
                                         echo "<option value='$locale'>$lang_region</option>";
                                 } ?>
@@ -253,7 +253,7 @@ if (isset($_GET['choice'])) {
                         <div class="col col-md-3">
                             <div>
                                 <label for="nationalCalendarLocales" class="fw-bold"><?php echo $messages['Locales']; ?></label>
-                                <select class="form-select calendarLocales" id="nationalCalendarLocales" data-requires-auth="true" disabled multiple="multiple">
+                                <select class="form-select calendarLocales" id="nationalCalendarLocales" data-requires-auth="true" disabled multiple="multiple" size="1">
                                 <?php foreach ($SystemLocalesWithRegion as $locale => $lang_region) {
                                         echo "<option value='$locale'>$lang_region</option>";
                                 } ?>
@@ -415,7 +415,7 @@ if (isset($_GET['choice'])) {
                         <div class="row justify-content-center align-items-baseline">
                             <div class="form-group col col-md-3">
                                 <label for="diocesanCalendarLocales" class="fw-bold"><?php echo $messages['Locales']; ?>:</label>
-                                <select class="form-select calendarLocales" id="diocesanCalendarLocales" multiple="multiple" disabled>
+                                <select class="form-select calendarLocales" id="diocesanCalendarLocales" multiple="multiple" size="1" disabled>
                                 <?php
                                 foreach ($SystemLocalesWithRegion as $AvlLOCALE => $AvlLANGUAGE) {
                                     echo "<option value=\"{$AvlLOCALE}\">{$AvlLANGUAGE}</option>";

--- a/src/FormControls.php
+++ b/src/FormControls.php
@@ -90,7 +90,7 @@ class FormControls
         if (self::$settings['colorField']) {
             $formRow .= '<div class="form-group col-sm-1">' .
             "<label for=\"{$uniqid}Color\">" . _('Liturgical color') . '</label>' .
-            "<select class=\"form-select litEvent litEventColor\" id=\"{$uniqid}Color\" multiple=\"multiple\" />" .
+            "<select class=\"form-select litEvent litEventColor\" id=\"{$uniqid}Color\" multiple=\"multiple\" size=\"1\" />" .
             '<option value="white" selected>' . strtoupper(_('white')) . '</option>' .
             '<option value="red">' . strtoupper(_('red')) . '</option>' .
             '<option value="purple">' . strtoupper(_('purple')) . '</option>' .
@@ -122,7 +122,7 @@ class FormControls
     {
         return '<div class="form-group col-sm-{colWidth}">' .
         '<label style="display:block;" for="onTheFly{uniqid}Common">' . _('Common (or Proper)') . '</label>' .
-        '<select class="form-select litEvent litEventCommon" id="onTheFly{uniqid}Common" multiple="multiple" />' .
+        '<select class="form-select litEvent litEventCommon" id="onTheFly{uniqid}Common" multiple="multiple" size="1" />' .
         '<option value="Proper" selected>' . $this->LitCommon->fullTranslate('Proper') . '</option>' .
         '<option value="Blessed Virgin Mary">' . $this->LitCommon->fullTranslate('Blessed Virgin Mary') . '</option>' .
         //"<optgroup label=\"" . $this->LitCommon->fullTranslate("Common of Martyrs") . "\">" .


### PR DESCRIPTION
## Summary

- Add `size="1"` attribute to all `<select multiple>` elements to prevent layout shift (FOUC) before bootstrap-multiselect renders them
- When the native multiselect hasn't been enhanced yet, it expands to show multiple options, causing content to jump when bootstrap-multiselect transforms it to a single-row button

## Changes

| File | Elements |
|------|----------|
| `extending.php` | `#widerRegionLocales`, `#nationalCalendarLocales`, `#diocesanCalendarLocales` |
| `assets/js/FormControls.js` | `.litEventColor` (2 occurrences) |
| `src/FormControls.php` | `.litEventColor`, `.litEventCommon` |

## Test plan

- [ ] Load extending.php and verify no layout shift when multiselects render
- [ ] Test wider region, national, and diocesan calendar forms
- [ ] Add new liturgical event rows and verify color/common selects render without FOUC

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the display height of multi-select dropdown menus for liturgical colors and calendar locale selections to render with a single visible row.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->