### PR TITLE
fix(ci): PAT fallback so dependabot auto-merge can land workflow bumps

### DIFF
--- a/.github/pat-expiry.txt
+++ b/.github/pat-expiry.txt
@@ -1,0 +1,8 @@
+# Expiration date (YYYY-MM-DD) of the WORKFLOW_AUTO_MERGE_PAT org-level
+# secret. The .github/workflows/pat-expiry-reminder.yml workflow reads
+# this date weekly and opens an issue when <30 days remain.
+#
+# When you rotate the PAT, update this date in the same PR / commit so
+# the reminder issue auto-closes when the new file change merges (via
+# the workflow's stale-issue cleanup).
+2027-06-05

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,9 +18,16 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # GITHUB_TOKEN cannot modify .github/workflows/* files (hard GitHub
+      # restriction — not a permissions: block setting). For Dependabot PRs
+      # that bump action versions, auto-merge therefore fails with
+      # "Tried to create or update workflow without `workflows` permission".
+      # Fall back through a fine-grained PAT (repo-scoped, Workflows: write)
+      # stored as WORKFLOW_AUTO_MERGE_PAT. When the secret is absent the
+      # workflow still works for non-workflow PRs.
       - name: Auto-merge minor and patch updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pat-expiry-reminder.yml
+++ b/.github/workflows/pat-expiry-reminder.yml
@@ -1,0 +1,111 @@
+name: PAT expiration reminder
+
+# Reads .github/pat-expiry.txt weekly. If the WORKFLOW_AUTO_MERGE_PAT is
+# within THRESHOLD_DAYS of expiring, opens an issue (idempotent — does
+# not re-open while an issue for the same expiration date is still open).
+# Closes any stale open reminder whose title does not match the current
+# expiration date (so post-rotation the old issue auto-closes).
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check PAT expiration and reconcile reminder issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          THRESHOLD_DAYS: '30'
+          EXPIRY_FILE: '.github/pat-expiry.txt'
+          ISSUE_LABEL: 'pat-expiry-reminder'
+        run: |
+          set -euo pipefail
+
+          if [ ! -f "$EXPIRY_FILE" ]; then
+            echo "::error file=$EXPIRY_FILE::expiry file not found"
+            exit 1
+          fi
+
+          EXPIRY=$(grep -v '^[[:space:]]*#' "$EXPIRY_FILE" \
+                   | grep -v '^[[:space:]]*$' \
+                   | head -1 \
+                   | tr -d '[:space:]')
+
+          if ! date -u -d "$EXPIRY" >/dev/null 2>&1; then
+            echo "::error file=$EXPIRY_FILE::invalid date '$EXPIRY' — expected YYYY-MM-DD"
+            exit 1
+          fi
+
+          DAYS_LEFT=$(( ( $(date -u -d "$EXPIRY" +%s) - $(date -u +%s) ) / 86400 ))
+          CURRENT_TITLE="Rotate WORKFLOW_AUTO_MERGE_PAT — expires $EXPIRY"
+
+          echo "Expiry: $EXPIRY ($DAYS_LEFT days remaining)"
+          echo "Current expected issue title: $CURRENT_TITLE"
+
+          # Close any stale open reminders whose title doesn't match the
+          # current expiry (e.g. left over from before a rotation).
+          mapfile -t STALE < <(
+            gh issue list --label "$ISSUE_LABEL" --state open \
+              --json number,title \
+              --jq ".[] | select(.title != \"$CURRENT_TITLE\") | .number"
+          )
+          for NUM in "${STALE[@]}"; do
+            echo "Closing stale reminder issue #$NUM"
+            gh issue close "$NUM" \
+              --comment "Closing — pat-expiry.txt has been updated to a new expiration date."
+          done
+
+          if [ "$DAYS_LEFT" -gt "$THRESHOLD_DAYS" ]; then
+            echo "More than $THRESHOLD_DAYS days remaining; no reminder needed."
+            exit 0
+          fi
+
+          EXISTING=$(gh issue list --label "$ISSUE_LABEL" --state open \
+                     --json title \
+                     --jq "[.[] | select(.title == \"$CURRENT_TITLE\")] | length")
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Reminder issue already open."
+            exit 0
+          fi
+
+          # Body uses a heredoc to keep newlines clean; only the validated
+          # EXPIRY and DAYS_LEFT values are interpolated, both already
+          # date-validated above.
+          BODY=$(cat <<EOF
+          The fine-grained PAT \`WORKFLOW_AUTO_MERGE_PAT\` (org-level secret) expires on **$EXPIRY** — $DAYS_LEFT day(s) from now.
+
+          Without this PAT the Dependabot auto-merge workflow will silently fail to merge any PR that touches \`.github/workflows/*\` (e.g. action-version bumps), since GITHUB_TOKEN cannot modify workflow files.
+
+          ## To rotate
+
+          1. Create a new fine-grained PAT at <https://github.com/settings/personal-access-tokens/new>
+             - Resource owner: **Liturgical-Calendar**
+             - Repository access: **Only select repositories** → \`LiturgicalCalendarFrontend\`
+             - Repository permissions:
+               - **Contents**: Read and write
+               - **Pull requests**: Read and write
+               - **Workflows**: Read and write
+             - Pick a new expiry (max 1 year)
+          2. Replace the secret value at <https://github.com/organizations/Liturgical-Calendar/settings/secrets/actions/WORKFLOW_AUTO_MERGE_PAT>
+          3. Update \`.github/pat-expiry.txt\` with the new expiration date and commit
+          4. This issue will auto-close on the next workflow run after step 3 lands
+
+          (Reminder posted by \`.github/workflows/pat-expiry-reminder.yml\`.)
+          EOF
+          )
+
+          gh issue create \
+            --title "$CURRENT_TITLE" \
+            --label "$ISSUE_LABEL" \
+            --body "$BODY"


### PR DESCRIPTION
## Summary

PR #326 (actions/checkout 6.0.2 → 6.0.3) failed to auto-merge with `"Tried to create or update workflow without `workflows` permission"`. Diagnosed: `GITHUB_TOKEN` is hard-restricted from modifying `.github/workflows/*` files, regardless of `permissions:` block settings. This affects every Dependabot PR that touches a workflow file.

This PR adds a fallback through an optional repo secret `WORKFLOW_AUTO_MERGE_PAT`. When set, the auto-merge step uses it (PAT has `Workflows: write` scope, which `GITHUB_TOKEN` can't have). When absent, falls back to `GITHUB_TOKEN` — preserving existing behavior for non-workflow PRs.

PR #326 has already been manually merged (admin bypass).

## Setup required after merging this PR

1. **Create a fine-grained PAT** at <https://github.com/settings/personal-access-tokens/new>
   - Resource owner: **Liturgical-Calendar**
   - Repository access: **Only select repositories** → `LiturgicalCalendarFrontend`
   - Repository permissions:
     - **Contents**: Read and write
     - **Pull requests**: Read and write
     - **Workflows**: Read and write
   - Set an expiry you'll remember to rotate (max 1 year for fine-grained)

2. **Add as repo secret** at <https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/settings/secrets/actions>
   - Name: `WORKFLOW_AUTO_MERGE_PAT`
   - Value: the PAT from step 1

Once the secret is set, the next Dependabot PR that touches a workflow file will auto-merge after checks pass. PRs that don't touch workflows continue using `GITHUB_TOKEN` even if the secret exists (the `||` is short-circuit but GitHub uses whichever the workflow declares; effectively the PAT will be used for all auto-merges — the elevated scope is unused on non-workflow PRs and not exposed in logs).

## Why not the other options

- **Skip workflow PRs from auto-merge**: workable but defeats the purpose for the most common case (Dependabot action bumps).
- **GitHub App**: more setup, more moving parts, similar threat model to a fine-grained PAT for a solo-maintained repo.
- **Org-level ruleset bypass for Dependabot bot**: not available on the free tier (rulesets require GitHub Team).

## Test plan

- [x] Workflow YAML syntax valid
- [ ] After merge + secret setup: next workflow-touching Dependabot PR auto-merges
- [ ] After merge + secret setup: non-workflow Dependabot PR still auto-merges (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated dependency management workflow with improved authentication and fallback mechanisms for better security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->