### PR TITLE
fix(auth): union roles from access + ID token (me.php & AuthHelper)

### DIFF
--- a/auth/me.php
+++ b/auth/me.php
@@ -66,8 +66,18 @@ try {
     $idPayload   = $idToken !== null ? $oidcClient->validateToken($idToken, $additionalAudiences) : null;
     $claimSource = $idPayload ?? $accessPayload;
 
-    // Extract user info from the best available token
+    // Extract user info from the best available token (ID token preferred for profile claims)
     $user = $oidcClient->extractUserFromIdToken($claimSource);
+
+    // Roles may be asserted into the access token, the ID token, or both, depending on the
+    // Zitadel "User roles inside ID Token" / "Assert roles on authentication" settings.
+    // Union roles from every available token so a single config toggle (or a token that only
+    // carries minimal claims) cannot silently leave the user with no roles.
+    $roles = $oidcClient->extractRolesFromToken($accessPayload);
+    if ($idPayload !== null) {
+        $roles = array_merge($roles, $oidcClient->extractRolesFromToken($idPayload));
+    }
+    $user['roles'] = array_values(array_unique($roles));
 
     // Use access token expiry for session timing
     $exp = $accessPayload->exp ?? 0;

--- a/src/AuthHelper.php
+++ b/src/AuthHelper.php
@@ -49,8 +49,9 @@ class AuthHelper
      *
      * @param object|null $payload Validated JWT payload, or null if not authenticated
      * @param bool $isOidc Whether this is an OIDC token (different claim structure)
+     * @param array<int, string>|null $oidcRoles Roles unioned across the OIDC tokens (OIDC mode only)
      */
-    private function __construct(?object $payload, bool $isOidc = false)
+    private function __construct(?object $payload, bool $isOidc = false, ?array $oidcRoles = null)
     {
         if ($payload === null) {
             $this->isAuthenticated = false;
@@ -80,21 +81,9 @@ class AuthHelper
             $this->emailVerified = $payload->email_verified ?? false;
             $this->exp           = isset($payload->exp) && is_numeric($payload->exp) ? (int) $payload->exp : null;
 
-            // Extract roles from Zitadel claims
-            $roles    = [];
-            $rolesKey = 'urn:zitadel:iam:org:project:roles';
-            if (isset($payload->{$rolesKey}) && is_object($payload->{$rolesKey})) {
-                $roles = array_keys((array) $payload->{$rolesKey});
-            }
-            // Also check project-specific roles claim
-            $projectId = $_ENV['ZITADEL_PROJECT_ID'] ?? getenv('ZITADEL_PROJECT_ID') ?: null;
-            if ($projectId !== null) {
-                $projectRolesKey = "urn:zitadel:iam:org:project:{$projectId}:roles";
-                if (isset($payload->{$projectRolesKey}) && is_object($payload->{$projectRolesKey})) {
-                    $roles = array_merge($roles, array_keys((array) $payload->{$projectRolesKey}));
-                }
-            }
-            $this->roles       = !empty($roles) ? array_values(array_unique($roles)) : null;
+            // Roles are unioned across the ID and access tokens by tryValidateOidcToken(),
+            // since Zitadel may assert them into either token depending on configuration.
+            $this->roles       = !empty($oidcRoles) ? array_values(array_unique($oidcRoles)) : null;
             $this->permissions = null; // OIDC doesn't have permissions claim
         } else {
             // Legacy JWT token
@@ -170,9 +159,9 @@ class AuthHelper
 
             if ($issuer !== null && $clientId !== null) {
                 // Try OIDC validation first
-                $payload = self::tryValidateOidcToken();
-                if ($payload !== null) {
-                    self::$instance = new self($payload, true);
+                $oidc = self::tryValidateOidcToken();
+                if ($oidc !== null) {
+                    self::$instance = new self($oidc['payload'], true, $oidc['roles']);
                     return self::$instance;
                 }
             }
@@ -195,29 +184,30 @@ class AuthHelper
     }
 
     /**
-     * Try to validate OIDC token from Zitadel
+     * Try to validate the OIDC tokens from Zitadel.
      *
-     * Uses OidcClient for JWKS handling and token validation.
-     * Prefers ID token for user profile information (preferred_username, email, name, etc.)
-     * as the access token typically only contains minimal claims (sub).
+     * Uses OidcClient for JWKS handling and token validation. Prefers the ID token for user
+     * profile information (preferred_username, email, name, etc.) as the access token typically
+     * only contains minimal claims (sub). Roles are unioned across both tokens, since Zitadel may
+     * assert them into the ID token, the access token, or both depending on configuration.
      *
-     * @return object|null Validated payload or null
+     * @return array{payload: object, roles: array<int, string>}|null Profile payload and unioned
+     *                                                                 roles, or null if invalid
      */
-    private static function tryValidateOidcToken(): ?object
+    private static function tryValidateOidcToken(): ?array
     {
-        // Check if access token exists (proves user is authenticated)
+        // Access token must be present (proves the user is authenticated)
         $accessToken = $_COOKIE[self::ACCESS_TOKEN_COOKIE] ?? null;
         if ($accessToken === null || $accessToken === '') {
             return null;
         }
 
-        // Get ID token for user profile information
-        // ID token contains full user claims (preferred_username, email, name, etc.)
-        // Access token typically only has minimal claims (sub)
+        // ID token carries the richer profile claims (preferred_username, email, name, etc.);
+        // the access token typically only has minimal claims (sub).
         $idToken = $_COOKIE[self::ID_TOKEN_COOKIE] ?? null;
 
-        // Use ID token if available, fall back to access token
-        $token = $idToken ?? $accessToken;
+        // Prefer the ID token for the profile payload, fall back to the access token.
+        $profileToken = $idToken ?? $accessToken;
 
         try {
             $oidcClient = OidcClient::fromEnv();
@@ -229,7 +219,25 @@ class AuthHelper
                 $additionalAudiences[] = $projectId;
             }
 
-            return $oidcClient->validateToken($token, $additionalAudiences);
+            $profilePayload = $oidcClient->validateToken($profileToken, $additionalAudiences);
+            if ($profilePayload === null) {
+                return null;
+            }
+
+            // Union roles from every available token so a single Zitadel config toggle (or a
+            // token that only carries minimal claims) cannot silently leave the user with no roles.
+            $roles = $oidcClient->extractRolesFromToken($profilePayload);
+            if ($profileToken !== $accessToken) {
+                $accessPayload = $oidcClient->validateToken($accessToken, $additionalAudiences);
+                if ($accessPayload !== null) {
+                    $roles = array_merge($roles, $oidcClient->extractRolesFromToken($accessPayload));
+                }
+            }
+
+            return [
+                'payload' => $profilePayload,
+                'roles'   => array_values(array_unique($roles)),
+            ];
         } catch (\Exception) {
             // OidcClient instantiation or validation errors
             return null;

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -518,13 +518,34 @@ class OidcClient
             'preferred_username' => $payload->preferred_username ?? null,
         ];
 
-        // Extract Zitadel roles from both generic and project-specific claims
+        $user['roles'] = $this->extractRolesFromToken($payload);
+
+        return $user;
+    }
+
+    /**
+     * Extract Zitadel project roles from a validated token payload.
+     *
+     * Reads both the generic `urn:zitadel:iam:org:project:roles` claim and the
+     * project-specific `urn:zitadel:iam:org:project:{projectId}:roles` claim.
+     *
+     * Depending on the Zitadel configuration ("User roles inside ID Token" application
+     * setting vs "Assert roles on authentication" project setting), roles may be asserted
+     * into the ID token, the access token, or both. Callers should therefore union the
+     * result of this method across every available token so a single configuration toggle
+     * cannot silently leave a user with no roles.
+     *
+     * @param object $payload Decoded token payload (ID token or access token)
+     * @return array<int, string> Role keys, or empty array if none are present
+     */
+    public function extractRolesFromToken(object $payload): array
+    {
         $roles    = [];
         $rolesKey = 'urn:zitadel:iam:org:project:roles';
         if (isset($payload->{$rolesKey}) && is_object($payload->{$rolesKey})) {
             $roles = array_keys((array) $payload->{$rolesKey});
         }
-        // Also check project-specific roles claim (matching auth/me.php behavior)
+        // Also check the project-specific roles claim
         $projectId = $_ENV['ZITADEL_PROJECT_ID'] ?? getenv('ZITADEL_PROJECT_ID') ?: null;
         if ($projectId !== null) {
             $projectRolesKey = "urn:zitadel:iam:org:project:{$projectId}:roles";
@@ -532,9 +553,9 @@ class OidcClient
                 $roles = array_merge($roles, array_keys((array) $payload->{$projectRolesKey}));
             }
         }
-        $user['roles'] = !empty($roles) ? array_values(array_unique($roles)) : [];
 
-        return $user;
+        // array_keys on a cast object yields claim names (strings); normalize to a unique list.
+        return array_values(array_unique(array_map('strval', $roles)));
     }
 
     /**


### PR DESCRIPTION
## Problem

Project roles were read from a **single** OIDC token (the ID token, preferred), in two places:

- `auth/me.php` → drives client-side `Auth.hasRole()` (JS)
- `src/AuthHelper.php` → drives server-side `$authHelper->hasRole()` (e.g. developer nav and admin links in `layout/header.php`)

Depending on the Zitadel configuration (**"User roles inside ID Token"** application setting vs **"Assert roles on authentication"** project setting), project roles may be asserted into the access token, the ID token, or both. Reading only one token can silently leave a user with an empty `roles` array even when the grant is correct — with no error and no recovery via re-login or "refresh session".

This came out of debugging a live case where `/auth/me.php` returned `"roles": []` despite a valid admin grant. (Root cause there was a Zitadel grant bound to the wrong user subject; this PR is the defensive hardening so a single config toggle can't reproduce the empty-roles symptom, and so the client and server role checks stay consistent.)

## Change

- Extract the Zitadel role-parsing into a reusable `OidcClient::extractRolesFromToken(object $payload): array` (no behavior change for the existing `extractUserFromIdToken()` caller).
- `auth/me.php`: union roles from the access token **and** the ID token. ID token is still preferred for profile claims.
- `src/AuthHelper.php`: `tryValidateOidcToken()` now returns `{payload, roles}`, unioning roles across both validated tokens; the constructor takes the pre-computed roles.

**Auth gate is unchanged:** the profile token (ID token preferred) must still validate; the access token is validated *only* to collect roles, null-safely — it can't flip a logged-in user to logged-out.

## Verification

- `composer parallel-lint` ✓, `composer lint` (phpcs) ✓, `composer analyse` (PHPStan) ✓
- One-off behavioral checks (no PHPUnit harness exists in this repo yet):
  - `extractRolesFromToken` union logic — 7/7 cases (access-only, id-only, both/dedup, differing roles, neither, no-id-token, project-specific claim)
  - `AuthHelper` constructor wiring via reflection — 7/7 cases (roles → `hasRole`, empty-roles → `null`, unauthenticated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed authentication role consolidation by properly extracting and merging roles from both ID and access tokens, ensuring users receive accurate and complete role assignment
* Enhanced token validation to capture project-specific role claims, improving authorization accuracy and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->