### PR TITLE
Save and restore date values when toggling fixed/relative date

### DIFF
--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -1271,7 +1271,7 @@ const litEventStrtotimeSwitchHandler = (ev) => {
                 litEventMonth.remove();
                 litEventMonthFormGrp.querySelector('.month-label').textContent = 'Relative date';
                 litEventMonthFormGrp.querySelector('.month-label').setAttribute('for', strtotimeId);
-                litEventMonthFormGrp.insertAdjacentHTML('beforeend', `<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" value="${previousStrtotime.replace(/"/g, '&quot;')}" />`);
+                litEventMonthFormGrp.insertAdjacentHTML('beforeend', `<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" value="${escapeHtml(previousStrtotime)}" />`);
             }
         }
     } else {

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -1214,38 +1214,56 @@ const litEventStrtotimeSwitchHandler = (ev) => {
         const litEvent = CalendarData.litcal.find(item => item.liturgical_event.event_key === eventKey) ?? null;
         if (litEvent !== null) {
             if (false === ev.target.checked) {
-                delete litEvent.liturgical_event.strtotime;
-                litEvent.liturgical_event.day = 1;
-                litEvent.liturgical_event.month = 1;
+                // Switching from strtotime to day/month: save strtotime value, restore previous day/month
                 const strToTimeFormGroup = ev.target.closest('.form-group');
+                const litEventStrtotime = strToTimeFormGroup.querySelector('.litEventStrtotime');
+                const strtotimeVal = litEventStrtotime.value;
+                const previousDayMonth = strToTimeFormGroup.dataset.valuewas || '1-1';
+                const dayMonthParts = previousDayMonth.split('-');
+                const restoredDay = parseInt(dayMonthParts[0]) || 1;
+                const restoredMonth = parseInt(dayMonthParts[1]) || 1;
+
+                delete litEvent.liturgical_event.strtotime;
+                litEvent.liturgical_event.day = restoredDay;
+                litEvent.liturgical_event.month = restoredMonth;
+
                 strToTimeFormGroup.classList.remove('col-sm-3');
                 strToTimeFormGroup.classList.add('col-sm-2');
-                const litEventStrtotime = strToTimeFormGroup.querySelector('.litEventStrtotime');
+                strToTimeFormGroup.setAttribute('data-valuewas', strtotimeVal);
                 const dayId = litEventStrtotime.id.replace('Strtotime', 'Day');
                 const monthId = litEventStrtotime.id.replace('Strtotime', 'Month');
                 strToTimeFormGroup.insertAdjacentHTML('beforebegin', `<div class="form-group col-sm-1">
-                <label for="${dayId}">${Messages[ "Day" ]}</label><input type="number" min="1" max="31" value="1" class="form-control litEvent litEventDay" id="${dayId}" />
+                <label for="${dayId}">${Messages[ "Day" ]}</label><input type="number" min="1" max="31" value="${restoredDay}" class="form-control litEvent litEventDay" id="${dayId}" />
                 </div>`);
                 litEventStrtotime.remove();
                 let formRow = `<select class="form-select litEvent litEventMonth" id="${monthId}">`;
                 const formatter = new Intl.DateTimeFormat(jsLocale, { month: 'long' });
                 for (let i = 0; i < 12; i++) {
                     const month = new Date(Date.UTC(0, i, 2, 0, 0, 0));
-                    formRow += `<option value=${i + 1}>${formatter.format(month)}</option>`;
+                    formRow += `<option value=${i + 1}${i + 1 === restoredMonth ? ' selected' : ''}>${formatter.format(month)}</option>`;
                 }
                 formRow += `</select>`;
                 strToTimeFormGroup.insertAdjacentHTML('beforeend', formRow);
                 strToTimeFormGroup.querySelector('.month-label').textContent = Messages[ 'Month' ];
                 strToTimeFormGroup.querySelector('.month-label').setAttribute('for', monthId);
             } else {
-                delete litEvent.liturgical_event.day;
-                delete litEvent.liturgical_event.month;
-                litEvent.liturgical_event.strtotime = '';
-
-                const dayFormGroup = row.querySelector('.litEventDay').closest('.form-group');
-                dayFormGroup.remove();
+                // Switching from day/month to strtotime: save day/month values, restore previous strtotime
+                const dayInput = row.querySelector('.litEventDay');
+                const monthSelect = row.querySelector('.litEventMonth');
+                const dayVal = dayInput ? dayInput.value : '1';
+                const monthVal = monthSelect ? monthSelect.value : '1';
 
                 const litEventMonthFormGrp = ev.target.closest('.form-group');
+                const previousStrtotime = litEventMonthFormGrp.dataset.valuewas || '';
+
+                delete litEvent.liturgical_event.day;
+                delete litEvent.liturgical_event.month;
+                litEvent.liturgical_event.strtotime = previousStrtotime;
+
+                const dayFormGroup = dayInput.closest('.form-group');
+                litEventMonthFormGrp.setAttribute('data-valuewas', `${dayVal}-${monthVal}`);
+                dayFormGroup.remove();
+
                 const litEventMonth = litEventMonthFormGrp.querySelector('.litEventMonth');
                 const strtotimeId = litEventMonth.id.replace('Month', 'Strtotime');
                 litEventMonthFormGrp.classList.remove('col-sm-2');
@@ -1253,7 +1271,7 @@ const litEventStrtotimeSwitchHandler = (ev) => {
                 litEventMonth.remove();
                 litEventMonthFormGrp.querySelector('.month-label').textContent = 'Relative date';
                 litEventMonthFormGrp.querySelector('.month-label').setAttribute('for', strtotimeId);
-                litEventMonthFormGrp.insertAdjacentHTML('beforeend', `<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" />`);
+                litEventMonthFormGrp.insertAdjacentHTML('beforeend', `<input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!" class="form-control litEvent litEventStrtotime" id="${strtotimeId}" value="${previousStrtotime.replace(/"/g, '&quot;')}" />`);
             }
         }
     } else {

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -2152,7 +2152,7 @@ const datetypeToggleBtnClicked = (ev) => {
         const valueWas = dayFormGroup.dataset.valuewas;
         const strToTimeTemplate = `<label for="onTheFly${uniqid}Strtotime">Relative date</label>
             <input type="text" placeholder="e.g. fourth thursday of november" title="e.g. fourth thursday of november | php strtotime syntax supported here!"
-                value="${valueWas}" class="form-control litEvent litEventStrtotime" id="onTheFly${uniqid}Strtotime"
+                value="${escapeHtml(valueWas || '')}" class="form-control litEvent litEventStrtotime" id="onTheFly${uniqid}Strtotime"
             />`;
         dayFormGroup.innerHTML = '';
         dayFormGroup.classList.remove('col-sm-1');


### PR DESCRIPTION
## Summary

- Save day/month values when switching to strtotime (relative date) and restore them when switching back
- Save strtotime value when switching to day/month (fixed date) and restore it when switching back
- Uses `data-valuewas` attributes on the form group, matching the pattern already used by the on-the-fly form's `datetypeToggleBtnClicked` handler

Fixes #98

## Test plan

- [ ] Load a diocesan or national calendar in the extending page
- [ ] Set a day/month value on an event (e.g., day=15, month=March)
- [ ] Toggle the switch to relative date — verify the day/month fields are replaced with strtotime input
- [ ] Enter a strtotime value (e.g., "fourth thursday of november")
- [ ] Toggle back to fixed date — verify day=15 and month=March are restored
- [ ] Toggle to relative again — verify "fourth thursday of november" is restored
- [ ] Verify the on-the-fly form toggle still works correctly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date input mode switching for liturgical events so previously entered values are preserved and restored when toggling formats, preventing accidental resets and data loss.

* **Security**
  * Escaped on-the-fly date input values to prevent quote/HTML injection when switching input modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->