### PR TITLE
feat(docker): align stack with API #604 — auto-apply Doctrine migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   # ============================================================================
   db-init:
     image: litcal-api:latest
-    build: https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI.git#feat/openfga
+    build: https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI.git#development
     entrypoint: ["cp", "/var/www/html/scripts/init-db.sql", "/init/init-litcal.sql"]
     volumes:
       - db_init_scripts:/init
@@ -251,9 +251,35 @@ services:
   # ============================================================================
   # LiturgicalCalendar Application Services
   # ============================================================================
+  # One-shot Doctrine migrate runner for the litcal database.
+  # scripts/init-db.sql (run by db-init/db) is bootstrap-only — roles,
+  # databases, pgcrypto, empty doctrine_migration_versions tracking table.
+  # Application-table DDL (access_requests, applications, api_keys,
+  # audit_log, ...) lives in src/Migrations/ in the API repo and is
+  # applied by this service against the running db.
+  #
+  # Reuses the already-built litcal-api:latest image (same pattern as
+  # openfga-setup above). litcal-api gates on this completing so the
+  # HTTP server never serves traffic against an unmigrated schema.
+  litcal-migrate:
+    image: litcal-api:latest
+    command: ["php", "bin/doctrine-migrations", "migrate", "--no-interaction"]
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: litcal
+      DB_USER: litcal
+      DB_PASSWORD: litcal_secure_password
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - litcal
+    restart: "no"
+
   litcal-api:
     image: litcal-api:latest
-    build: https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI.git#feat/openfga
+    build: https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI.git#development
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8000/calendars > /dev/null"]
@@ -298,6 +324,8 @@ services:
       openfga:
         condition: service_healthy
       openfga-setup:
+        condition: service_completed_successfully
+      litcal-migrate:
         condition: service_completed_successfully
 
   litcal-frontend:


### PR DESCRIPTION
## Summary

- Adds a `litcal-migrate` one-shot service to `docker-compose.yml` that runs `php bin/doctrine-migrations migrate --no-interaction` against the litcal db before `litcal-api` accepts traffic. Symmetric with how `openfga` already gates on `openfga-migrate`.
- Wires `litcal-api.depends_on` to wait for `litcal-migrate: service_completed_successfully`, so the HTTP server never starts serving against an unmigrated schema.
- Bumps the `db-init` and `litcal-api` build refs from `feat/openfga` → `development`. The `feat/openfga` branch has been merged.

Mirrors [API PR #604](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/604) in the frontend stack so a fresh `docker compose up -d` here doesn't reproduce the foot-gun that #604 closes on the API side (API container up, but `relation "api_keys" does not exist` 500s until the human runs `composer db:migrate`).

The new service reuses `image: litcal-api:latest` with no own `build:` directive — same pattern as `openfga-setup` (line 241). This keeps `docker-compose.override.yml` untouched: the local override's redirect of `litcal-api.build` to `../LiturgicalCalendarAPI` produces the same image tag that `litcal-migrate` then consumes.

## :warning: Blocked on API #604

The new `litcal-migrate` service invokes `php bin/doctrine-migrations`, which requires `bin/` and `doctrine-migrations.php` to be **inside** the `litcal-api:latest` image. Those files only land in the image after API PR #604 merges to `development` — that PR adds the `Dockerfile` `COPY ./bin ./bin` + `COPY ./doctrine-migrations.php ./` lines plus the matching `.dockerignore` whitelist (`!bin`, `!doctrine-migrations.php`).

- **Locally** (with `docker-compose.override.yml` pointing at `../LiturgicalCalendarAPI` checked out on the PR #604 branch): works today.
- **Non-override consumers** (CI, fresh clones, anyone using the documented `git#...` build ref): broken until API #604 merges to `development`.

Do not merge this PR until API #604 is in.

## Test plan

- [x] `docker compose config --quiet` — schema valid
- [ ] After API #604 merges to `development`: wipe `postgres_data` volume → `docker compose up -d --build` → `docker compose logs litcal-migrate` shows `[notice] Migrated.` and `litcal-api` becomes healthy without a manual host-side `composer db:migrate`
- [ ] Subsequent `docker compose up -d --build` (no new migrations) — `litcal-migrate` is a no-op (`No migrations to execute`), `litcal-api` comes back healthy
- [ ] Verify `litcal-frontend` and `litcal-tests` start cleanly once `litcal-api` is healthy (transitive `depends_on` chain through litcal-migrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application startup process with improved database initialization to ensure migrations execute successfully before the application becomes operational.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarFrontend/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->