### PR TITLE
feat(notifications): show bell to all authenticated users (#304)

### DIFF
--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -1,32 +1,34 @@
 /**
- * Admin Notifications Module
+ * Notifications Module
  *
- * Handles fetching and displaying admin notifications in the navbar.
- * Only active for users with the 'admin' role.
+ * Renders the navbar notification bell.
+ *
+ * Two modes, decided at init() based on Auth.hasRole('admin'):
+ *   - admin: polls /admin/notifications, shows pending review queue
+ *           (role_request | access_request | application items).
+ *           Badge = data.total (pending count).
+ *   - user:  polls /auth/notifications, shows reviewed-access events
+ *           (access_request_reviewed items). Badge = data.unread_count.
+ *           POSTs /auth/notifications/seen when dropdown opens, to clear
+ *           the unread badge.
  *
  * @module Notifications
  */
 const Notifications = {
-    /**
-     * Polling interval in milliseconds (5 minutes)
-     * @private
-     */
     _pollInterval: 5 * 60 * 1000,
-
-    /**
-     * Interval ID for polling
-     * @private
-     */
     _intervalId: null,
-
-    /**
-     * Cached notification data
-     * @private
-     */
     _cachedData: null,
 
     /**
-     * Role display names
+     * 'admin' | 'user' — fixed at init(). Drives endpoint, badge field,
+     * render branch, and whether to POST /seen on dropdown open.
+     * @private
+     */
+    _mode: null,
+
+    /**
+     * Role display names for admin-mode rendering. Also reused for
+     * user-mode rendering of requested_role labels.
      * @private
      */
     _roleNames: {
@@ -35,46 +37,27 @@ const Notifications = {
         'test_editor': 'Accuracy Test Editor'
     },
 
-    /**
-     * Flag to prevent double initialization
-     * @private
-     */
     _initialized: false,
 
     /**
-     * Initialize as admin (skip Auth.hasRole check)
-     * Used when PHP has already verified admin status
-     * @private
-     */
-    _initAsAdmin() {
-        if (this._initialized) {
-            return;
-        }
-        this._initialized = true;
-        console.log('Notifications: Initializing (admin verified by PHP)');
-        this._startNotificationServices();
-    },
-
-    /**
-     * Initialize notifications module
-     * Call this after Auth has initialized
+     * Initialize the notification bell for the current authenticated user.
+     * Caller is responsible for ensuring Auth is ready and the user is
+     * authenticated; this method picks the mode based on Auth.hasRole('admin').
      */
     init() {
-        // Prevent double initialization
         if (this._initialized) {
             return;
         }
-
-        // Only initialize for admin users
-        if (!Auth.hasRole('admin')) {
-            console.log('Notifications: User is not admin, skipping initialization');
+        if (typeof Auth === 'undefined' || !Auth.isAuthenticated()) {
             return;
         }
 
+        this._mode = Auth.hasRole('admin') ? 'admin' : 'user';
         this._initialized = true;
-        console.log('Notifications: Initializing for admin user');
+        console.log(`Notifications: Initializing in ${this._mode} mode`);
 
-        // Show the notifications container
+        // Container should already be visible from PHP for any authenticated
+        // user, but force it here in case auth state changed after page load.
         const container = document.getElementById('notificationsContainer');
         if (container) {
             container.classList.remove('d-none');
@@ -83,44 +66,30 @@ const Notifications = {
         this._startNotificationServices();
     },
 
-    /**
-     * Start notification fetching and polling services
-     * @private
-     */
     _startNotificationServices() {
-        // Fetch notifications immediately
         this.fetchNotifications();
-
-        // Start polling
         this.startPolling();
 
-        // Refresh on dropdown open (use Bootstrap 5 event)
         const dropdownEl = document.getElementById('notificationsDropdown');
         if (dropdownEl) {
             dropdownEl.addEventListener('shown.bs.dropdown', () => {
                 this.fetchNotifications();
+                if (this._mode === 'user') {
+                    this.markSeen();
+                }
             });
         }
     },
 
-    /**
-     * Start polling for new notifications
-     */
     startPolling() {
         if (this._intervalId !== null) {
             return;
         }
-
         this._intervalId = setInterval(() => {
-            if (Auth.hasRole('admin')) {
-                this.fetchNotifications();
-            }
+            this.fetchNotifications();
         }, this._pollInterval);
     },
 
-    /**
-     * Stop polling
-     */
     stopPolling() {
         if (this._intervalId !== null) {
             clearInterval(this._intervalId);
@@ -128,31 +97,28 @@ const Notifications = {
         }
     },
 
-    /**
-     * Fetch notifications from the API
-     */
     async fetchNotifications() {
-        console.log('Notifications: Fetching notifications...');
-
         if (typeof BaseUrl === 'undefined' || !BaseUrl) {
             console.error('Notifications: BaseUrl is not defined');
             this.showEmpty();
             return;
         }
+        if (this._mode === null) {
+            return;
+        }
+
+        const endpoint = this._mode === 'admin'
+            ? `${BaseUrl}/admin/notifications`
+            : `${BaseUrl}/auth/notifications`;
 
         try {
-            const response = await fetch(`${BaseUrl}/admin/notifications`, {
+            const response = await fetch(endpoint, {
                 method: 'GET',
                 credentials: 'include',
-                headers: {
-                    'Accept': 'application/json'
-                }
+                headers: { 'Accept': 'application/json' }
             });
 
-            console.log('Notifications: Response status:', response.status);
-
             if (!response.ok) {
-                // Try to get error details but don't fail if we can't
                 let errorText = '';
                 try {
                     errorText = await response.text();
@@ -165,29 +131,51 @@ const Notifications = {
             }
 
             const data = await response.json();
-            console.log('Notifications: Received data:', data);
             this._cachedData = data;
             this.updateUI(data);
         } catch (error) {
             console.error('Failed to fetch notifications:', error);
-            // Show empty state instead of error for better UX
             this.showEmpty();
         }
     },
 
     /**
-     * Update the UI with notification data
-     * @param {Object} data - Notification data from API
+     * Mark the user's inbox as seen. User mode only; fire-and-forget — a
+     * failure is reconciled by the next poll.
      */
+    async markSeen() {
+        if (this._mode !== 'user' || typeof BaseUrl === 'undefined' || !BaseUrl) {
+            return;
+        }
+        try {
+            const response = await fetch(`${BaseUrl}/auth/notifications/seen`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                },
+                body: '{}'
+            });
+            if (!response.ok) {
+                console.warn('Notifications: mark-seen failed', response.status);
+                return;
+            }
+            // Optimistically clear the badge; next poll confirms.
+            this.updateBadge(0);
+        } catch (error) {
+            console.warn('Notifications: mark-seen network error', error);
+        }
+    },
+
     updateUI(data) {
-        this.updateBadge(data.total || 0);
+        const count = this._mode === 'user'
+            ? (data.unread_count || 0)
+            : (data.total || 0);
+        this.updateBadge(count);
         this.updateList(data.items || []);
     },
 
-    /**
-     * Update the notification badge count
-     * @param {number} count - Total notification count
-     */
     updateBadge(count) {
         const badge = document.getElementById('notificationsBadge');
         if (!badge) return;
@@ -200,10 +188,6 @@ const Notifications = {
         }
     },
 
-    /**
-     * Update the notifications list dropdown
-     * @param {Array} items - Array of notification items
-     */
     updateList(items) {
         const list = document.getElementById('notificationsList');
         if (!list) return;
@@ -225,13 +209,11 @@ const Notifications = {
         list.innerHTML = html;
     },
 
-    /**
-     * Render a single notification item
-     * @param {Object} item - Notification item
-     * @returns {string} HTML string
-     * @private
-     */
     _renderNotificationItem(item) {
+        if (item.type === 'access_request_reviewed') {
+            return this._renderReviewedRequest(item);
+        }
+
         const timeAgo = this._formatTimeAgo(item.created_at);
         const safeUrl = this._sanitizeUrl(item.url);
 
@@ -311,9 +293,55 @@ const Notifications = {
     },
 
     /**
-     * Show empty state in the dropdown (no pending notifications)
+     * Render a user-mode `access_request_reviewed` notification.
+     * @param {Object} item - { type, request_id, requested_role, status,
+     *   review_notes, reviewed_at, permissions, unread }
+     * @returns {string} HTML string
      * @private
      */
+    _renderReviewedRequest(item) {
+        const statusVisuals = {
+            approved: {
+                icon: 'fas fa-check-circle text-success',
+                label: this._getTranslation('yourRequestApproved', 'Your request was approved')
+            },
+            rejected: {
+                icon: 'fas fa-times-circle text-danger',
+                label: this._getTranslation('yourRequestRejected', 'Your request was rejected')
+            },
+            revoked: {
+                icon: 'fas fa-ban text-warning',
+                label: this._getTranslation('yourRequestRevoked', 'Your access was revoked')
+            }
+        };
+        const visuals = statusVisuals[item.status] || statusVisuals.approved;
+
+        const timeAgo = this._formatTimeAgo(item.reviewed_at);
+        const requestId = String(item.request_id || '');
+        const safeUrl = this._sanitizeUrl(`permission-requests.php#request-${encodeURIComponent(requestId)}`);
+        const roleName = this._escapeHtml(this._roleNames[item.requested_role] || item.requested_role || '');
+        const reviewNotesHtml = item.review_notes
+            ? `<div class="small fst-italic text-muted">${this._escapeHtml(item.review_notes)}</div>`
+            : '';
+        const unreadClass = item.unread ? ' bg-light fw-semibold' : '';
+
+        return `
+            <a class="dropdown-item py-2${unreadClass}" href="${safeUrl}">
+                <div class="d-flex align-items-start">
+                    <div class="flex-shrink-0">
+                        <i class="${visuals.icon} me-2"></i>
+                    </div>
+                    <div class="flex-grow-1">
+                        <div class="small fw-bold">${this._escapeHtml(visuals.label)}</div>
+                        <div class="small text-muted">${roleName}</div>
+                        ${reviewNotesHtml}
+                        <div class="small text-muted">${timeAgo}</div>
+                    </div>
+                </div>
+            </a>
+        `;
+    },
+
     showEmpty() {
         const list = document.getElementById('notificationsList');
         if (!list) return;
@@ -326,10 +354,6 @@ const Notifications = {
         `;
     },
 
-    /**
-     * Show error state in the dropdown
-     * @private
-     */
     showError() {
         const list = document.getElementById('notificationsList');
         if (!list) return;
@@ -342,12 +366,6 @@ const Notifications = {
         `;
     },
 
-    /**
-     * Format a timestamp as relative time
-     * @param {string} timestamp - ISO timestamp
-     * @returns {string} Relative time string
-     * @private
-     */
     _formatTimeAgo(timestamp) {
         if (!timestamp) return '';
 
@@ -377,15 +395,7 @@ const Notifications = {
         }
     },
 
-    /**
-     * Get translation string (with fallback)
-     * @param {string} key - Translation key
-     * @param {string} fallback - Fallback string
-     * @returns {string} Translated string or fallback
-     * @private
-     */
     _getTranslation(key, fallback) {
-        // Check if translations object exists (set via PHP)
         if (typeof NotificationTranslations !== 'undefined' && NotificationTranslations[key]) {
             return NotificationTranslations[key];
         }
@@ -393,10 +403,8 @@ const Notifications = {
     },
 
     /**
-     * Sanitize URL to prevent XSS via javascript:, data:, vbscript: schemes
-     * Only allows http, https, protocol-relative (//), and relative paths
-     * @param {string} url - URL to sanitize
-     * @returns {string} Sanitized URL safe for href attribute
+     * Sanitize URL to prevent XSS via javascript:, data:, vbscript: schemes.
+     * Only allows http, https, protocol-relative (//), and relative paths.
      * @private
      */
     _sanitizeUrl(url) {
@@ -404,10 +412,7 @@ const Notifications = {
             return '#';
         }
 
-        // Trim and normalize
         const trimmed = url.trim();
-
-        // Block dangerous schemes (case-insensitive, ignore whitespace)
         const normalized = trimmed.toLowerCase().replace(/\s+/g, '');
         const dangerousSchemes = ['javascript:', 'data:', 'vbscript:'];
         for (const scheme of dangerousSchemes) {
@@ -416,7 +421,6 @@ const Notifications = {
             }
         }
 
-        // Allow only safe schemes: http://, https://, protocol-relative (//), or relative paths
         const isAbsolute = /^https?:\/\//i.test(trimmed);
         const isProtocolRelative = trimmed.startsWith('//');
         const isRelative = trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../') || !trimmed.includes(':');
@@ -425,16 +429,9 @@ const Notifications = {
             return '#';
         }
 
-        // HTML-escape the URL to prevent attribute injection
         return this._escapeHtml(trimmed);
     },
 
-    /**
-     * Escape HTML entities
-     * @param {string} text - Text to escape
-     * @returns {string} Escaped text
-     * @private
-     */
     _escapeHtml(text) {
         if (!text) return '';
         const div = document.createElement('div');
@@ -443,33 +440,17 @@ const Notifications = {
     }
 };
 
-// Clean up polling on page unload
 window.addEventListener('beforeunload', () => {
     Notifications.stopPolling();
 });
 
-// Initialize after Auth is ready
 document.addEventListener('DOMContentLoaded', () => {
-    // Check if notifications container exists and is visible (PHP determined user is admin)
-    const container = document.getElementById('notificationsContainer');
-    const isVisibleFromPhp = container && !container.classList.contains('d-none');
-
-    // If PHP already determined user is admin, initialize immediately
-    if (isVisibleFromPhp) {
-        console.log('Notifications: Container visible from PHP, initializing...');
-        // Force initialization since PHP already verified admin status
-        Notifications._initialized = false; // Reset in case of reload
-        Notifications._initAsAdmin();
-        return;
-    }
-
-    // Otherwise, wait for Auth to initialize and check auth state
-    // Use exponential backoff retry to handle variable Auth initialization times
+    // PHP marks the bell visible for any authenticated user, but we still
+    // need Auth to be ready before we know admin-vs-user. Retry with
+    // exponential backoff to absorb variable Auth init timing.
     const waitForAuth = (retries = 5, delay = 100) => {
         if (typeof Auth !== 'undefined' && Auth.isAuthenticated()) {
-            if (Auth.hasRole('admin')) {
-                Notifications.init();
-            }
+            Notifications.init();
         } else if (retries > 0) {
             setTimeout(() => waitForAuth(retries - 1, delay * 2), delay);
         }
@@ -477,12 +458,12 @@ document.addEventListener('DOMContentLoaded', () => {
     waitForAuth();
 });
 
-// Also listen for auth state changes (if user logs in after page load)
 document.addEventListener('authStateChange', (event) => {
-    if (event.detail && event.detail.authenticated && Auth.hasRole('admin')) {
+    if (event.detail && event.detail.authenticated) {
         Notifications.init();
     } else {
         Notifications.stopPolling();
-        Notifications._initialized = false; // Allow re-initialization on next admin login
+        Notifications._initialized = false;
+        Notifications._mode = null;
     }
 });

--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -196,7 +196,7 @@ const Notifications = {
             list.innerHTML = `
                 <div class="dropdown-item text-muted text-center py-3">
                     <i class="fas fa-check-circle me-2 text-success"></i>
-                    ${this._getTranslation('noNotifications', 'No pending requests')}
+                    ${this._emptyText()}
                 </div>
             `;
             return;
@@ -207,6 +207,17 @@ const Notifications = {
             html += this._renderNotificationItem(item);
         }
         list.innerHTML = html;
+    },
+
+    /**
+     * Empty-state text, mode-aware: admin sees the pending-queue framing,
+     * user sees an inbox framing.
+     * @private
+     */
+    _emptyText() {
+        return this._mode === 'user'
+            ? this._getTranslation('noNotificationsUser', 'No new notifications')
+            : this._getTranslation('noNotifications', 'No pending requests');
     },
 
     _renderNotificationItem(item) {
@@ -314,7 +325,11 @@ const Notifications = {
                 label: this._getTranslation('yourRequestRevoked', 'Your access was revoked')
             }
         };
-        const visuals = statusVisuals[item.status] || statusVisuals.approved;
+        let visuals = statusVisuals[item.status];
+        if (!visuals) {
+            console.warn(`Notifications: unknown status "${item.status}" for request ${item.request_id}; falling back to approved styling`);
+            visuals = statusVisuals.approved;
+        }
 
         const timeAgo = this._formatTimeAgo(item.reviewed_at);
         const requestId = String(item.request_id || '');
@@ -349,7 +364,7 @@ const Notifications = {
         list.innerHTML = `
             <div class="dropdown-item text-muted text-center py-3">
                 <i class="fas fa-check-circle me-2 text-success"></i>
-                ${this._getTranslation('noNotifications', 'No pending requests')}
+                ${this._emptyText()}
             </div>
         `;
     },

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -395,8 +395,9 @@ document.addEventListener('DOMContentLoaded', async function() {
                 `;
             }
 
+            const safeRequestId = escapeHtml(String(request.id));
             html += `
-                <tr>
+                <tr id="request-${safeRequestId}">
                     <td><span class="badge bg-info">${escapeHtml(roleName)}</span></td>
                     <td>${summarizePermissions(request.permissions)}</td>
                     <td>
@@ -420,6 +421,26 @@ document.addEventListener('DOMContentLoaded', async function() {
                 openResubmitForm(this.dataset.requestId, requests);
             });
         });
+
+        scrollToAnchoredRequest();
+    }
+
+    /**
+     * If the page was loaded with `#request-<uuid>` (e.g. from a
+     * notification click-through), scroll the matching row into view and
+     * briefly highlight it. No-op if the anchor doesn't match a rendered
+     * row.
+     */
+    function scrollToAnchoredRequest() {
+        const hash = window.location.hash;
+        if (!hash.startsWith('#request-')) return;
+
+        const target = document.getElementById(hash.slice(1));
+        if (!target) return;
+
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        target.classList.add('table-warning');
+        setTimeout(() => target.classList.remove('table-warning'), 2500);
     }
 
     // Track resubmit state

--- a/layout/footer.php
+++ b/layout/footer.php
@@ -90,6 +90,7 @@ if ( AppEnv === 'development' ) console.info({
 <script>
 const NotificationTranslations = {
     noNotifications: <?php echo json_encode(_('No pending requests')); ?>,
+    noNotificationsUser: <?php echo json_encode(_('No new notifications')); ?>,
     loadError: <?php echo json_encode(_('Could not load notifications')); ?>,
     justNow: <?php echo json_encode(_('Just now')); ?>,
     minutesAgo: <?php echo json_encode(_('min ago')); ?>,

--- a/layout/footer.php
+++ b/layout/footer.php
@@ -96,7 +96,10 @@ const NotificationTranslations = {
     hoursAgo: <?php echo json_encode(_('hours ago')); ?>,
     daysAgo: <?php echo json_encode(_('days ago')); ?>,
     requestedRole: <?php echo json_encode(_('Requested')); ?>,
-    requestedAccess: <?php echo json_encode(_('Requested access')); ?>
+    requestedAccess: <?php echo json_encode(_('Requested access')); ?>,
+    yourRequestApproved: <?php echo json_encode(_('Your request was approved')); ?>,
+    yourRequestRejected: <?php echo json_encode(_('Your request was rejected')); ?>,
+    yourRequestRevoked: <?php echo json_encode(_('Your access was revoked')); ?>
 };
 </script>
 <?php include_once('includes/login-modal.php'); ?>

--- a/layout/header.php
+++ b/layout/header.php
@@ -120,8 +120,9 @@ asort($langsAssoc);
                 </div>
             </li>
             <li class="vr mx-2 d-none d-lg-block"></li>
-            <!-- Notifications (Admin only) -->
-            <li class="nav-item dropdown<?php echo ( $authHelper->isAuthenticated && $authHelper->hasRole('admin') ) ? '' : ' d-none'; ?>" id="notificationsContainer" data-requires-role="admin">
+            <!-- Notifications: admin sees pending review queue; regular users see access-request status changes -->
+            <?php $viewAllRequestsUrl = $authHelper->hasRole('admin') ? 'admin-dashboard.php' : 'permission-requests.php'; ?>
+            <li class="nav-item dropdown<?php echo $authHelper->isAuthenticated ? '' : ' d-none'; ?>" id="notificationsContainer" data-requires-auth>
                 <a class="nav-link position-relative" href="#" id="notificationsDropdown" role="button"
                     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                     title="<?php echo htmlspecialchars(_('Notifications'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
@@ -140,7 +141,7 @@ asort($langsAssoc);
                         </div>
                     </div>
                     <div class="dropdown-divider"></div>
-                    <a class="dropdown-item text-center text-primary" href="admin-dashboard.php">
+                    <a class="dropdown-item text-center text-primary" href="<?php echo htmlspecialchars($viewAllRequestsUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
                         <small><?php echo htmlspecialchars(_('View all requests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></small>
                     </a>
                 </div>


### PR DESCRIPTION
## Summary

- Lifts the notifications bell out of admin-only territory: end users now get in-app feedback when an admin approves, rejects, or revokes their access requests.
- Single mode-aware `notifications.js` module — admin behavior unchanged, new user mode hits `/auth/notifications`, badges `unread_count`, marks inbox seen on dropdown open.
- Notification items click through to `permission-requests.php#request-{uuid}`; the page scrolls and briefly highlights the matching row.

Closes #304. Depends on [LiturgicalCalendarAPI#618](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/618) (already merged), which adds `GET /auth/notifications` + `POST /auth/notifications/seen`.

## Behavior matrix

| Mode | Endpoint | Badge field | Items shown | On dropdown open |
| --- | --- | --- | --- | --- |
| admin | `/admin/notifications` | `data.total` (pending count) | role_request, access_request, application | refetch only |
| user | `/auth/notifications` | `data.unread_count` | `access_request_reviewed` (approved / rejected / revoked) | refetch + `POST /seen` (fire-and-forget) |

## Files

- `layout/header.php` — drop `d-none`/`data-requires-role="admin"` gate; "View all requests" link picks `admin-dashboard.php` (admin) or `permission-requests.php` (user) server-side.
- `assets/js/notifications.js` — mode-aware refactor: `_mode` set in `init()` from `Auth.hasRole('admin')`; `fetchNotifications()` picks endpoint by mode; `updateUI()` picks badge field by mode; new `_renderReviewedRequest()` branch; new `markSeen()`; reset `_initialized` + `_mode` on auth-state change.
- `layout/footer.php` — three new translation keys (`yourRequestApproved`, `yourRequestRejected`, `yourRequestRevoked`). `reviewedBy` from the issue scope was intentionally dropped — API spec exposes no reviewer field and surfacing one would require Zitadel name lookups (standard in-app notifications don't name reviewers either).
- `assets/js/permission-requests.js` — each request row renders with `id="request-{uuid}"`; new `scrollToAnchoredRequest()` scrolls + briefly highlights the row matching `window.location.hash`.

## Test plan

- [x] PHP linters: `composer parallel-lint`, `composer lint` (phpcs)
- [x] PHP static analysis: `composer analyse` (PHPStan level 7)
- [x] JS syntax: `node --check assets/js/{notifications,permission-requests}.js`
- [x] JS lint: `yarn lint` (eslint)
- [x] **Anonymous:** bell hidden via `d-none`; `data-requires-role` attribute removed
- [x] **User mode (synthetic, patched `Auth`):** mode='user', endpoint `/auth/notifications`, badge uses `unread_count` (1) not `total` (3), all 3 status variants render with correct icon/color/label, unread item has `bg-light fw-semibold`, hrefs are `permission-requests.php#request-{uuid}`
- [x] **Admin regression (synthetic):** flipping `Auth.hasRole('admin')`→true switches endpoint to `/admin/notifications`
- [x] **POST `/seen` shape:** `Content-Type: application/json`, body `'{}'`, `credentials: 'include'`; CORS preflight OK
- [ ] **Full real-user round-trip** (create non-admin in Zitadel → submit access request → admin approves → user sees notification → click → land on highlighted row) — not run; synthetic tests cover everything except cookie-auth, which is the same `OidcAuthMiddleware` path as the working `/auth/access-requests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications feature extended to all authenticated users
  * Users now receive updates on access request approvals and rejections
  * Permission requests can be accessed via direct links with automatic scrolling

* **Enhancements**
  * "View all requests" link now routes to the appropriate dashboard based on user role
  * Added translated messages for request status lifecycle events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->