### PR TITLE
feat(notifications): synthetic onboarding-invite in user bell (#305)

### DIFF
--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -156,6 +156,7 @@ const Notifications = {
      * @private
      */
     async _fetchOnboardingStatus() {
+        const safeDefault = { needs_access_request: false };
         try {
             const response = await fetch(`${BaseUrl}/auth/access-requests/status`, {
                 method: 'GET',
@@ -163,12 +164,19 @@ const Notifications = {
                 headers: { 'Accept': 'application/json' }
             });
             if (!response.ok) {
-                return { needs_access_request: false };
+                return safeDefault;
             }
-            return await response.json();
+            const payload = await response.json();
+            if (payload === null
+                || typeof payload !== 'object'
+                || Array.isArray(payload)
+                || typeof payload.needs_access_request !== 'boolean') {
+                return safeDefault;
+            }
+            return payload;
         } catch (error) {
             console.warn('Notifications: onboarding status fetch failed', error);
-            return { needs_access_request: false };
+            return safeDefault;
         }
     },
 

--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -131,11 +131,44 @@ const Notifications = {
             }
 
             const data = await response.json();
+
+            if (this._mode === 'user') {
+                const status = await this._fetchOnboardingStatus();
+                if (status.needs_access_request) {
+                    data.items = [{ type: 'onboarding_invite' }, ...(data.items || [])];
+                    data.unread_count = (data.unread_count || 0) + 1;
+                }
+            }
+
             this._cachedData = data;
             this.updateUI(data);
         } catch (error) {
             console.error('Failed to fetch notifications:', error);
             this.showEmpty();
+        }
+    },
+
+    /**
+     * Fetch the user's access-request status to decide whether to surface
+     * the synthetic onboarding-invite entry. Fail-safe: on any error,
+     * return `{needs_access_request: false}` so the bell still renders
+     * real notifications without the synthetic item.
+     * @private
+     */
+    async _fetchOnboardingStatus() {
+        try {
+            const response = await fetch(`${BaseUrl}/auth/access-requests/status`, {
+                method: 'GET',
+                credentials: 'include',
+                headers: { 'Accept': 'application/json' }
+            });
+            if (!response.ok) {
+                return { needs_access_request: false };
+            }
+            return await response.json();
+        } catch (error) {
+            console.warn('Notifications: onboarding status fetch failed', error);
+            return { needs_access_request: false };
         }
     },
 
@@ -221,6 +254,9 @@ const Notifications = {
     },
 
     _renderNotificationItem(item) {
+        if (item.type === 'onboarding_invite') {
+            return this._renderOnboardingInvite();
+        }
         if (item.type === 'access_request_reviewed') {
             return this._renderReviewedRequest(item);
         }
@@ -351,6 +387,35 @@ const Notifications = {
                         <div class="small text-muted">${roleName}</div>
                         ${reviewNotesHtml}
                         <div class="small text-muted">${timeAgo}</div>
+                    </div>
+                </div>
+            </a>
+        `;
+    },
+
+
+    /**
+     * Render the synthetic onboarding-invite item shown when the user has
+     * no roles, no pending requests, and no approved-but-unsynced requests
+     * (server-derived `needs_access_request === true` from
+     * `/auth/access-requests/status`). The entry self-clears once the user
+     * submits a request — no mark-as-seen call.
+     * @returns {string} HTML string
+     * @private
+     */
+    _renderOnboardingInvite() {
+        const safeUrl = this._sanitizeUrl('permission-requests.php');
+        const label = this._escapeHtml(this._getTranslation('onboardingInvite', 'Request access to start using the system'));
+        const cta = this._escapeHtml(this._getTranslation('onboardingInviteCta', 'Get started'));
+        return `
+            <a class="dropdown-item py-2 bg-light fw-semibold" href="${safeUrl}">
+                <div class="d-flex align-items-start">
+                    <div class="flex-shrink-0">
+                        <i class="fas fa-user-plus text-info me-2"></i>
+                    </div>
+                    <div class="flex-grow-1">
+                        <div class="small fw-bold">${label}</div>
+                        <div class="small text-primary">${cta} &rarr;</div>
                     </div>
                 </div>
             </a>

--- a/layout/footer.php
+++ b/layout/footer.php
@@ -100,7 +100,9 @@ const NotificationTranslations = {
     requestedAccess: <?php echo json_encode(_('Requested access')); ?>,
     yourRequestApproved: <?php echo json_encode(_('Your request was approved')); ?>,
     yourRequestRejected: <?php echo json_encode(_('Your request was rejected')); ?>,
-    yourRequestRevoked: <?php echo json_encode(_('Your access was revoked')); ?>
+    yourRequestRevoked: <?php echo json_encode(_('Your access was revoked')); ?>,
+    onboardingInvite: <?php echo json_encode(_('Request access to start using the system')); ?>,
+    onboardingInviteCta: <?php echo json_encode(_('Get started')); ?>
 };
 </script>
 <?php include_once('includes/login-modal.php'); ?>


### PR DESCRIPTION
## Summary

- New users (verified email, no roles, no pending/approved requests) now see an onboarding prompt in the notification bell pointing them to the access-request flow.
- The synthetic entry is composed client-side from the API's existing server-derived `needs_access_request` flag on `GET /auth/access-requests/status` — it self-clears the moment the user submits a request.
- No read/unread tracking. Pure additive change to the user-mode rendering path (#304); admin mode untouched.

Closes #305. Follow-up to #304.

## Behavior

`fetchNotifications()` in user mode now calls `/auth/access-requests/status` after `/auth/notifications`. When `needs_access_request === true`:

- A `{type: 'onboarding_invite'}` item is **prepended** to `items[]`
- `unread_count` is incremented by 1 (so the bell badge alerts the user)
- The dropdown renders: `fa-user-plus` icon · "Request access to start using the system" · "Get started →" · link to `permission-requests.php`

Fail-safe: any error from the status endpoint defaults to `needs_access_request: false` — real notifications still render, just no synthetic prompt.

## Files

- `assets/js/notifications.js` — new `_fetchOnboardingStatus()`, composition logic in `fetchNotifications()` user branch, new `_renderOnboardingInvite()`, dispatch branch in `_renderNotificationItem()`.
- `layout/footer.php` — two new i18n keys: `onboardingInvite`, `onboardingInviteCta`.

## Test plan

- [x] PHP: `composer parallel-lint`, `composer lint`, `composer analyse`
- [x] JS: `node --check`, `yarn lint`
- [x] Browser (synthetic fetch interception, user mode):
  - [x] `needs=true` + 0 events → synthetic only, badge=1, correct icon/label/CTA/href
  - [x] `needs=false` + 0 events → no synthetic, badge hidden, "No new notifications"
  - [x] `needs=true` + 1 unread event → synthetic prepended, badge=2, real item below
  - [x] status endpoint errors → fail-safe, no synthetic, real events still render
- [ ] Live round-trip on a freshly-created Zitadel user — not run; the synthetic test covers the composition logic and the cookie-auth path is the same `OidcAuthMiddleware` already exercised by `/auth/notifications` and `/auth/access-requests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The notification system now automatically displays onboarding invite notifications when users are required to complete access requests.
  * New notification entries appear in the notification dropdown with localized labels, direct action links to permission request workflows, and automatic unread badge count updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->