### PR TITLE
fix(auth): scope OIDC login/registration to ZITADEL_ORG_ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# dotenv-linter:off UnorderedKey
+# ^ Intentional: keys in this file are grouped by purpose and ordered
+# by operational importance (REQUIRED blocks first, optional ones
+# after), NOT alphabetically. Suppresses dotenv-linter's UnorderedKey
+# rule (and CodeRabbit's surfacing of it) for the whole file.
+
 ##
 # Copy to .env.local (dev), .env.staging (staging), or .env.production
 # (prod) depending on your deployment.

--- a/.env.example
+++ b/.env.example
@@ -101,10 +101,20 @@ TEST_PASSWORD=testpassword
 # Without ZITADEL_ISSUER + ZITADEL_CLIENT_ID, /auth/login.php returns
 # HTTP 503: {"error":"OIDC not configured"}
 # ZITADEL_PROJECT_ID is optional — used for RBAC project-role lookups.
+#
+# ZITADEL_ORG_ID is STRONGLY RECOMMENDED in shared Zitadel instances.
+# When set, OidcClient appends the `urn:zitadel:iam:org:id:<id>` scope
+# to every authorization request, forcing both login AND new-user
+# registration into that specific org. Without it, the hosted login
+# lands new passkey/email registrations in Zitadel's IAM-internal
+# default org, which carries no project roles — the user appears
+# "registered" but has no RBAC permissions and is invisible to
+# org-scoped admin APIs.
 ##
 ZITADEL_ISSUER=http://localhost:8080
 ZITADEL_CLIENT_ID=your-frontend-client-id
 # ZITADEL_PROJECT_ID=your-project-id
+# ZITADEL_ORG_ID=your-zitadel-org-id
 
 ##
 # Docker Compose Port Configuration

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,12 @@ parameters:
         - about.php
         - admin-applications.php
         - admin-dashboard.php
-        - admin-role-requests.php
+        # admin-role-requests.php intentionally omitted: it's a legacy redirect
+        # stub (header()+exit on line 11) followed by ~260 lines of dead doc
+        # code preserved as historical reference. Analyzing it just produces
+        # noise — phpstan flags everything after the exit as unreachable, and
+        # since the dead code reaches no bootstrap-variable references, the
+        # corresponding ignoreErrors entry below also stays unmatched.
         - admin-users.php
         - developer-dashboard.php
         - missals-editor.php
@@ -37,7 +42,6 @@ parameters:
                 - about.php
                 - admin-applications.php
                 - admin-dashboard.php
-                - admin-role-requests.php
                 - admin-users.php
                 - developer-dashboard.php
                 - missals-editor.php

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -86,7 +86,36 @@ class OidcClient
         $this->clientId    = $clientId;
         $this->redirectUri = $redirectUri;
         $this->internalUrl = $internalUrl !== null ? rtrim($internalUrl, '/') : null;
-        $this->orgId       = $orgId !== null && $orgId !== '' ? $orgId : null;
+        $this->orgId       = self::normalizeOrgId($orgId);
+    }
+
+    /**
+     * Normalize and validate a Zitadel org ID.
+     *
+     * Trims whitespace (env values commonly arrive with stray padding from
+     * copy-paste), treats empty input as "not set", and rejects anything
+     * non-numeric — Zitadel IDs are snowflake-style 18-digit decimal
+     * strings, so a non-digit value can only be a misconfiguration and
+     * would silently produce a malformed `urn:zitadel:iam:org:id:<id>`
+     * scope that Zitadel rejects with a less helpful error.
+     *
+     * @throws \InvalidArgumentException If $orgId is non-empty but not all digits.
+     */
+    private static function normalizeOrgId(?string $orgId): ?string
+    {
+        if ($orgId === null) {
+            return null;
+        }
+        $trimmed = trim($orgId);
+        if ($trimmed === '') {
+            return null;
+        }
+        if (!ctype_digit($trimmed)) {
+            throw new \InvalidArgumentException(
+                'ZITADEL_ORG_ID must be a numeric Zitadel ID (snowflake), got: ' . $orgId
+            );
+        }
+        return $trimmed;
     }
 
     /**

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -35,6 +35,16 @@ class OidcClient
     private ?string $internalUrl;
 
     /**
+     * Zitadel organization ID to scope login and registration to.
+     * When set, the `urn:zitadel:iam:org:id:<id>` scope is appended to every
+     * authorization request, forcing both login AND new-user registration
+     * into that specific org. Without it, Zitadel's hosted login lands new
+     * passkey registrations in the IAM-internal default org, which won't
+     * carry the project's RBAC roles.
+     */
+    private ?string $orgId;
+
+    /**
      * Cached discovery document.
      *
      * @var array<string, mixed>|null
@@ -62,13 +72,21 @@ class OidcClient
      * @param string $issuer Zitadel issuer URL
      * @param string $clientId Zitadel client ID
      * @param string $redirectUri Callback URL for code exchange
+     * @param string|null $internalUrl Internal URL for server-side requests
+     * @param string|null $orgId Zitadel org ID to scope login/registration to
      */
-    public function __construct(string $issuer, string $clientId, string $redirectUri, ?string $internalUrl = null)
-    {
+    public function __construct(
+        string $issuer,
+        string $clientId,
+        string $redirectUri,
+        ?string $internalUrl = null,
+        ?string $orgId = null
+    ) {
         $this->issuer      = rtrim($issuer, '/');
         $this->clientId    = $clientId;
         $this->redirectUri = $redirectUri;
         $this->internalUrl = $internalUrl !== null ? rtrim($internalUrl, '/') : null;
+        $this->orgId       = $orgId !== null && $orgId !== '' ? $orgId : null;
     }
 
     /**
@@ -100,8 +118,9 @@ class OidcClient
         }
 
         $internalUrl = $_ENV['ZITADEL_INTERNAL_URL'] ?? getenv('ZITADEL_INTERNAL_URL') ?: null;
+        $orgId       = $_ENV['ZITADEL_ORG_ID'] ?? getenv('ZITADEL_ORG_ID') ?: null;
 
-        return new self($issuer, $clientId, $redirectUri, $internalUrl ?: null);
+        return new self($issuer, $clientId, $redirectUri, $internalUrl ?: null, $orgId ?: null);
     }
 
     /**
@@ -154,7 +173,15 @@ class OidcClient
             'offline_access',
             'urn:zitadel:iam:org:project:roles',
         ];
-        $allScopes     = array_unique(array_merge($defaultScopes, $scopes));
+
+        // Scope login/registration to a specific Zitadel org when configured.
+        // Without this, Zitadel's hosted login lands new passkey registrations
+        // in the IAM-internal default org, which carries no project roles.
+        if ($this->orgId !== null) {
+            $defaultScopes[] = 'urn:zitadel:iam:org:id:' . $this->orgId;
+        }
+
+        $allScopes = array_unique(array_merge($defaultScopes, $scopes));
 
         // Build authorization URL
         $authEndpoint = $this->getAuthorizationEndpoint();


### PR DESCRIPTION
## Problem

A test signup to `litcal-staging.johnromanodorazio.com` produced a user that:

1. Landed in Zitadel's **IAM-internal default org** instead of the **LiturgicalCalendar org**.
2. Carried zero project roles → invisible to the app's RBAC + org-scoped admin APIs.
3. Got no confirmation email — because passkey-only registration in Zitadel doesn't trigger email verification by default.

Diagnosis from another agent confirmed the root cause: `OidcClient::getAuthorizationUrl()` builds a fixed scope list with no org context, so Zitadel's hosted login defaults the registration org to its internal one.

The orphan user has been deleted out-of-band; this PR fixes the code path that produced it.

## Fix

`OidcClient` learns a new optional `ZITADEL_ORG_ID` env var. When set:

```php
$defaultScopes[] = 'urn:zitadel:iam:org:id:' . $this->orgId;
```

This Zitadel-specific scope forces **both login AND new-user registration** into the named org. Login from outside the org is rejected; registrations land in the org with the project's role bindings already attached.

## Backward compatibility

- `__construct` gains a fifth optional parameter (`?string $orgId = null`); all six existing `OidcClient::fromEnv()` callers (`auth/{login,callback,logout,me,refresh}.php`, `AuthHelper`) work unchanged.
- When `ZITADEL_ORG_ID` is unset, the scope is not added → identical behavior to today. Local dev against a single-org Zitadel container keeps working.

## Server state

`/var/www/.../LiturgicalCalendar-staging/.env.staging` already has `ZITADEL_ORG_ID=373246703018442755` (set ahead of this PR), so the auto-deploy that fires on merge will immediately honor it. The frontend's `.env.production` doesn't yet have the var — to be added when auth features land on prod.

## Test plan

- [x] PHP syntax (`composer parallel-lint`) — passes
- [x] PHP code style (`composer lint`) — passes after lint:fix bumped one equals-alignment
- [x] PHPStan errors unchanged from `development` baseline (12 pre-existing errors, all in untouched lines: Firebase\JWT class visibility + a stale ignore pattern)
- [ ] After merge: re-register as a new user on staging, verify via Zitadel API that the new user lands in the correct org

## Related

- Orphan user deleted via Zitadel management API (HTTP 200, re-query confirms 0 matches)
- Per other agent's analysis: SMTP path is healthy (`/admin/v1/smtp/_test` proved deliverability); no email was sent because Zitadel doesn't queue one for passkey-only signups. Behavior unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization scoping for Zitadel authentication: a new config option enables scoping login and new-user registration to a specific organization, affecting role and project visibility.
* **Documentation**
  * Example environment config updated to show the new organization-scoping option and explain its effects.
* **Chores**
  * Static analysis configuration adjusted to exclude a legacy path that produced noise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarFrontend/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->