### PR TITLE
fix(ui): wrap long usernames in user-profile to prevent table overflow

### DIFF
--- a/user-profile.php
+++ b/user-profile.php
@@ -76,7 +76,7 @@ if (!$authHelper->isAuthenticated) {
                                 <th scope="row" class="text-muted">
                                     <i class="fas fa-at me-2"></i><?php echo htmlspecialchars(_('Username'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
                                 </th>
-                                <td><?php echo htmlspecialchars($authHelper->username ?? '-', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></td>
+                                <td class="text-break"><?php echo htmlspecialchars($authHelper->username ?? '-', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></td>
                             </tr>
 
                             <?php if ($authHelper->email !== null) : ?>


### PR DESCRIPTION
## Problem

After enabling **"Add Organization Domain as suffix to loginnames"** in Zitadel, the loginname
(e.g. `user@domain@org-login-domain`) is a long unbroken token. In `user-profile.php` it overflows
its table cell and pushes the layout wider than the card on narrower viewports.

## Change

Add Bootstrap's `text-break` utility (`word-break: break-word`) to the username value cell so the
loginname wraps cleanly within the cell. The full value stays visible and selectable — preferred
over ellipsis truncation on a profile page where the user may want to read/copy their loginname.

No custom CSS; uses the existing Bootstrap utility already available in the theme.

## Notes

- Scoped to the reported Username cell. The Email and Full Name value cells in the same table are
  also free-form and could be given the same treatment if desired.
- The navbar user menu (`layout/header.php`) may also render the loginname; if it overflows there it
  would warrant separate handling (likely truncation in that tight dropdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)