### PR TITLE
fix(auth): include .env.staging in Dotenv loader

### DIFF
--- a/auth/callback.php
+++ b/auth/callback.php
@@ -13,7 +13,7 @@ use LiturgicalCalendar\Frontend\OidcClient;
 use LiturgicalCalendar\Frontend\CookieHelper;
 
 // Load environment
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.production', '.env']);
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.staging', '.env.production', '.env']);
 $dotenv->safeLoad();
 
 // Enable error display in development

--- a/auth/login.php
+++ b/auth/login.php
@@ -12,7 +12,7 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 use LiturgicalCalendar\Frontend\OidcClient;
 
 // Load environment
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.production', '.env']);
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.staging', '.env.production', '.env']);
 $dotenv->safeLoad();
 
 // Check if OIDC is configured

--- a/auth/logout.php
+++ b/auth/logout.php
@@ -13,7 +13,7 @@ use LiturgicalCalendar\Frontend\OidcClient;
 use LiturgicalCalendar\Frontend\CookieHelper;
 
 // Load environment
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.production', '.env']);
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.staging', '.env.production', '.env']);
 $dotenv->safeLoad();
 
 // Get ID token for Zitadel logout hint (if available)

--- a/auth/me.php
+++ b/auth/me.php
@@ -12,7 +12,7 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 use LiturgicalCalendar\Frontend\OidcClient;
 
 // Load environment
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.production', '.env']);
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.staging', '.env.production', '.env']);
 $dotenv->safeLoad();
 
 // Set JSON response headers

--- a/auth/refresh.php
+++ b/auth/refresh.php
@@ -12,7 +12,7 @@ use LiturgicalCalendar\Frontend\OidcClient;
 use LiturgicalCalendar\Frontend\CookieHelper;
 
 // Load environment
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.production', '.env']);
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__), ['.env.local', '.env.development', '.env.staging', '.env.production', '.env']);
 $dotenv->safeLoad();
 
 // Set JSON response headers


### PR DESCRIPTION
The five PHP entry points under `auth/` all bootstrap the env via:

```php
Dotenv\Dotenv::createImmutable(dirname(__DIR__),
    ['.env.local', '.env.development', '.env.production', '.env']);
```

`.env.staging` is missing from the file list. Staging deployments (e.g. `litcal-staging.johnromanodorazio.com`) that put `ZITADEL_*` and related secrets in `.env.staging` have their values silently ignored.

## Symptom

`auth/login.php` returns HTTP 503 with `{"error": "OIDC not configured"}` because `OidcClient::isConfigured()` sees `null` for both `ZITADEL_ISSUER` and `ZITADEL_CLIENT_ID`.

Hit live this morning when wiring the staging frontend against the new shared CatholicOS umbrella Zitadel — see Liturgical-Calendar/LiturgicalCalendarAPI#597 for context.

## Change

Insert `.env.staging` between `.env.development` and `.env.production` in all 5 files (`callback.php`, `login.php`, `logout.php`, `me.php`, `refresh.php`).

**Position rationale**: `createImmutable` + `safeLoad` means earlier files in the list win. Putting staging above production lets a `.env.staging` file on a staging host override any `.env.production` defaults that may also be present, while still letting `.env.local` and `.env.development` win for local-dev overrides.

## Test plan

| Environment | Files present | Behaviour |
|---|---|---|
| Local dev | `.env.local`, `.env.development`, `.env` | Unaffected — `.env.staging` slot is empty, lookup unchanged |
| Staging | `.env.staging` | **Now loads correctly** (previously silent failure) |
| Production | `.env.production` | Unaffected — staging slot is empty |
| Hybrid prod+staging file | both | Staging values win on the staging host, which is the intended override semantics |

After merge + deploy on the staging host, `https://litcal-staging.johnromanodorazio.com/auth/login.php` should redirect to the Zitadel authorize endpoint instead of returning HTTP 503.