### PR TITLE
feat(ui): general_roman_calendar object type (frontend Phase B)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         id: update_pot
         run: |
           sudo apt-get install -y gettext
-          xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" --keyword="ngettext:1,2" -L PHP -o i18n/litcal.pot index.php usage.php easter.php about.php examples.php translations.php liturgyOfAnyDay.php src/LitColor.php src/LitCommon.php src/LitGrade.php src/Utilities.php src/FormControls.php layout/header.php includes/login-modal.php includes/messages.php includes/functions.php admin-permissions.php permission-requests.php
+          xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" --keyword="ngettext:1,2" -L PHP -o i18n/litcal.pot index.php usage.php easter.php about.php examples.php translations.php liturgyOfAnyDay.php src/LitColor.php src/LitCommon.php src/LitGrade.php src/Utilities.php src/FormControls.php layout/header.php layout/footer.php includes/login-modal.php includes/messages.php includes/functions.php includes/admin-blocks.php admin-permissions.php permission-requests.php admin-applications.php admin-dashboard.php admin-role-requests.php admin-users.php developer-dashboard.php missals-editor.php temporale.php user-profile.php
           echo "POT_LINES_CHANGED=$(git diff -U0 | grep '^[+|-][^+|-]' | grep -Ev '^[+-]"POT-Creation-Date' | wc -l)" >> $GITHUB_OUTPUT
 
       # Direct push to development is blocked by branch protection (required

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         id: update_pot
         run: |
           sudo apt-get install -y gettext
-          xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" --keyword="ngettext:1,2" -L PHP -o i18n/litcal.pot index.php usage.php easter.php about.php examples.php translations.php liturgyOfAnyDay.php src/LitColor.php src/LitCommon.php src/LitGrade.php src/Utilities.php src/FormControls.php layout/header.php includes/login-modal.php includes/messages.php includes/functions.php
+          xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" --keyword="ngettext:1,2" -L PHP -o i18n/litcal.pot index.php usage.php easter.php about.php examples.php translations.php liturgyOfAnyDay.php src/LitColor.php src/LitCommon.php src/LitGrade.php src/Utilities.php src/FormControls.php layout/header.php includes/login-modal.php includes/messages.php includes/functions.php admin-permissions.php permission-requests.php
           echo "POT_LINES_CHANGED=$(git diff -U0 | grep '^[+|-][^+|-]' | grep -Ev '^[+-]"POT-Creation-Date' | wc -l)" >> $GITHUB_OUTPUT
 
       # Direct push to development is blocked by branch protection (required

--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -285,6 +285,7 @@ if (!$isAdmin) {
                             <option value="diocesan_calendar"><?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="wider_region"><?php echo htmlspecialchars(_('Wider Region'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="test_definition"><?php echo htmlspecialchars(_('Test Definition'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         </select>
                     </div>
                     <div class="mb-3">
@@ -369,6 +370,13 @@ if (!$isAdmin) {
                 diocesanCalendar: <?php echo json_encode(_('Diocesan Calendar')); ?>,
                 widerRegion: <?php echo json_encode(_('Wider Region')); ?>,
                 testDefinition: <?php echo json_encode(_('Test Definition')); ?>,
+                generalRomanCalendar: <?php echo json_encode(_('General Roman Calendar')); ?>,
+                grcTemporale: <?php echo json_encode(_('Temporale')); ?>,
+                grcSanctorale1970: <?php echo json_encode(_('Sanctorale — Editio Typica 1970')); ?>,
+                grcSanctorale2002: <?php echo json_encode(_('Sanctorale — Editio Typica 2002')); ?>,
+                grcSanctorale2008: <?php echo json_encode(_('Sanctorale — Editio Typica 2008')); ?>,
+                grcDecrees: <?php echo json_encode(_('Decrees of the Dicastery for Divine Worship')); ?>,
+                enterObjectId: <?php echo json_encode(_('Enter object ID...')); ?>,
                 // Relation display names
                 admin: <?php echo json_encode(_('Admin')); ?>,
                 viewer: <?php echo json_encode(_('Viewer')); ?>,

--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -74,6 +74,7 @@ if (!$isAdmin) {
                         <option value="diocesan_calendar"><?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="wider_region"><?php echo htmlspecialchars(_('Wider Region'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="test_definition"><?php echo htmlspecialchars(_('Test Definition'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                     </select>
                 </div>
                 <div class="col-md-3">
@@ -377,6 +378,7 @@ if (!$isAdmin) {
                 grcSanctorale2008: <?php echo json_encode(_('Sanctorale — Editio Typica 2008')); ?>,
                 grcDecrees: <?php echo json_encode(_('Decrees of the Dicastery for Divine Worship')); ?>,
                 enterObjectId: <?php echo json_encode(_('Enter object ID...')); ?>,
+                selectObjectId: <?php echo json_encode(_('Select object ID...')); ?>,
                 // Relation display names
                 admin: <?php echo json_encode(_('Admin')); ?>,
                 viewer: <?php echo json_encode(_('Viewer')); ?>,

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -30,10 +30,50 @@ document.addEventListener('DOMContentLoaded', function() {
     const grantModal = new bootstrap.Modal(document.getElementById('grantModal'));
     const grantUser = document.getElementById('grantUser');
     const grantObjectType = document.getElementById('grantObjectType');
-    const grantObjectId = document.getElementById('grantObjectId');
+    // Note: the Object ID control is looked up live (document.getElementById) wherever it is
+    // used, because syncObjectIdField() swaps the input<->select element when the object type
+    // changes; a cached reference would go stale after that swap.
     const grantRelation = document.getElementById('grantRelation');
     const grantModalAlerts = document.getElementById('grantModalAlerts');
     const confirmGrantBtn = document.getElementById('confirmGrantBtn');
+
+    // Fixed object-id choices for the General Roman Calendar type.
+    const GRC_OBJECT_IDS = [
+        { id: 'temporale',          label: config.i18n.grcTemporale },
+        { id: 'EDITIO_TYPICA_1970', label: config.i18n.grcSanctorale1970 },
+        { id: 'EDITIO_TYPICA_2002', label: config.i18n.grcSanctorale2002 },
+        { id: 'EDITIO_TYPICA_2008', label: config.i18n.grcSanctorale2008 },
+        { id: 'decrees',            label: config.i18n.grcDecrees }
+    ];
+
+    // Swap the free-text Object ID input for a <select> when GRC is selected, and back otherwise.
+    function syncObjectIdField(objectType) {
+        const current = document.getElementById('grantObjectId');
+        if (objectType === 'general_roman_calendar') {
+            if (current.tagName === 'SELECT') {
+                return;
+            }
+            const select = document.createElement('select');
+            select.className = 'form-select';
+            select.id = 'grantObjectId';
+            select.required = true;
+            for (const opt of GRC_OBJECT_IDS) {
+                const o = document.createElement('option');
+                o.value = opt.id;
+                o.textContent = opt.label;
+                select.appendChild(o);
+            }
+            current.replaceWith(select);
+        } else if (current.tagName === 'SELECT') {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'form-control';
+            input.id = 'grantObjectId';
+            input.required = true;
+            input.placeholder = config.i18n.enterObjectId || '';
+            current.replaceWith(input);
+        }
+    }
 
     // Revoke modal elements
     const revokeModal = new bootstrap.Modal(document.getElementById('revokeModal'));
@@ -54,7 +94,8 @@ document.addEventListener('DOMContentLoaded', function() {
         'national_calendar': config.i18n.nationalCalendar,
         'diocesan_calendar': config.i18n.diocesanCalendar,
         'wider_region': config.i18n.widerRegion,
-        'test_definition': config.i18n.testDefinition
+        'test_definition': config.i18n.testDefinition,
+        'general_roman_calendar': config.i18n.generalRomanCalendar
     };
 
     // Relation display names and badge classes
@@ -256,7 +297,8 @@ document.addEventListener('DOMContentLoaded', function() {
     function openGrantModal() {
         grantUser.value = '';
         grantObjectType.value = '';
-        grantObjectId.value = '';
+        syncObjectIdField('');
+        document.getElementById('grantObjectId').value = '';
         grantRelation.value = '';
         grantModalAlerts.innerHTML = '';
         grantModal.show();
@@ -268,7 +310,7 @@ document.addEventListener('DOMContentLoaded', function() {
     async function handleGrant() {
         const user = grantUser.value.trim();
         const objectType = grantObjectType.value;
-        const objectId = grantObjectId.value.trim();
+        const objectId = document.getElementById('grantObjectId').value.trim();
         const relation = grantRelation.value;
 
         if (!user || !objectType || !objectId || !relation) {
@@ -449,6 +491,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     grantPermissionBtn.addEventListener('click', openGrantModal);
+    grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
     confirmGrantBtn.addEventListener('click', handleGrant);
     confirmRevokeBtn.addEventListener('click', handleRevoke);
     applyFiltersBtn.addEventListener('click', loadPermissions);

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -38,6 +38,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const confirmGrantBtn = document.getElementById('confirmGrantBtn');
 
     // Fixed object-id choices for the General Roman Calendar type.
+    // The five enumerated General Roman Calendar sub-resource ids.
+    // Keep in sync with the API constant AccessRequestRepository::GRC_OBJECT_IDS
+    // and the identical copy in assets/js/permission-requests.js.
     const GRC_OBJECT_IDS = [
         { id: 'temporale',          label: config.i18n.grcTemporale },
         { id: 'EDITIO_TYPICA_1970', label: config.i18n.grcSanctorale1970 },
@@ -57,6 +60,14 @@ document.addEventListener('DOMContentLoaded', function() {
             select.className = 'form-select';
             select.id = 'grantObjectId';
             select.required = true;
+            // Empty placeholder forces an explicit choice instead of silently defaulting to the
+            // first id (temporale); consistent with the object-type and relation selects.
+            const placeholder = document.createElement('option');
+            placeholder.value = '';
+            placeholder.textContent = config.i18n.selectObjectId || 'Select object ID...';
+            placeholder.disabled = true;
+            placeholder.selected = true;
+            select.appendChild(placeholder);
             for (const opt of GRC_OBJECT_IDS) {
                 const o = document.createElement('option');
                 o.value = opt.id;

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -50,7 +50,8 @@ document.addEventListener('DOMContentLoaded', async function() {
         'national_calendar': config.i18n.nationalCalendar,
         'diocesan_calendar': config.i18n.diocesanCalendar,
         'wider_region': config.i18n.widerRegion,
-        'test_definition': config.i18n.testDefinition
+        'test_definition': config.i18n.testDefinition,
+        'general_roman_calendar': config.i18n.generalRomanCalendar
     };
 
     // Relation display names
@@ -77,11 +78,20 @@ document.addEventListener('DOMContentLoaded', async function() {
         'revoked': { class: 'bg-secondary', icon: 'fas fa-ban', text: config.i18n.statusRevoked }
     };
 
+    // Fixed object-id choices for the General Roman Calendar type.
+    const GRC_OBJECT_IDS = [
+        { id: 'temporale',          label: config.i18n.grcTemporale },
+        { id: 'EDITIO_TYPICA_1970', label: config.i18n.grcSanctorale1970 },
+        { id: 'EDITIO_TYPICA_2002', label: config.i18n.grcSanctorale2002 },
+        { id: 'EDITIO_TYPICA_2008', label: config.i18n.grcSanctorale2008 },
+        { id: 'decrees',            label: config.i18n.grcDecrees }
+    ];
+
     // Object types allowed per role
     const roleObjectTypes = {
-        'calendar_editor': ['national_calendar', 'diocesan_calendar', 'wider_region'],
+        'calendar_editor': ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'],
         'test_editor': ['test_definition'],
-        'developer': ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition']
+        'developer': ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition', 'general_roman_calendar']
     };
 
     let permissionRowCounter = 0;
@@ -96,6 +106,41 @@ document.addEventListener('DOMContentLoaded', async function() {
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
+    }
+
+    /**
+     * Swap the free-text Object ID input for a <select> when GRC is selected,
+     * and restore the free-text input for any other object type.
+     * The element is looked up live from the row so that repeated calls
+     * after a previous swap work correctly (no stale cached reference).
+     * @param {HTMLElement} row - The permission row (.card element)
+     * @param {string} objectType - The currently selected object type
+     */
+    function syncRowObjectIdField(row, objectType) {
+        const current = row.querySelector('.perm-object-id');
+        if (!current) return;
+        if (objectType === 'general_roman_calendar') {
+            if (current.tagName === 'SELECT') {
+                return;
+            }
+            const select = document.createElement('select');
+            select.className = 'form-select form-select-sm perm-object-id';
+            select.required = true;
+            for (const opt of GRC_OBJECT_IDS) {
+                const o = document.createElement('option');
+                o.value = opt.id;
+                o.textContent = opt.label;
+                select.appendChild(o);
+            }
+            current.replaceWith(select);
+        } else if (current.tagName === 'SELECT') {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'form-control form-control-sm perm-object-id';
+            input.required = true;
+            input.placeholder = config.i18n.objectIdPlaceholder || '';
+            current.replaceWith(input);
+        }
     }
 
     /**
@@ -210,6 +255,11 @@ document.addEventListener('DOMContentLoaded', async function() {
             updateAddPermissionBtnState();
         });
 
+        // Swap object-id control when type changes (GRC → <select>; others → <input>)
+        row.querySelector('.perm-object-type').addEventListener('change', function() {
+            syncRowObjectIdField(row, this.value);
+        });
+
         updateAddPermissionBtnState();
     }
 
@@ -235,6 +285,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                         sel.value = currentVal;
                     }
                 }
+                // Sync object-id control in case the type was removed from the allowed list
+                syncRowObjectIdField(sel.closest('.card'), sel.value);
             });
             // Add an initial row if there are none
             if (permissionRows.children.length === 0) {
@@ -468,10 +520,13 @@ document.addEventListener('DOMContentLoaded', async function() {
             const row = permissionRows.lastElementChild;
             if (!row) continue;
             const typeSelect = row.querySelector('.perm-object-type');
-            const idInput = row.querySelector('.perm-object-id');
             const relSelect = row.querySelector('.perm-relation');
             if (typeSelect) typeSelect.value = perm.object_type || '';
-            if (idInput) idInput.value = perm.object_id || '';
+            // Sync the object-id control BEFORE setting its value; for GRC the
+            // input is replaced with a <select>, so re-query after the swap.
+            syncRowObjectIdField(row, perm.object_type || '');
+            const idField = row.querySelector('.perm-object-id');
+            if (idField) idField.value = perm.object_id || '';
             if (relSelect) relSelect.value = perm.relation || '';
         }
     }

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -79,6 +79,9 @@ document.addEventListener('DOMContentLoaded', async function() {
     };
 
     // Fixed object-id choices for the General Roman Calendar type.
+    // The five enumerated General Roman Calendar sub-resource ids.
+    // Keep in sync with the API constant AccessRequestRepository::GRC_OBJECT_IDS
+    // and the identical copy in assets/js/admin-permissions.js.
     const GRC_OBJECT_IDS = [
         { id: 'temporale',          label: config.i18n.grcTemporale },
         { id: 'EDITIO_TYPICA_1970', label: config.i18n.grcSanctorale1970 },
@@ -126,6 +129,14 @@ document.addEventListener('DOMContentLoaded', async function() {
             const select = document.createElement('select');
             select.className = 'form-select form-select-sm perm-object-id';
             select.required = true;
+            // Empty placeholder forces an explicit choice instead of silently defaulting to the
+            // first id (temporale); consistent with the object-type and relation selects.
+            const placeholder = document.createElement('option');
+            placeholder.value = '';
+            placeholder.textContent = config.i18n.selectObjectId || 'Select object ID...';
+            placeholder.disabled = true;
+            placeholder.selected = true;
+            select.appendChild(placeholder);
             for (const opt of GRC_OBJECT_IDS) {
                 const o = document.createElement('option');
                 o.value = opt.id;

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -228,6 +228,7 @@ if (!$authHelper->emailVerified) {
                 objectId: <?php echo json_encode(_('Object ID'), $jsonFlags); ?>,
                 relation: <?php echo json_encode(_('Relation'), $jsonFlags); ?>,
                 selectObjectType: <?php echo json_encode(_('Select object type...'), $jsonFlags); ?>,
+                selectObjectId: <?php echo json_encode(_('Select object ID...'), $jsonFlags); ?>,
                 selectRelation: <?php echo json_encode(_('Select relation...'), $jsonFlags); ?>,
                 remove: <?php echo json_encode(_('Remove'), $jsonFlags); ?>,
                 // Object type display names

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -235,6 +235,16 @@ if (!$authHelper->emailVerified) {
                 diocesanCalendar: <?php echo json_encode(_('Diocesan Calendar'), $jsonFlags); ?>,
                 widerRegion: <?php echo json_encode(_('Wider Region'), $jsonFlags); ?>,
                 testDefinition: <?php echo json_encode(_('Test Definition'), $jsonFlags); ?>,
+                generalRomanCalendar: <?php echo json_encode(_('General Roman Calendar'), $jsonFlags); ?>,
+                grcTemporale: <?php echo json_encode(_('Temporale'), $jsonFlags); ?>,
+                // phpcs:ignore Generic.Files.LineLength
+                grcSanctorale1970: <?php echo json_encode(_('Sanctorale — Editio Typica 1970'), $jsonFlags); ?>,
+                // phpcs:ignore Generic.Files.LineLength
+                grcSanctorale2002: <?php echo json_encode(_('Sanctorale — Editio Typica 2002'), $jsonFlags); ?>,
+                // phpcs:ignore Generic.Files.LineLength
+                grcSanctorale2008: <?php echo json_encode(_('Sanctorale — Editio Typica 2008'), $jsonFlags); ?>,
+                // phpcs:ignore Generic.Files.LineLength
+                grcDecrees: <?php echo json_encode(_('Decrees of the Dicastery for Divine Worship'), $jsonFlags); ?>,
                 // Role display names
                 calendarEditor: <?php echo json_encode(_('Calendar Editor'), $jsonFlags); ?>,
                 testEditor: <?php echo json_encode(_('Accuracy Test Editor'), $jsonFlags); ?>,


### PR DESCRIPTION
## Summary

Frontend (Phase B) of the General Roman Calendar object type. The API side merged in
Liturgical-Calendar/LiturgicalCalendarAPI#655; this exposes the new `general_roman_calendar`
OpenFGA object type in the frontend's permission UIs.

A grant/request for this type targets one of five enumerated sub-resources (stored verbatim in the
FGA tuple, matching the API's `AccessRequestRepository::GRC_OBJECT_IDS`):

| Sub-resource | Object ID |
|---|---|
| Temporale | `temporale` |
| Sanctorale — Editio Typica 1970 | `EDITIO_TYPICA_1970` |
| Sanctorale — Editio Typica 2002 | `EDITIO_TYPICA_2002` |
| Sanctorale — Editio Typica 2008 | `EDITIO_TYPICA_2008` |
| Decrees of the Dicastery for Divine Worship | `decrees` |

## Changes

- **Admin grant UI** (`admin-permissions.php` + `assets/js/admin-permissions.js`): adds the
  `general_roman_calendar` object-type option; when selected, the Object ID field becomes a
  `<select>` of the five ids (and reverts to free-text for other types).
- **Access-request flow** (`permission-requests.php` + `assets/js/permission-requests.js`): adds the
  type to `roleObjectTypes` for `calendar_editor` and `developer`, with the same per-row object-id
  dropdown.
- **i18n** (`.github/workflows/main.yml`): adds `admin-permissions.php` and `permission-requests.php`
  to the "Update POTs" `xgettext` file list so their translatable strings (including the new labels)
  are extracted into `litcal.pot`. These admin pages were previously outside the extraction scan, so
  the next automated POT regen will add their existing strings too.

## Notes

- The frontend's `scripts/openfga-model.json` is intentionally gitignored (extracted from the API
  Docker image at runtime; the API repo is canonical), so there is no model file in this diff.
- `request-access.php` is a pure redirect to `permission-requests.php`; i18n keys live there only.
- The frontend performs no runtime OpenFGA checks — it only manages tuples via API calls — so the
  five-id list here is a client-side copy that must stay in sync with the API constant (verified).

## Testing

- `node --check` on both changed JS files, `composer lint` (phpcs), `composer analyse` (PHPStan): all clean.
- Object-id swap verified: GRC → dropdown of the five ids; other types → free-text; reset restores
  text input; submit reads the live control (no stale references); all referenced i18n keys defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “General Roman Calendar” as a new object type in the admin permissions interface and permission request workflows.
  * Enabled selection of General Roman Calendar subtypes during permission granting and access requests.
  * Updated the UI to dynamically switch the object-id input method for General Roman Calendar (dropdown for allowed IDs; text entry for other types).
  * Added new internationalized labels for General Roman Calendar object types and request placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->