### PR TITLE
ci: add staging + production deploy workflow

### DIFF
--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -69,11 +69,12 @@ CLAUDE.md
 CODE_OF_CONDUCT.md
 README.md
 
-# --- TRACKED EXAMPLE FILES (transferred + overwritten every deploy) ---
-# The "+" prefix is an rsync include-override: these rules must precede
-# the matching ".env.*" exclude below for first-match-wins to honor them.
-# We intentionally DO want .env.example and docker-compose.override.example.yml
-# to ship so admins can diff them against the live copies on the server.
+# --- TRACKED EXAMPLE FILE (transferred + overwritten every deploy) ---
+# The "+" prefix is an rsync include-override: this rule must precede the
+# matching ".env.*" exclude below for first-match-wins to honor it. We
+# intentionally DO want .env.example to ship and overwrite the server's
+# copy on every deploy so admins can diff it against .env.staging /
+# .env.production to spot new or deprecated environment variables.
 + .env.example
 
 # --- Zitadel / OpenFGA bootstrap artifacts (server has its own) ---

--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -1,0 +1,100 @@
+# Patterns excluded from `rsync --delete` deploys.
+#
+# These patterns serve two purposes:
+#   1. Files matched here are NOT transferred from the runner.
+#   2. Files matched here are NOT removed on the destination by --delete.
+#
+# Anything that should live only on the server (env files, runtime
+# logs, server-managed state) MUST be listed here so it isn't wiped
+# on deploy.
+
+# --- VCS / CI / agent metadata ---
+.git/
+.github/
+.gitignore
+.gitattributes
+.editorconfig
+.serena/
+.worktrees/
+.claude/
+
+# --- IDE / local tooling ---
+.vscode/
+.idea/
+.phpunit.cache/
+.phpcs.cache
+
+# --- Tests, dev-only sources ---
+e2e/
+tests/
+playwright.config.ts
+playwright-report/
+test-results/
+docs/
+
+# --- Build / dev configuration with no runtime role ---
+phpcs.xml
+phpcs.xml.dist
+phpstan.neon
+phpstan.neon.dist
+phpstan-bootstrap.php
+phpunit.xml
+phpunit.xml.dist
+captainhook.json
+.markdownlint.yml
+eslint.config.mjs
+docker-compose.yml
+docker-compose.yaml
+docker-compose.override.yml
+docker-compose.override.example.yml
+Dockerfile
+.dockerignore
+
+# --- Node / Yarn (only used for E2E tests + markdown linting) ---
+node_modules/
+.yarn/
+.yarnrc.yml
+.pnp.*
+package.json
+yarn.lock
+
+# --- Local dev / one-shot setup scripts (not used in production) ---
+scripts/
+
+# --- Composer install-time only (never read at runtime) ---
+composer.lock
+
+# --- Project meta files ---
+CLAUDE.md
+CODE_OF_CONDUCT.md
+README.md
+
+# --- TRACKED EXAMPLE FILES (transferred + overwritten every deploy) ---
+# The "+" prefix is an rsync include-override: these rules must precede
+# the matching ".env.*" exclude below for first-match-wins to honor them.
+# We intentionally DO want .env.example and docker-compose.override.example.yml
+# to ship so admins can diff them against the live copies on the server.
++ .env.example
+
+# --- Zitadel / OpenFGA bootstrap artifacts (server has its own) ---
+*.pat
+test-service-account-key.json
+
+# --- SERVER-MANAGED FILES (never transferred, never --delete) ---
+# These are server-only state: .env / .env.production / .env.staging
+# carry the live secrets, logs/ accumulates runtime logs. Both stay
+# untouched by rsync.
+.env
+.env.*
+logs/
+
+# --- RUNTIME CACHE (preserve server-side state) ---
+# Excludes contents only; the directory itself is created on the server
+# in a pre-rsync SSH-exec step so PHP can still write to it.
+/cache/*
+
+# --- Dev-only symlink to local liturgy-components-js checkout ---
+/assets/components-js
+
+# --- Generated data dir (gitignored locally, server-managed) ---
+/assets/json/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,8 +38,22 @@ jobs:
           set -euo pipefail
           case "${EVENT_NAME}" in
             workflow_dispatch)
+              # Force the canonical branch per target so a user with
+              # workflow_dispatch perms can't deploy an arbitrary branch
+              # (the UI lets them pick one, but we ignore it).
               TARGET="${INPUT_TARGET}"
-              REF="${GIT_REF#refs/heads/}"
+              case "${TARGET}" in
+                production) REF="main" ;;
+                staging)    REF="development" ;;
+                *)
+                  echo "::error::Unsupported workflow_dispatch target: ${TARGET}" >&2
+                  exit 1
+                  ;;
+              esac
+              SELECTED_REF="${GIT_REF#refs/heads/}"
+              if [ "${SELECTED_REF}" != "${REF}" ]; then
+                echo "::notice::workflow_dispatch was triggered from '${SELECTED_REF}', but ${TARGET} always deploys '${REF}'. Using '${REF}'."
+              fi
               ;;
             push)
               case "${GIT_REF}" in
@@ -76,6 +90,10 @@ jobs:
         env:
           APP_PATH: ${{ vars.VPS_APP_PATH }}
           APP_URL: ${{ vars.VPS_APP_URL }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USERNAME }}
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          VPS_KNOWN_HOSTS: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
           TARGET: ${{ needs.resolve.outputs.target }}
         run: |
           set -euo pipefail
@@ -86,6 +104,22 @@ jobs:
           fi
           if [ -z "${APP_URL}" ]; then
             echo "::error::Environment variable VPS_APP_URL is not set for '${TARGET}'." >&2
+            missing=1
+          fi
+          if [ -z "${VPS_HOST}" ]; then
+            echo "::error::Secret VPS_HOST is not set for '${TARGET}'." >&2
+            missing=1
+          fi
+          if [ -z "${VPS_USER}" ]; then
+            echo "::error::Secret VPS_USERNAME is not set for '${TARGET}'." >&2
+            missing=1
+          fi
+          if [ -z "${VPS_SSH_KEY}" ]; then
+            echo "::error::Secret VPS_SSH_PRIVATE_KEY is not set for '${TARGET}'." >&2
+            missing=1
+          fi
+          if [ -z "${VPS_KNOWN_HOSTS}" ]; then
+            echo "::error::Secret VPS_SSH_KNOWN_HOSTS is not set for '${TARGET}'. Refusing to deploy without a pinned host key." >&2
             missing=1
           fi
           [ "${missing}" -eq 0 ]

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,219 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Deployment target'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+  push:
+    branches:
+      - development
+      - main
+
+concurrency:
+  group: deploy-${{ github.event_name == 'workflow_dispatch' && inputs.target || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve target
+    runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.t.outputs.target }}
+      ref: ${{ steps.t.outputs.ref }}
+    steps:
+      - name: Pick target + ref
+        id: t
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TARGET: ${{ inputs.target }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          case "${EVENT_NAME}" in
+            workflow_dispatch)
+              TARGET="${INPUT_TARGET}"
+              REF="${GIT_REF#refs/heads/}"
+              ;;
+            push)
+              case "${GIT_REF}" in
+                refs/heads/main)        TARGET="production"; REF="main" ;;
+                refs/heads/development) TARGET="staging";    REF="development" ;;
+                *)
+                  echo "::error::Push to unsupported branch: ${GIT_REF}" >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
+            *)
+              echo "::error::Unsupported event: ${EVENT_NAME}" >&2
+              exit 1
+              ;;
+          esac
+          {
+            echo "target=${TARGET}"
+            echo "ref=${REF}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "::notice::Deploying ${TARGET} from ref=${REF}"
+
+  deploy:
+    name: Deploy ${{ needs.resolve.outputs.target }}
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: ${{ needs.resolve.outputs.target }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Validate required environment configuration
+        env:
+          APP_PATH: ${{ vars.VPS_APP_PATH }}
+          APP_URL: ${{ vars.VPS_APP_URL }}
+          TARGET: ${{ needs.resolve.outputs.target }}
+        run: |
+          set -euo pipefail
+          missing=0
+          if [ -z "${APP_PATH}" ]; then
+            echo "::error::Environment variable VPS_APP_PATH is not set for '${TARGET}'." >&2
+            missing=1
+          fi
+          if [ -z "${APP_URL}" ]; then
+            echo "::error::Environment variable VPS_APP_URL is not set for '${TARGET}'." >&2
+            missing=1
+          fi
+          [ "${missing}" -eq 0 ]
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        with:
+          php-version: '8.4'
+          extensions: intl, json, simplexml, dom, calendar, zip, gettext, curl, xml, mbstring
+          tools: composer:v2
+          coverage: none
+
+      - name: Install production dependencies
+        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress --no-scripts --no-plugins --prefer-dist
+
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_KNOWN_HOSTS}" ]; then
+            echo "::error::Secret VPS_SSH_KNOWN_HOSTS is empty. Refusing to deploy without a pinned host key." >&2
+            exit 1
+          fi
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Sanity-check pinned host key against DNS SSHFP records
+        env:
+          SSH_KNOWN_HOSTS: ${{ secrets.VPS_SSH_KNOWN_HOSTS }}
+          SSHFP_HOST: ${{ secrets.VPS_HOST }}
+        run: |
+          set -euo pipefail
+          if ! command -v dig >/dev/null; then
+            echo "::warning::dig not available; skipping SSHFP drift check."
+            exit 0
+          fi
+          PIN_FPS=$(printf '%s\n' "${SSH_KNOWN_HOSTS}" \
+            | awk '$2 ~ /^(ssh-|ecdsa-)/' \
+            | while read -r _host _alg keyb64 _; do
+                printf '%s' "$keyb64" | base64 -d 2>/dev/null | sha256sum | awk '{print toupper($1)}'
+              done \
+            | sort -u)
+          DNS_FPS=$(dig +short SSHFP "${SSHFP_HOST}" \
+            | awk '$2 == "2" {for (i=3; i<=NF; i++) printf "%s", $i; print ""}' \
+            | tr -d ' ' \
+            | tr 'a-f' 'A-F' \
+            | sort -u)
+          if [ -z "${DNS_FPS}" ]; then
+            echo "::warning::No SHA-256 SSHFP records found for ${SSHFP_HOST}; skipping drift check."
+            exit 0
+          fi
+          if [ -z "${PIN_FPS}" ]; then
+            echo "::warning::Could not derive any fingerprints from VPS_SSH_KNOWN_HOSTS; skipping drift check."
+            exit 0
+          fi
+          PIN_NOT_IN_DNS=$(comm -23 <(echo "${PIN_FPS}") <(echo "${DNS_FPS}"))
+          DNS_NOT_IN_PIN=$(comm -13 <(echo "${PIN_FPS}") <(echo "${DNS_FPS}"))
+          if [ -n "${PIN_NOT_IN_DNS}" ]; then
+            while IFS= read -r fp; do
+              echo "::warning::Pinned key SHA256:${fp} not in DNS SSHFP for ${SSHFP_HOST}."
+            done <<< "${PIN_NOT_IN_DNS}"
+          fi
+          if [ -n "${DNS_NOT_IN_PIN}" ]; then
+            while IFS= read -r fp; do
+              echo "::warning::DNS SSHFP advertises SHA256:${fp} not present in VPS_SSH_KNOWN_HOSTS."
+            done <<< "${DNS_NOT_IN_PIN}"
+          fi
+          if [ -z "${PIN_NOT_IN_DNS}" ] && [ -z "${DNS_NOT_IN_PIN}" ]; then
+            echo "Pin matches DNS SSHFP records."
+          fi
+
+      - name: Ensure deploy + cache + logs dirs exist
+        env:
+          VPS_USER: ${{ secrets.VPS_USERNAME }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+          DEPLOY_PATH: ${{ vars.VPS_APP_PATH }}
+        run: |
+          set -euo pipefail
+          remote_cmd=$(printf 'mkdir -p %q %q %q' \
+            "${DEPLOY_PATH}" \
+            "${DEPLOY_PATH}/cache" \
+            "${DEPLOY_PATH}/logs")
+          ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o ConnectTimeout=10 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=2 \
+            "${VPS_USER}@${VPS_HOST}" \
+            "${remote_cmd}"
+
+      - name: Deploy via rsync
+        env:
+          VPS_USER: ${{ secrets.VPS_USERNAME }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+          DEPLOY_PATH: ${{ vars.VPS_APP_PATH }}
+        run: |
+          set -euo pipefail
+          rsync \
+            --archive --no-owner --no-group \
+            --compress --human-readable --verbose \
+            --delete --protect-args \
+            --exclude-from=.github/deploy/rsync-exclude.txt \
+            -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
+            ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"
+
+      - name: Post-deploy health check
+        env:
+          APP_URL: ${{ vars.VPS_APP_URL }}
+        run: |
+          set -euo pipefail
+          curl -fsS --retry 3 --retry-delay 5 --max-time 15 \
+            "${APP_URL%/}/" -o /dev/null
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
## Summary

- New GitHub Actions workflow at `.github/workflows/deploy.yaml` that deploys the frontend to staging or production via SSH + rsync, mirroring the pattern established in `LiturgicalCalendarAPI/.github/workflows/deploy.yaml`.
- New `.github/deploy/rsync-exclude.txt` that keeps dev tooling, tests, env files, and server-managed `logs/` + `cache/` contents off the wire.
- Composer runs on the runner (`composer install --no-dev --optimize-autoloader`) so production dependencies — including the `liturgical-calendar/components` PHP package — are baked into `vendor/` before rsync ships it.

## Triggers

| Event                                  | Target       |
|----------------------------------------|--------------|
| Push to `development`                  | staging      |
| Push to `main`                         | production   |
| `workflow_dispatch` (manual)           | staging *or* production (input) |

Concurrency groups are per-target so staging and production never serialize behind each other, and same-target deploys queue instead of cancelling mid-flight.

## Required configuration (per environment)

Create `staging` and `production` GitHub Environments and set:

- `vars.VPS_APP_PATH` — absolute deploy dir on the VPS (e.g. `/var/www/litcal-staging`, `/var/www/litcal`)
- `vars.VPS_APP_URL` — base URL for the post-deploy health check (e.g. `https://litcal-staging.johnromanodorazio.com`, `https://litcal.johnromanodorazio.com`)

Reused from the API's setup (repo-level):

- `secrets.VPS_SSH_PRIVATE_KEY`, `secrets.VPS_SSH_KNOWN_HOSTS`, `secrets.VPS_USERNAME`, `secrets.VPS_HOST`
- `vars.VPS_SSH_PORT` (optional, defaults to `22`)

**Recommended:** mark the `production` environment as protected with required reviewers so a push to `main` waits for explicit approval before deploying.

## Frontend vs. API workflow differences

- No subdir versioning (`vN/`, `dev/`) — each environment targets its own absolute path
- No `_ops/migrate` step — frontend has no DB migrations
- Health check is a plain `GET ${VPS_APP_URL}/` (site root)
- No release-trigger / version-tag plumbing

## JS components note

`layout/footer.php:104-107` already gates the `./assets/components-js/` symlink behind `APP_ENV === 'development'` and falls back to the jsDelivr CDN otherwise, so excluding `/assets/components-js` from rsync (as this PR does) is safe. Ensure `.env.staging` and `.env.production` on the VPS have `APP_ENV` set to a non-`development` value.

## Test plan

- [x] Create `staging` + `production` environments in repo settings with `VPS_APP_PATH` + `VPS_APP_URL`
- [x] On the VPS, place `.env.staging` / `.env.production` (with `APP_ENV` ≠ `development`) at each `VPS_APP_PATH`
- [ ] Trigger via `workflow_dispatch → staging` and verify: composer pulls `liturgical-calendar/components` into `vendor/`, rsync transfers it, `/cache` + `/logs` are created, health check returns 2xx
- [ ] Verify `.env.staging`, `.env.production`, `logs/`, and `cache/*` survive a redeploy (rsync `--delete` does not wipe them)
- [ ] Browser smoke test on staging URL: importmap resolves to jsDelivr CDN, pages render
- [ ] Repeat via `workflow_dispatch → production` once staging is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated deployment pipeline for staging and production environments with validation checks and health monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarFrontend/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->