### PR TITLE
fix(ci): create POT regen PR with PAT so auto-merge can land

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,21 @@ jobs:
       # Direct push to development is blocked by branch protection (required
       # status checks). Open a PR instead and let auto-merge land it once
       # CodeQL + Analyze (javascript) go green on the .pot-only diff.
+      #
+      # The PR MUST be created with a PAT (WORKFLOW_AUTO_MERGE_PAT), not the
+      # default GITHUB_TOKEN: GitHub deliberately does not trigger `pull_request`
+      # workflow runs for PRs opened by GITHUB_TOKEN (recursion guard), so the
+      # required status checks would never start and auto-merge would wait
+      # forever. A PAT-authored PR triggers the checks normally. Falls back to
+      # GITHUB_TOKEN when the secret is absent (same pattern as
+      # dependabot-auto-merge.yml). NOTE: WORKFLOW_AUTO_MERGE_PAT is rotated
+      # periodically (see the rotation-reminder workflow).
       - name: Open PR with regenerated POT
         if: ${{ steps.update_pot.outputs.POT_LINES_CHANGED > 0 }}
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
           branch: chore/regenerate-pot
           delete-branch: true
           add-paths: i18n/litcal.pot
@@ -49,6 +58,6 @@ jobs:
       - name: Enable auto-merge
         if: steps.create_pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
         run: gh pr merge "$PR_NUMBER" --auto --merge


### PR DESCRIPTION
## Problem

The auto-generated `chore(i18n): regenerate i18n/litcal.pot` PRs from the **Update POTs** workflow
never auto-merge — they sit pending a maintainer/checks gate.

**Root cause:** the workflow opens the PR with the default `secrets.GITHUB_TOKEN`. GitHub
deliberately does **not** trigger `pull_request` workflow runs for PRs created by `GITHUB_TOKEN`
(a recursion guard). So the branch-protection required status checks (CodeQL, Analyze javascript)
never start on the POT PR, and `gh pr merge --auto` waits forever on checks that can't run.

## Fix

Use the existing `WORKFLOW_AUTO_MERGE_PAT` secret (with `GITHUB_TOKEN` fallback) for both:
- the `peter-evans/create-pull-request` **token** — a PAT-authored PR triggers the required checks
  normally, which is the key change; and
- the **`gh pr merge --auto`** step — mirroring the established pattern already used in
  `dependabot-auto-merge.yml`.

```yaml
token:   ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}   # create-pull-request
GH_TOKEN: ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}  # enable auto-merge
```

The fallback keeps the workflow functional (current behavior) if the secret is ever absent.

## Notes / verification

- YAML validated locally (`yaml.safe_load`).
- No behavior change beyond the token source; PR commit author/committer remain `github-actions[bot]`.
- This depends on `WORKFLOW_AUTO_MERGE_PAT` being present and unexpired (already used by dependabot
  auto-merge; there's a rotation-reminder workflow). If the existing pending POT PR was opened under
  the old token, it'll still need a manual merge — the fix applies to future regenerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)