### PR TITLE
feat(rbac): scoped admin-review for resource-admins + RBAC access-request E2E suite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,3 +147,7 @@ ZITADEL_CLIENT_ID=your-frontend-client-id
 # TESTS_PORT=3003
 # DB_PORT=5432
 # ADMINER_PORT=8088
+
+# Mailpit REST API base URL (local email capture). Used by the RBAC E2E
+# registration specs to read Zitadel verification emails. Default: http://localhost:8025
+MAILPIT_API_URL=http://localhost:8025

--- a/.env.example
+++ b/.env.example
@@ -151,3 +151,9 @@ ZITADEL_CLIENT_ID=your-frontend-client-id
 # Mailpit REST API base URL (local email capture). Used by the RBAC E2E
 # registration specs to read Zitadel verification emails. Default: http://localhost:8025
 MAILPIT_API_URL=http://localhost:8025
+
+# Internal URL for server-side frontend->API calls (e.g. AuthHelper GET /auth/admin-scopes).
+# Needed in containerized/Docker deploys where API_HOST (the public host) is not reachable from
+# within the frontend container. Unset in single-host deploys (falls back to the public API URL).
+# Local Docker stack: http://litcal-api:8000
+# API_INTERNAL_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ api/*
 !src/*.php
 !dist/*.php
 !includes/*.php
+!tests/*.php
 
 .php-ini
 .php-version

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ phpstan.neon
 !phpstan.neon.dist
 phpunit.xml
 !phpunit.xml.dist
+.phpunit.cache/
 /assets/json/
 
 /cache/

--- a/admin-dashboard.php
+++ b/admin-dashboard.php
@@ -140,6 +140,33 @@ if (!$hasCalendarRole) {
     </div>
     <?php endif; ?>
 
+    <?php if (!$isAdmin && $authHelper->isResourceAdmin()) : ?>
+    <hr class="my-4">
+    <h4 class="mb-3 text-black" style="--bs-text-opacity: .6;">
+        <i class="fas fa-user-shield me-2"></i><?php echo htmlspecialchars(_('Administration'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+    </h4>
+    <div class="row">
+        <div class="col-12 col-md-6 col-lg-4 mb-4">
+            <div class="card admin-block shadow h-100 border-dark">
+                <div class="card-body text-center d-flex flex-column">
+                    <div class="admin-block-icon mb-3">
+                        <i class="fas fa-inbox fa-3x text-dark"></i>
+                    </div>
+                    <h5 class="card-title"><?php echo htmlspecialchars(_('Access Requests to Review'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h5>
+                    <p class="card-text text-muted small flex-grow-1">
+                        <?php echo htmlspecialchars(_('Review and approve access requests for the resources you administer'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </p>
+                    <div class="admin-block-actions mt-auto">
+                        <a href="admin-permissions.php" class="btn btn-dark btn-sm">
+                            <i class="fas fa-tasks me-1"></i><?php echo htmlspecialchars(_('Review'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
+
     <?php include_once('./layout/footer.php'); ?>
 </body>
 </html>

--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -16,11 +16,14 @@ if (!$authHelper->isAuthenticated) {
     exit;
 }
 
-// Check if user has admin role
-$isAdmin = $authHelper->hasRole('admin');
+// Global admins manage everything; resource-admins may review the access
+// requests scoped to the resources they administer. The API enforces the
+// actual scoping — this gate only decides who the UI lets in.
+$isGlobalAdmin   = $authHelper->hasRole('admin');
+$isResourceAdmin = $authHelper->isResourceAdmin();
 
-// Redirect non-admins to dashboard
-if (!$isAdmin) {
+// Redirect users who are neither to the dashboard.
+if (!$isGlobalAdmin && !$isResourceAdmin) {
     header('Location: admin-dashboard.php');
     exit;
 }
@@ -50,6 +53,7 @@ if (!$isAdmin) {
         echo htmlspecialchars($managePermsDesc, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     ?></p>
 
+    <?php if ($isGlobalAdmin) : ?>
     <!-- Filter Controls -->
     <div class="card shadow mb-4">
         <div class="card-header py-3">
@@ -130,6 +134,7 @@ if (!$isAdmin) {
             </div>
         </div>
     </div>
+    <?php endif; ?>
 
     <!-- Access Requests Review Section -->
     <div class="card shadow mb-4">
@@ -262,6 +267,7 @@ if (!$isAdmin) {
         </a>
     </div>
 
+    <?php if ($isGlobalAdmin) : ?>
     <!-- Grant Permission Modal -->
     <div class="modal fade" id="grantModal" tabindex="-1" aria-labelledby="grantModalLabel">
         <div class="modal-dialog">
@@ -343,11 +349,13 @@ if (!$isAdmin) {
             </div>
         </div>
     </div>
+    <?php endif; ?>
 
     <!-- Config for JavaScript -->
     <script>
         window.AdminPermissionsConfig = {
             apiUrl: <?php echo json_encode($apiBaseUrl); ?>,
+            isGlobalAdmin: <?php echo json_encode($isGlobalAdmin); ?>,
             i18n: {
                 loading: <?php echo json_encode(_('Loading...')); ?>,
                 noPermissions: <?php echo json_encode(_('No permissions found.')); ?>,

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -27,7 +27,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const filterRelation = document.getElementById('filterRelation');
 
     // Grant modal elements
-    const grantModal = new bootstrap.Modal(document.getElementById('grantModal'));
+    const grantModalEl = document.getElementById('grantModal');
+    const grantModal = grantModalEl ? new bootstrap.Modal(grantModalEl) : null;
     const grantUser = document.getElementById('grantUser');
     const grantObjectType = document.getElementById('grantObjectType');
     // Note: the Object ID control is looked up live (document.getElementById) wherever it is
@@ -87,7 +88,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // Revoke modal elements
-    const revokeModal = new bootstrap.Modal(document.getElementById('revokeModal'));
+    const revokeModalEl = document.getElementById('revokeModal');
+    const revokeModal = revokeModalEl ? new bootstrap.Modal(revokeModalEl) : null;
     const revokeConfirmText = document.getElementById('revokeConfirmText');
     const revokeModalAlerts = document.getElementById('revokeModalAlerts');
     const confirmRevokeBtn = document.getElementById('confirmRevokeBtn');
@@ -490,33 +492,37 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // Event listeners
-    refreshBtn.addEventListener('click', async function() {
-        const icon = this.querySelector('i');
-        icon.classList.add('fa-spin');
-        // Refresh user map first so newly-granted-to users appear with friendly names.
-        await loadUserMap();
-        loadPermissions().finally(function() {
-            icon.classList.remove('fa-spin');
+    // Event listeners — the FGA permission-tuple management section is
+    // global-admin-only; its DOM is absent for resource-admins, so skip its
+    // wiring and initial load entirely.
+    if (config.isGlobalAdmin) {
+        refreshBtn.addEventListener('click', async function() {
+            const icon = this.querySelector('i');
+            icon.classList.add('fa-spin');
+            // Refresh user map first so newly-granted-to users appear with friendly names.
+            await loadUserMap();
+            loadPermissions().finally(function() {
+                icon.classList.remove('fa-spin');
+            });
         });
-    });
 
-    grantPermissionBtn.addEventListener('click', openGrantModal);
-    grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
-    confirmGrantBtn.addEventListener('click', handleGrant);
-    confirmRevokeBtn.addEventListener('click', handleRevoke);
-    applyFiltersBtn.addEventListener('click', loadPermissions);
+        grantPermissionBtn.addEventListener('click', openGrantModal);
+        grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
+        confirmGrantBtn.addEventListener('click', handleGrant);
+        confirmRevokeBtn.addEventListener('click', handleRevoke);
+        applyFiltersBtn.addEventListener('click', loadPermissions);
 
-    clearFiltersBtn.addEventListener('click', function() {
-        filterUser.value = '';
-        filterObjectType.value = '';
-        filterObjectId.value = '';
-        filterRelation.value = '';
-        loadPermissions();
-    });
+        clearFiltersBtn.addEventListener('click', function() {
+            filterUser.value = '';
+            filterObjectType.value = '';
+            filterObjectId.value = '';
+            filterRelation.value = '';
+            loadPermissions();
+        });
 
-    // Load user map and then permissions on page load
-    loadUserMap().then(loadPermissions);
+        // Load user map and then permissions on page load
+        loadUserMap().then(loadPermissions);
+    }
 
     // ========================================================================
     // Access Requests Review Section

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -956,7 +956,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 // Approving creates a tuple, revoking removes one; reject doesn't
                 // affect tuples but a re-fetch is cheap. Refresh userMap first so
                 // a freshly-promoted user appears with their friendly name.
-                loadUserMap().then(loadPermissions);
+                // The FGA permissions table only exists for global admins; resource-admins
+                // have no such DOM, so skip its refresh (loadAccessRequests above already
+                // refreshed the review list they care about).
+                if (config.isGlobalAdmin) {
+                    loadUserMap().then(loadPermissions);
+                }
                 // Refresh notifications
                 if (typeof Notifications !== 'undefined' && Notifications.fetchNotifications) {
                     Notifications.fetchNotifications();

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -65,6 +65,18 @@ const Auth = {
     _isLoggingOut: false,
 
     /**
+     * Cached resource-admin result for this page load (null = not yet fetched).
+     * @private
+     */
+    _resourceAdminCache: null,
+
+    /**
+     * In-flight resource-admin fetch, to dedupe concurrent callers.
+     * @private
+     */
+    _resourceAdminPromise: null,
+
+    /**
      * Validate that BaseUrl is defined before making API calls
      * @private
      * @param {string} methodName - Name of the calling method for error messages
@@ -785,6 +797,52 @@ const Auth = {
 
         const roles = this._cachedAuthState.roles;
         return roles && roles.includes(role);
+    },
+
+    /**
+     * Check whether the caller is an OpenFGA resource-admin (holds an `admin`
+     * tuple on at least one resource) via GET /auth/admin-scopes.
+     *
+     * Result is cached for the page load and concurrent calls are deduped.
+     * Fails closed to false on any network/API error.
+     *
+     * @returns {Promise<boolean>} True if the caller is a resource-admin
+     */
+    async isResourceAdmin() {
+        if (this._resourceAdminCache !== null) {
+            return this._resourceAdminCache;
+        }
+        if (this._resourceAdminPromise !== null) {
+            return this._resourceAdminPromise;
+        }
+        if (!this._validateBaseUrl('isResourceAdmin')) {
+            return false;
+        }
+
+        this._resourceAdminPromise = (async () => {
+            try {
+                const response = await fetch(`${BaseUrl}/auth/admin-scopes`, {
+                    method: 'GET',
+                    credentials: 'include',
+                    headers: { 'Accept': 'application/json' }
+                });
+                if (!response.ok) {
+                    return false;
+                }
+                const data = await response.json();
+                return Boolean(data.is_resource_admin);
+            } catch (error) {
+                console.error('Auth.isResourceAdmin failed:', error);
+                return false;
+            }
+        })();
+
+        try {
+            this._resourceAdminCache = await this._resourceAdminPromise;
+            return this._resourceAdminCache;
+        } finally {
+            this._resourceAdminPromise = null;
+        }
     },
 
     /**

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -820,11 +820,16 @@ const Auth = {
         }
 
         this._resourceAdminPromise = (async () => {
+            // Abort after 5s so a stalled endpoint can't hang the promise — and
+            // every concurrent caller awaiting it — indefinitely.
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 5000);
             try {
                 const response = await fetch(`${BaseUrl}/auth/admin-scopes`, {
                     method: 'GET',
                     credentials: 'include',
-                    headers: { 'Accept': 'application/json' }
+                    headers: { 'Accept': 'application/json' },
+                    signal: controller.signal
                 });
                 if (!response.ok) {
                     return false;
@@ -832,8 +837,11 @@ const Auth = {
                 const data = await response.json();
                 return Boolean(data.is_resource_admin);
             } catch (error) {
+                // AbortError (timeout) and network/parse errors all fail closed.
                 console.error('Auth.isResourceAdmin failed:', error);
                 return false;
+            } finally {
+                clearTimeout(timeoutId);
             }
         })();
 

--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -42,9 +42,10 @@ const Notifications = {
     /**
      * Initialize the notification bell for the current authenticated user.
      * Caller is responsible for ensuring Auth is ready and the user is
-     * authenticated; this method picks the mode based on Auth.hasRole('admin').
+     * authenticated; this method picks the mode based on Auth.hasRole('admin')
+     * or Auth.isResourceAdmin() (resource-admins see the scoped review queue).
      */
-    init() {
+    async init() {
         if (this._initialized) {
             return;
         }
@@ -52,7 +53,10 @@ const Notifications = {
             return;
         }
 
-        this._mode = Auth.hasRole('admin') ? 'admin' : 'user';
+        // Global admins use the review queue; resource-admins do too, but the
+        // API scopes /admin/notifications to the resources they administer.
+        const isAdmin = Auth.hasRole('admin') || await Auth.isResourceAdmin();
+        this._mode = isAdmin ? 'admin' : 'user';
         this._initialized = true;
         console.log(`Notifications: Initializing in ${this._mode} mode`);
 

--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -52,12 +52,12 @@ const Notifications = {
         if (typeof Auth === 'undefined' || !Auth.isAuthenticated()) {
             return;
         }
+        this._initialized = true;
 
         // Global admins use the review queue; resource-admins do too, but the
         // API scopes /admin/notifications to the resources they administer.
         const isAdmin = Auth.hasRole('admin') || await Auth.isResourceAdmin();
         this._mode = isAdmin ? 'admin' : 'user';
-        this._initialized = true;
         console.log(`Notifications: Initializing in ${this._mode} mode`);
 
         // Container should already be visible from PHP for any authenticated

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
         },
         "files": ["src/pgettext.php"]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "LiturgicalCalendar\\Frontend\\Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "John R. D'Orazio",

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
         ],
         "lint": "phpcs || ( echo 'Linting failed. Please run composer lint:fix to fix the linting issues.' && exit 1 )",
         "lint:fix": "bash scripts/lint-fix.sh",
-        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\"",
-        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" --fix",
+        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\"",
+        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" --fix",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit tests"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,6 +340,11 @@ services:
       API_HOST: localhost
       API_PORT: ${API_PORT:-8000}
       API_BASE_PATH: ""
+      # Internal Docker-network URL for server-side frontend->API calls (e.g.
+      # AuthHelper's GET /auth/admin-scopes). API_HOST=localhost resolves to the
+      # frontend container's own loopback, so server-side Guzzle must use the
+      # service name. Mirrors ZITADEL_INTERNAL_URL below.
+      API_INTERNAL_URL: ${API_INTERNAL_URL:-http://litcal-api:8000}
       FRONTEND_URL: http://localhost:${FRONTEND_PORT:-3000}
       ACCURACY_TESTS_URL: http://localhost:${TESTS_PORT:-3003}
       ZITADEL_ISSUER: http://localhost:8080

--- a/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
@@ -1,0 +1,783 @@
+# Frontend RBAC E2E — Harness Implementation Plan (Phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended)
+> or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** Build the reusable Playwright harness that seeds ~11 scoped Zitadel users + OpenFGA tuples,
+saves a per-user authenticated session, and proves it end-to-end with one dashboard-scoping smoke spec.
+
+**Architecture:** A new Playwright project `rbac` with its own setup dependency. Seeding is done in
+TypeScript against the Zitadel management API and OpenFGA HTTP API directly (self-contained in the
+frontend worktree — no API-repo changes). Per-user `storageState` files are produced by the setup project;
+an `actingAs(user)` fixture opens a browser context as any user. Cleanup deletes seeded Zitadel users +
+FGA tuples and truncates app tables via `docker compose exec db psql`.
+
+**Tech Stack:** Playwright (`@playwright/test`), TypeScript, Zitadel management API v1/v2, OpenFGA HTTP API,
+Mailpit API (Phase 2), the project's `docker-compose` stack.
+
+## Global Constraints
+
+- Suite lives under `e2e/rbac/`; do NOT modify `e2e/auth.setup.ts` or the existing specs.
+- Playwright runs **serial, single worker** (shared API/DB/FGA state) — keep `fullyParallel: false`.
+- All seeded users use email pattern `<user-id>+e2e@litcal.test` so cleanup targets only test users.
+- All seeded users live in the **LiturgicalCalendar Zitadel org** (id from `ZITADEL_ORG_ID`).
+- Reuse existing env: `API_PROTOCOL/HOST/PORT`, `FRONTEND_URL`, `ZITADEL_ISSUER`,
+  `ZITADEL_MACHINE_TOKEN`, `ZITADEL_ORG_ID`, `OPENFGA_API_URL`, `OPENFGA_STORE_ID`, `OPENFGA_MODEL_ID`.
+- TypeScript strict: the suite typechecks under `e2e/tsconfig.json` (`yarn typecheck`).
+- Project role for non-super users is `calendar_editor`; `super-admin` gets the global `admin` role.
+
+---
+
+### Task 1: Scaffold the `rbac` Playwright project
+
+**Files:**
+
+- Modify: `playwright.config.ts` (add a `rbac` project + its setup)
+- Create: `e2e/rbac/.gitignore` (ignore `../.auth/*.json` is already covered; add report dirs if any)
+- Create: `e2e/rbac/support/.gitkeep`
+
+**Interfaces:**
+
+- Produces: a Playwright project named `rbac` whose `storageState` is resolved per-spec (not globally),
+  depending on a setup project `rbac-setup` that runs `e2e/rbac/rbac.setup.ts`.
+
+- [ ] **Step 1: Add the rbac setup + project to `playwright.config.ts`**
+
+In the `projects` array, append:
+
+```typescript
+{
+    name: 'rbac-setup',
+    testMatch: /rbac\/rbac\.setup\.ts/,
+},
+{
+    name: 'rbac',
+    testMatch: /rbac\/.*\.spec\.ts/,
+    use: { ...devices['Desktop Chrome'] },
+    dependencies: ['rbac-setup'],
+},
+```
+
+(No global `storageState` here — rbac specs open contexts per user via the `actingAs` fixture in Task 8.)
+
+- [ ] **Step 2: Verify config still parses**
+
+Run: `cd LiturgicalCalendarFrontend-e2e-rbac && yarn playwright test --list --project=rbac 2>&1 | head`
+Expected: lists 0 rbac specs (none yet) without a config error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add playwright.config.ts e2e/rbac/support/.gitkeep
+git commit -m "test(rbac): scaffold rbac Playwright project"
+```
+
+---
+
+### Task 2: User matrix (`users.ts`)
+
+**Files:**
+
+- Create: `e2e/rbac/support/users.ts`
+- Test: `e2e/rbac/support/users.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `type RbacUser = { id: string; email: string; password: string; role: 'admin' | 'calendar_editor';
+    fga: { relation: 'admin' | 'editor'; objectType: string; objectId: string } | null }`
+  - `const USERS: Record<string, RbacUser>` keyed by id (`super-admin`, `cei-admin`, …, `europe-editor`)
+  - `const SEEDED_USER_IDS: string[]` and `const REGISTRATION_USER_IDS: string[]` (`cei-admin`,
+    `usccb-editor`) — the two whose specs use real registration (their seeding is skipped in setup).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { USERS, SEEDED_USER_IDS, REGISTRATION_USER_IDS } from './users';
+
+test('matrix has 11 users with unique emails', () => {
+    const ids = Object.keys(USERS);
+    expect(ids).toHaveLength(11);
+    const emails = ids.map((i) => USERS[i].email);
+    expect(new Set(emails).size).toBe(11);
+});
+
+test('only super-admin holds the global admin role; others are calendar_editor', () => {
+    expect(USERS['super-admin'].role).toBe('admin');
+    expect(USERS['super-admin'].fga).toBeNull();
+    for (const id of Object.keys(USERS).filter((i) => i !== 'super-admin')) {
+        expect(USERS[id].role).toBe('calendar_editor');
+        expect(USERS[id].fga).not.toBeNull();
+    }
+});
+
+test('registration users are a subset not included in seeded ids', () => {
+    expect(REGISTRATION_USER_IDS).toEqual(['cei-admin', 'usccb-editor']);
+    for (const id of REGISTRATION_USER_IDS) expect(SEEDED_USER_IDS).not.toContain(id);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn playwright test e2e/rbac/support/users.test.ts --project=rbac-setup`
+Expected: FAIL — cannot find module `./users`.
+
+- [ ] **Step 3: Implement `users.ts`**
+
+```typescript
+export type RbacRelation = 'admin' | 'editor';
+
+export interface RbacUser {
+    id: string;
+    email: string;
+    password: string;
+    role: 'admin' | 'calendar_editor';
+    fga: { relation: RbacRelation; objectType: string; objectId: string } | null;
+}
+
+const pw = 'E2e-Test-Passw0rd!'; // shared test password; users live only in the test org
+
+function mk(id: string, role: RbacUser['role'], fga: RbacUser['fga']): RbacUser {
+    return { id, email: `${id}+e2e@litcal.test`, password: pw, role, fga };
+}
+
+export const USERS: Record<string, RbacUser> = {
+    'super-admin': mk('super-admin', 'admin', null),
+    'cei-admin': mk('cei-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'IT' }),
+    'cei-editor': mk('cei-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'IT' }),
+    'usccb-admin': mk('usccb-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'USA' }),
+    'usccb-editor': mk('usccb-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'USA' }),
+    'rome-admin': mk('rome-admin', 'calendar_editor', { relation: 'admin', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
+    'rome-editor': mk('rome-editor', 'calendar_editor', { relation: 'editor', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
+    'grc-admin': mk('grc-admin', 'calendar_editor', { relation: 'admin', objectType: 'general_roman_calendar', objectId: 'GRC' }),
+    'grc-editor': mk('grc-editor', 'calendar_editor', { relation: 'editor', objectType: 'general_roman_calendar', objectId: 'GRC' }),
+    'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: 'EU' }),
+    'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: 'EU' }),
+};
+
+export const REGISTRATION_USER_IDS = ['cei-admin', 'usccb-editor'];
+export const SEEDED_USER_IDS = Object.keys(USERS).filter((id) => !REGISTRATION_USER_IDS.includes(id));
+```
+
+> NOTE during execution: confirm the real object_ids (`EU` vs `Europe`; the GRC key + whether GRC is a
+> single resource or sub-resources `temporale`/`decrees`/Latin missals) against the API source data and
+> PR #339, and correct the matrix here — this is the single source of truth.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn playwright test e2e/rbac/support/users.test.ts --project=rbac-setup`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/users.ts e2e/rbac/support/users.test.ts
+git commit -m "test(rbac): user/permission seed matrix"
+```
+
+---
+
+### Task 3: Zitadel admin client (`support/zitadel.ts`)
+
+**Files:**
+
+- Create: `e2e/rbac/support/zitadel.ts`
+- Test: `e2e/rbac/support/zitadel.test.ts`
+
+**Interfaces:**
+
+- Consumes: env `ZITADEL_ISSUER`, `ZITADEL_MACHINE_TOKEN`, `ZITADEL_ORG_ID`, and `ZITADEL_PROJECT_ID`
+  (for role grants).
+- Produces a `ZitadelAdmin` class:
+  - `findUserIdByEmail(email: string): Promise<string | null>`
+  - `createVerifiedUser(u: { email: string; password: string; firstName: string; lastName: string }):
+    Promise<string>` — returns the new userId; email pre-verified, password set, not requiring change.
+  - `grantProjectRole(userId: string, role: string): Promise<void>`
+  - `deleteUser(userId: string): Promise<void>`
+  - all calls send `Authorization: Bearer <machine token>` and the org header
+    `x-zitadel-orgid: <ZITADEL_ORG_ID>`.
+
+- [ ] **Step 1: Write the failing test** (runs against the live Zitadel in the stack)
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { ZitadelAdmin } from './zitadel';
+
+test('create, find, grant role, delete a verified user', async () => {
+    const z = new ZitadelAdmin();
+    const email = `zit-probe+e2e@litcal.test`;
+    // clean slate
+    const existing = await z.findUserIdByEmail(email);
+    if (existing) await z.deleteUser(existing);
+
+    const id = await z.createVerifiedUser({ email, password: 'E2e-Test-Passw0rd!', firstName: 'Zit', lastName: 'Probe' });
+    expect(id).toMatch(/^\d+$/);
+    expect(await z.findUserIdByEmail(email)).toBe(id);
+
+    await z.grantProjectRole(id, 'calendar_editor'); // must not throw
+    await z.deleteUser(id);
+    expect(await z.findUserIdByEmail(email)).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn playwright test e2e/rbac/support/zitadel.test.ts --project=rbac-setup`
+Expected: FAIL — cannot find module `./zitadel`.
+
+- [ ] **Step 3: Implement `zitadel.ts`**
+
+Use the Zitadel v2 user API for create (`POST {issuer}/v2/users/human`) with
+`{ profile, email: { email, isVerified: true }, password: { password, changeRequired: false } }`,
+v2 search (`POST {issuer}/v2/users` with an `emailQuery`), v1 management grant
+(`POST {issuer}/management/v1/users/{id}/grants` with `{ projectId, roleKeys: [role] }`), and v2 delete
+(`DELETE {issuer}/v2/users/{id}`). Headers on every call:
+`{ Authorization: 'Bearer ' + token, 'Content-Type': 'application/json', 'x-zitadel-orgid': orgId }`.
+
+```typescript
+export class ZitadelAdmin {
+    private issuer = process.env.ZITADEL_ISSUER!.replace(/\/$/, '');
+    private token = process.env.ZITADEL_MACHINE_TOKEN!;
+    private orgId = process.env.ZITADEL_ORG_ID!;
+    private projectId = process.env.ZITADEL_PROJECT_ID!;
+
+    private async req(method: string, path: string, body?: unknown): Promise<any> {
+        const res = await fetch(`${this.issuer}${path}`, {
+            method,
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+                'Content-Type': 'application/json',
+                'x-zitadel-orgid': this.orgId,
+            },
+            body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        const text = await res.text();
+        if (!res.ok) throw new Error(`Zitadel ${method} ${path} -> ${res.status}: ${text}`);
+        return text ? JSON.parse(text) : {};
+    }
+
+    async findUserIdByEmail(email: string): Promise<string | null> {
+        const data = await this.req('POST', '/v2/users', {
+            queries: [{ emailQuery: { emailAddress: email } }],
+        });
+        const u = (data.result ?? [])[0];
+        return u?.userId ?? null;
+    }
+
+    async createVerifiedUser(u: { email: string; password: string; firstName: string; lastName: string }): Promise<string> {
+        const data = await this.req('POST', '/v2/users/human', {
+            profile: { givenName: u.firstName, familyName: u.lastName },
+            email: { email: u.email, isVerified: true },
+            password: { password: u.password, changeRequired: false },
+        });
+        return data.userId as string;
+    }
+
+    async grantProjectRole(userId: string, role: string): Promise<void> {
+        await this.req('POST', `/management/v1/users/${userId}/grants`, {
+            projectId: this.projectId,
+            roleKeys: [role],
+        });
+    }
+
+    async deleteUser(userId: string): Promise<void> {
+        await this.req('DELETE', `/v2/users/${userId}`);
+    }
+}
+```
+
+> NOTE during execution: exact v2 request/response field names vary slightly by Zitadel version; verify
+> against `scripts/setup-zitadel.sh` in the API repo (which already calls these APIs) and the running
+> instance, adjusting field names if a call 4xxs.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn playwright test e2e/rbac/support/zitadel.test.ts --project=rbac-setup`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/zitadel.ts e2e/rbac/support/zitadel.test.ts
+git commit -m "test(rbac): zitadel admin client (create/find/grant/delete user)"
+```
+
+---
+
+### Task 4: OpenFGA client (`support/fga.ts`)
+
+**Files:**
+
+- Create: `e2e/rbac/support/fga.ts`
+- Test: `e2e/rbac/support/fga.test.ts`
+
+**Interfaces:**
+
+- Consumes: env `OPENFGA_API_URL`, `OPENFGA_STORE_ID`, `OPENFGA_MODEL_ID`.
+- Produces a `Fga` class:
+  - `write(user: string, relation: string, object: string): Promise<void>` (idempotent — ignores
+    `already exists`)
+  - `delete(user: string, relation: string, object: string): Promise<void>` (idempotent — ignores
+    `not found`)
+  - `check(user: string, relation: string, object: string): Promise<boolean>`
+  - where `user` is `user:<zitadelUserId>` and `object` is `<objectType>:<objectId>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { Fga } from './fga';
+
+test('write, check true, delete, check false (idempotent)', async () => {
+    const f = new Fga();
+    const user = 'user:fga-probe-e2e';
+    const obj = 'national_calendar:ZZ';
+    await f.delete(user, 'admin', obj); // clean slate, must not throw
+    expect(await f.check(user, 'admin', obj)).toBe(false);
+    await f.write(user, 'admin', obj);
+    await f.write(user, 'admin', obj); // idempotent
+    expect(await f.check(user, 'admin', obj)).toBe(true);
+    await f.delete(user, 'admin', obj);
+    expect(await f.check(user, 'admin', obj)).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn playwright test e2e/rbac/support/fga.test.ts --project=rbac-setup`
+Expected: FAIL — cannot find module `./fga`.
+
+- [ ] **Step 3: Implement `fga.ts`**
+
+```typescript
+export class Fga {
+    private url = process.env.OPENFGA_API_URL!.replace(/\/$/, '');
+    private store = process.env.OPENFGA_STORE_ID!;
+    private model = process.env.OPENFGA_MODEL_ID!;
+
+    private async post(path: string, body: unknown): Promise<{ status: number; text: string }> {
+        const res = await fetch(`${this.url}/stores/${this.store}${path}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        return { status: res.status, text: await res.text() };
+    }
+
+    async write(user: string, relation: string, object: string): Promise<void> {
+        const r = await this.post('/write', {
+            writes: { tuple_keys: [{ user, relation, object }] },
+            authorization_model_id: this.model,
+        });
+        if (r.status >= 400 && !/already exists|duplicate/i.test(r.text)) {
+            throw new Error(`FGA write ${r.status}: ${r.text}`);
+        }
+    }
+
+    async delete(user: string, relation: string, object: string): Promise<void> {
+        const r = await this.post('/write', {
+            deletes: { tuple_keys: [{ user, relation, object }] },
+            authorization_model_id: this.model,
+        });
+        if (r.status >= 400 && !/not found|cannot delete/i.test(r.text)) {
+            throw new Error(`FGA delete ${r.status}: ${r.text}`);
+        }
+    }
+
+    async check(user: string, relation: string, object: string): Promise<boolean> {
+        const r = await this.post('/check', {
+            tuple_key: { user, relation, object },
+            authorization_model_id: this.model,
+        });
+        if (r.status >= 400) throw new Error(`FGA check ${r.status}: ${r.text}`);
+        return JSON.parse(r.text).allowed === true;
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn playwright test e2e/rbac/support/fga.test.ts --project=rbac-setup`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/fga.ts e2e/rbac/support/fga.test.ts
+git commit -m "test(rbac): openfga tuple client (write/delete/check)"
+```
+
+---
+
+### Task 5: Seed + login one user (`support/seed.ts`)
+
+**Files:**
+
+- Create: `e2e/rbac/support/seed.ts`
+- Test: `e2e/rbac/support/seed.test.ts`
+
+**Interfaces:**
+
+- Consumes: `USERS`, `ZitadelAdmin`, `Fga`.
+- Produces:
+  - `seedUser(id: string): Promise<string>` — upsert (delete-then-create) the Zitadel user, grant the
+    role, write the FGA tuple (if any); returns the Zitadel userId.
+  - `loginAndSaveState(id: string, request: APIRequestContext, page: Page): Promise<void>` — log the
+    user in via `POST {api}/auth/login` and save `storageState` to `e2e/.auth/<id>.json`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { seedUser } from './seed';
+import { Fga } from './fga';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+test('seedUser creates user, grants role, writes scoped tuple', async () => {
+    const id = await seedUser('cei-editor');
+    expect(id).toMatch(/^\d+$/);
+    const f = new Fga();
+    const u = USERS['cei-editor'].fga!;
+    expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+    // cleanup
+    await new ZitadelAdmin().deleteUser(id);
+    await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn playwright test e2e/rbac/support/seed.test.ts --project=rbac-setup`
+Expected: FAIL — cannot find module `./seed`.
+
+- [ ] **Step 3: Implement `seed.ts`**
+
+```typescript
+import { APIRequestContext, Page } from '@playwright/test';
+import * as path from 'path';
+import { USERS } from './users';
+import { ZitadelAdmin } from './zitadel';
+import { Fga } from './fga';
+
+export async function seedUser(id: string): Promise<string> {
+    const u = USERS[id];
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+
+    const existing = await z.findUserIdByEmail(u.email);
+    if (existing) {
+        if (u.fga) await f.delete(`user:${existing}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+        await z.deleteUser(existing);
+    }
+    const userId = await z.createVerifiedUser({ email: u.email, password: u.password, firstName: u.id, lastName: 'E2E' });
+    await z.grantProjectRole(userId, u.role);
+    if (u.fga) await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+    return userId;
+}
+
+export async function loginAndSaveState(id: string, page: Page): Promise<void> {
+    const u = USERS[id];
+    const apiUrl = new URL(`${process.env.API_PROTOCOL || 'http'}://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || '8000'}`).origin;
+    await page.goto(`${process.env.FRONTEND_URL || 'http://localhost:3000'}/`);
+    const ok = await page.evaluate(async (args) => {
+        const r = await fetch(`${args.apiUrl}/auth/login`, {
+            method: 'POST', credentials: 'include',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+            body: JSON.stringify({ username: args.email, password: args.password }),
+        });
+        return r.ok;
+    }, { apiUrl, email: u.email, password: u.password });
+    if (!ok) throw new Error(`login failed for ${id}`);
+    await page.context().storageState({ path: path.join(__dirname, '..', '..', '.auth', `${id}.json`) });
+}
+```
+
+> NOTE during execution: confirm `POST /auth/login` accepts the Zitadel-registered email+password (the
+> existing `auth.setup.ts` uses an admin password login; verify the API resolves a Zitadel user login the
+> same way, or switch to the OIDC password-grant / a token exchange if needed).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn playwright test e2e/rbac/support/seed.test.ts --project=rbac-setup`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/seed.ts e2e/rbac/support/seed.test.ts
+git commit -m "test(rbac): seed one user (zitadel + role + fga tuple)"
+```
+
+---
+
+### Task 6: Cleanup (`support/cleanup.ts`)
+
+**Files:**
+
+- Create: `e2e/rbac/support/cleanup.ts`
+- Test: `e2e/rbac/support/cleanup.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `truncateAppTables(): Promise<void>` — `docker compose exec -T db psql` TRUNCATE of
+    `access_requests`, `audit_log`, and the user-notification-state table.
+  - `deleteAllSeededUsers(): Promise<void>` — for each id in `USERS`, find by email, delete the Zitadel
+    user and its FGA tuple if present.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { truncateAppTables, deleteAllSeededUsers } from './cleanup';
+import { seedUser } from './seed';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+test('deleteAllSeededUsers removes a seeded user', async () => {
+    await seedUser('rome-editor');
+    await deleteAllSeededUsers();
+    expect(await new ZitadelAdmin().findUserIdByEmail(USERS['rome-editor'].email)).toBeNull();
+});
+
+test('truncateAppTables runs without error', async () => {
+    await truncateAppTables();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn playwright test e2e/rbac/support/cleanup.test.ts --project=rbac-setup`
+Expected: FAIL — cannot find module `./cleanup`.
+
+- [ ] **Step 3: Implement `cleanup.ts`**
+
+```typescript
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { USERS } from './users';
+import { ZitadelAdmin } from './zitadel';
+import { Fga } from './fga';
+
+const exec = promisify(execFile);
+
+export async function truncateAppTables(): Promise<void> {
+    const apiPath = process.env.API_REPO_PATH || '../LiturgicalCalendarAPI';
+    const sql = 'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
+    await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql], { cwd: apiPath });
+}
+
+export async function deleteAllSeededUsers(): Promise<void> {
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+    for (const id of Object.keys(USERS)) {
+        const u = USERS[id];
+        const zid = await z.findUserIdByEmail(u.email);
+        if (!zid) continue;
+        if (u.fga) await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+        await z.deleteUser(zid);
+    }
+}
+```
+
+> NOTE during execution: confirm the notification-state table name (`user_notification_state` vs actual)
+> from the API migrations; correct the TRUNCATE list. Confirm the psql user/db (`litcal`/`litcal`) against
+> `docker-compose.yml`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn playwright test e2e/rbac/support/cleanup.test.ts --project=rbac-setup`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/cleanup.ts e2e/rbac/support/cleanup.test.ts
+git commit -m "test(rbac): cleanup (truncate app tables, delete seeded users)"
+```
+
+---
+
+### Task 7: Global setup (`rbac.setup.ts`)
+
+**Files:**
+
+- Create: `e2e/rbac/rbac.setup.ts`
+
+**Interfaces:**
+
+- Consumes: `truncateAppTables`, `deleteAllSeededUsers`, `seedUser`, `loginAndSaveState`,
+  `SEEDED_USER_IDS`.
+- Produces: 9 `e2e/.auth/<id>.json` session files (all `SEEDED_USER_IDS`), with a clean DB + clean
+  Zitadel/FGA state beforehand. (The 2 `REGISTRATION_USER_IDS` are intentionally not seeded.)
+
+- [ ] **Step 1: Implement the setup**
+
+```typescript
+import { test as setup } from '@playwright/test';
+import { truncateAppTables, deleteAllSeededUsers } from './support/cleanup';
+import { seedUser, loginAndSaveState } from './support/seed';
+import { SEEDED_USER_IDS } from './support/users';
+
+setup('seed rbac users', async ({ page }) => {
+    setup.setTimeout(180_000);
+    await deleteAllSeededUsers();
+    await truncateAppTables();
+    for (const id of SEEDED_USER_IDS) {
+        await seedUser(id);
+        await loginAndSaveState(id, page);
+    }
+});
+```
+
+- [ ] **Step 2: Run the setup standalone**
+
+Run: `yarn playwright test --project=rbac-setup`
+Expected: PASS; `ls e2e/.auth` shows 9 `<id>.json` files (super-admin, cei-editor, usccb-admin, …) and
+NOT cei-admin/usccb-editor.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/rbac/rbac.setup.ts
+git commit -m "test(rbac): global setup seeds 9 users + saves sessions"
+```
+
+---
+
+### Task 8: `actingAs` fixture (`support/actingAs.ts`)
+
+**Files:**
+
+- Create: `e2e/rbac/support/actingAs.ts`
+- Test: `e2e/rbac/support/actingAs.test.ts`
+
+**Interfaces:**
+
+- Consumes: per-user `e2e/.auth/<id>.json` produced by Task 7.
+- Produces: `actingAs(browser: Browser, id: string): Promise<{ context: BrowserContext; page: Page }>` —
+  opens a context with that user's storageState and a ready page; caller closes the context.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { actingAs } from './actingAs';
+
+test('actingAs super-admin is authenticated', async ({ browser }) => {
+    const { context, page } = await actingAs(browser, 'super-admin');
+    const apiUrl = new URL(`${process.env.API_PROTOCOL || 'http'}://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || '8000'}`).origin;
+    const me = await page.evaluate(async (u) => (await fetch(`${u}/auth/me`, { credentials: 'include' })).status, apiUrl);
+    expect(me).toBe(200);
+    await context.close();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn playwright test e2e/rbac/support/actingAs.test.ts --project=rbac`
+Expected: FAIL — cannot find module `./actingAs`.
+
+- [ ] **Step 3: Implement `actingAs.ts`**
+
+```typescript
+import { Browser, BrowserContext, Page } from '@playwright/test';
+import * as path from 'path';
+
+export async function actingAs(browser: Browser, id: string): Promise<{ context: BrowserContext; page: Page }> {
+    const context = await browser.newContext({ storageState: path.join(__dirname, '..', '..', '.auth', `${id}.json`) });
+    const page = await context.newPage();
+    return { context, page };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn playwright test e2e/rbac/support/actingAs.test.ts --project=rbac`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/actingAs.ts e2e/rbac/support/actingAs.test.ts
+git commit -m "test(rbac): actingAs fixture (per-user browser context)"
+```
+
+---
+
+### Task 9: End-to-end smoke spec — dashboard card scoping
+
+**Files:**
+
+- Create: `e2e/rbac/00-smoke-dashboard-scoping.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `actingAs`. Asserts the harness produces *differently-scoped* sessions by checking the admin
+  dashboard for two users.
+
+- [ ] **Step 1: Write the spec (the deliverable)**
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+
+test('super-admin sees the admin section; cei-editor does not', async ({ browser }) => {
+    const sa = await actingAs(browser, 'super-admin');
+    await sa.page.goto('/admin-dashboard.php');
+    // super-admin sees the admin-only section (Users/Permissions); use a stable selector present only for admins
+    await expect(sa.page.locator('a[href="admin-users.php"]')).toBeVisible();
+    await sa.context.close();
+
+    const ed = await actingAs(browser, 'cei-editor');
+    await ed.page.goto('/admin-dashboard.php');
+    // a calendar_editor (non-admin) must NOT see the admin-only Users link
+    await expect(ed.page.locator('a[href="admin-users.php"]')).toHaveCount(0);
+    // but DOES see editor cards (e.g. National)
+    await expect(ed.page.locator('.admin-block[data-block-id="national"]')).toBeVisible();
+    await ed.context.close();
+});
+```
+
+- [ ] **Step 2: Run the spec end-to-end**
+
+Run: `yarn playwright test e2e/rbac/00-smoke-dashboard-scoping.spec.ts --project=rbac`
+Expected: PASS (setup project runs first, seeds users, then the spec passes). If a selector is wrong,
+inspect the real DOM (`admin-dashboard.php`, `includes/admin-blocks.php`) and correct the locator — do not
+weaken the assertion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/rbac/00-smoke-dashboard-scoping.spec.ts
+git commit -m "test(rbac): smoke spec proves per-user dashboard scoping"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (this phase):** Tasks 1–9 cover the harness sections of the spec — Playwright project,
+seed matrix, seeding (Zitadel + FGA + role), per-user sessions, `actingAs`, cleanup, and a scoping smoke
+spec. The 11 narrative scenarios + real-registration + Mailpit + revoke/negative/scoped-edit/session
+specs are **Phase 2** (separate plan), built on this harness — out of scope here by design.
+
+**Placeholder scan:** No "TBD/handle errors/similar to Task N". The three `> NOTE during execution`
+callouts are explicit verification points against the live stack (object_ids, Zitadel field names, table
+names / login mechanism), not deferred work — each names exactly what to confirm and where.
+
+**Type consistency:** `RbacUser`/`USERS`/`SEEDED_USER_IDS`/`REGISTRATION_USER_IDS` (Task 2) are consumed
+unchanged in Tasks 5–8. `ZitadelAdmin` methods (Task 3) and `Fga` methods (Task 4) are used with the same
+signatures in `seed.ts`/`cleanup.ts`. `actingAs` returns `{ context, page }` and is used that way in
+Tasks 8–9.
+
+## Phase 2 (separate plan, after harness is green)
+
+Scenario specs `01`–`11` from the design spec, each: seed its precondition grants, drive the UI as the
+relevant user(s) via `actingAs`, assert request visibility/routing + notifications + dashboard scoping,
+and clean up. Includes the two real-registration specs (Zitadel UI + Mailpit) and the negative-auth,
+revoke-lifecycle, scoped-edit, and session-resilience specs. Written against the real DOM once the harness
+runs green.

--- a/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
@@ -22,8 +22,9 @@ Mailpit API (Phase 2), the project's `docker-compose` stack.
 - Playwright runs **serial, single worker** (shared API/DB/FGA state) — keep `fullyParallel: false`.
 - All seeded users use email pattern `<user-id>+e2e@litcal.test` so cleanup targets only test users.
 - All seeded users live in the **LiturgicalCalendar Zitadel org** (id from `ZITADEL_ORG_ID`).
-- Reuse existing env: `API_PROTOCOL/HOST/PORT`, `FRONTEND_URL`, `ZITADEL_ISSUER`,
+- Reuse existing env: `API_PROTOCOL/HOST/PORT`, `FRONTEND_URL`, `ZITADEL_ISSUER`, `ZITADEL_CLIENT_ID`,
   `ZITADEL_MACHINE_TOKEN`, `ZITADEL_ORG_ID`, `OPENFGA_API_URL`, `OPENFGA_STORE_ID`, `OPENFGA_MODEL_ID`.
+  (`ZITADEL_CLIENT_ID` is the OIDC client reused for the headless PKCE login flow in Task 5.)
 - TypeScript strict: the suite typechecks under `e2e/tsconfig.json` (`yarn typecheck`).
 - Project role for non-super users is `calendar_editor`; `super-admin` gets the global `admin` role.
 
@@ -286,7 +287,7 @@ export class ZitadelAdmin {
                 Authorization: `Bearer ${this.token}`,
                 'Content-Type': 'application/json',
                 'x-zitadel-orgid': this.orgId,
-                Host: 'localhost',
+                Host: new URL(this.issuer).hostname,
             },
             body: body === undefined ? undefined : JSON.stringify(body),
         });
@@ -524,8 +525,13 @@ import { ZitadelAdmin } from './zitadel';
 import { Fga } from './fga';
 
 const ISSUER = (process.env.ZITADEL_ISSUER || 'http://localhost:8080').replace(/\/$/, '');
-const CLIENT_ID = process.env.ZITADEL_CLIENT_ID!;            // Frontend OIDC client (authorization_code + PKCE)
+// Reuse the existing Zitadel OIDC client (authorization_code + PKCE, public/no-secret) for the
+// headless login flow. We drive it server-side via the session API rather than a browser redirect.
+const CLIENT_ID = process.env.ZITADEL_CLIENT_ID!;
 const REDIRECT_URI = `${process.env.FRONTEND_URL || 'http://localhost:3000'}/auth/callback.php`;
+// Zitadel matches requests by its configured external domain; send Host = the issuer hostname
+// (port-stripped) rather than hardcoding 'localhost', so a non-localhost ZITADEL_ISSUER still works.
+const HOST = new URL(ISSUER).hostname;
 const b64url = (b: Buffer) => b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 
 export async function seedUser(id: string): Promise<string> {
@@ -550,7 +556,7 @@ export async function seedUser(id: string): Promise<string> {
  * Returns the access_token to be set as the `litcal_access_token` cookie.
  */
 export async function oidcLogin(email: string, password: string, loginClientToken: string): Promise<string> {
-    const Hl = { Authorization: `Bearer ${loginClientToken}`, 'Content-Type': 'application/json', Host: 'localhost' };
+    const Hl = { Authorization: `Bearer ${loginClientToken}`, 'Content-Type': 'application/json', Host: HOST };
     const json = async (r: Response) => { const t = await r.text(); if (!r.ok) throw new Error(`${r.url} -> ${r.status}: ${t}`); return JSON.parse(t); };
 
     // 1. Create a password-checked session (login-client token).
@@ -566,7 +572,7 @@ export async function oidcLogin(email: string, password: string, loginClientToke
         response_type: 'code', client_id: CLIENT_ID, redirect_uri: REDIRECT_URI,
         scope: 'openid profile email', code_challenge: challenge, code_challenge_method: 'S256', state: id_state(),
     });
-    const authResp = await fetch(`${ISSUER}/oauth/v2/authorize?${qs}`, { headers: { Host: 'localhost' }, redirect: 'manual' });
+    const authResp = await fetch(`${ISSUER}/oauth/v2/authorize?${qs}`, { headers: { Host: HOST }, redirect: 'manual' });
     const loc = authResp.headers.get('location') || '';
     const arMatch = loc.match(/authRequest(?:Id)?=([^&]+)/);
     if (!arMatch) throw new Error(`authorize did not return an authRequest id: ${authResp.status} ${loc}`);
@@ -584,7 +590,7 @@ export async function oidcLogin(email: string, password: string, loginClientToke
     // 4. Exchange the code for tokens (public client, PKCE — no client secret).
     const form = new URLSearchParams({ grant_type: 'authorization_code', code, redirect_uri: REDIRECT_URI, client_id: CLIENT_ID, code_verifier: verifier });
     const tok = await json(await fetch(`${ISSUER}/oauth/v2/token`, {
-        method: 'POST', headers: { Host: 'localhost', 'Content-Type': 'application/x-www-form-urlencoded' }, body: form,
+        method: 'POST', headers: { Host: HOST, 'Content-Type': 'application/x-www-form-urlencoded' }, body: form,
     }));
     if (!tok.access_token) throw new Error(`token exchange returned no access_token: ${JSON.stringify(tok)}`);
     return tok.access_token as string;

--- a/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
@@ -691,9 +691,10 @@ import { Fga } from './fga';
 const exec = promisify(execFile);
 
 export async function truncateAppTables(): Promise<void> {
-    const apiPath = process.env.API_REPO_PATH || '../LiturgicalCalendarAPI';
+    // The active docker stack is the FRONTEND compose project (this repo root), not the API repo's.
+    // Run `docker compose exec` from the frontend repo root so it targets the running `db` service.
     const sql = 'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
-    await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql], { cwd: apiPath });
+    await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql]);
 }
 
 export async function deleteAllSeededUsers(): Promise<void> {

--- a/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
@@ -27,6 +27,22 @@ Mailpit API (Phase 2), the project's `docker-compose` stack.
 - TypeScript strict: the suite typechecks under `e2e/tsconfig.json` (`yarn typecheck`).
 - Project role for non-super users is `calendar_editor`; `super-admin` gets the global `admin` role.
 
+## Environment status (pre-flight done 2026-06-21)
+
+- Run the **frontend** docker stack (`docker compose up -d` in the frontend dir; compose project
+  `liturgicalcalendarfrontend`) — NOT the API repo's stack. They share ports, so only one runs at a time.
+  Host ports: api 8000, frontend 3000, zitadel 8080, openfga 8083, mailpit 8025. WSL single-file
+  bind-mount flakes → `docker compose up -d --force-recreate litcal-frontend`.
+- Playwright runs on the **host** and loads `.env.development`. Already added there:
+  `ZITADEL_ORG_ID=372235991517298694` and `ZITADEL_MACHINE_TOKEN` (the `test-service-account` token).
+  Project/store/model IDs already match the running stack.
+- **Login mechanism (validated):** `/auth/login` only authenticates the configured admin, NOT Zitadel
+  users. Scoped users authenticate via a Zitadel **OIDC access token** in the `litcal_access_token` cookie
+  (validated by `OidcAuthMiddleware`); verify a user via the **frontend `/auth/me.php`** (the API's
+  `/auth/me` is HS256/admin-only). The headless token flow (session API + PKCE) is implemented in Task 5
+  and was proven end-to-end. The session API needs a `login-client` PAT minted at setup (Task 7). See the
+  `project_rbac_e2e_harness` memory for the full validated sequence.
+
 ---
 
 ### Task 1: Scaffold the `rbac` Playwright project
@@ -48,6 +64,12 @@ In the `projects` array, append:
 
 ```typescript
 {
+    // Unit/integration tests for the support modules (users/zitadel/fga/seed/cleanup).
+    // They run against the live stack but do NOT need the full seed, so no dependency.
+    name: 'rbac-support',
+    testMatch: /rbac\/support\/.*\.test\.ts/,
+},
+{
     name: 'rbac-setup',
     testMatch: /rbac\/rbac\.setup\.ts/,
 },
@@ -59,7 +81,8 @@ In the `projects` array, append:
 },
 ```
 
-(No global `storageState` here — rbac specs open contexts per user via the `actingAs` fixture in Task 8.)
+(No global `storageState` here — rbac specs open contexts per user via the `actingAs` fixture in Task 8.
+Support `*.test.ts` files run under `--project=rbac-support`; `*.spec.ts` under `--project=rbac`.)
 
 - [ ] **Step 2: Verify config still parses**
 
@@ -121,7 +144,7 @@ test('registration users are a subset not included in seeded ids', () => {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `yarn playwright test e2e/rbac/support/users.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/users.test.ts --project=rbac-support`
 Expected: FAIL — cannot find module `./users`.
 
 - [ ] **Step 3: Implement `users.ts`**
@@ -147,27 +170,29 @@ export const USERS: Record<string, RbacUser> = {
     'super-admin': mk('super-admin', 'admin', null),
     'cei-admin': mk('cei-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'IT' }),
     'cei-editor': mk('cei-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'IT' }),
-    'usccb-admin': mk('usccb-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'USA' }),
-    'usccb-editor': mk('usccb-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'USA' }),
+    'usccb-admin': mk('usccb-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'US' }),
+    'usccb-editor': mk('usccb-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'US' }),
     'rome-admin': mk('rome-admin', 'calendar_editor', { relation: 'admin', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
     'rome-editor': mk('rome-editor', 'calendar_editor', { relation: 'editor', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
-    'grc-admin': mk('grc-admin', 'calendar_editor', { relation: 'admin', objectType: 'general_roman_calendar', objectId: 'GRC' }),
-    'grc-editor': mk('grc-editor', 'calendar_editor', { relation: 'editor', objectType: 'general_roman_calendar', objectId: 'GRC' }),
-    'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: 'EU' }),
-    'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: 'EU' }),
+    'grc-admin': mk('grc-admin', 'calendar_editor', { relation: 'admin', objectType: 'general_roman_calendar', objectId: 'temporale' }),
+    'grc-editor': mk('grc-editor', 'calendar_editor', { relation: 'editor', objectType: 'general_roman_calendar', objectId: 'temporale' }),
+    'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: 'Europe' }),
+    'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: 'Europe' }),
 };
 
 export const REGISTRATION_USER_IDS = ['cei-admin', 'usccb-editor'];
 export const SEEDED_USER_IDS = Object.keys(USERS).filter((id) => !REGISTRATION_USER_IDS.includes(id));
 ```
 
-> NOTE during execution: confirm the real object_ids (`EU` vs `Europe`; the GRC key + whether GRC is a
-> single resource or sub-resources `temporale`/`decrees`/Latin missals) against the API source data and
-> PR #339, and correct the matrix here — this is the single source of truth.
+> RESOLVED (verified against API source data + live stack, 2026-06-21): nation codes are `IT`/`US` (NOT
+> `USA`); wider_region is `Europe` (NOT `EU`); `general_roman_calendar` is one of the enumerated ids
+> `temporale,EDITIO_TYPICA_1970,EDITIO_TYPICA_2002,EDITIO_TYPICA_2008,decrees` (NOT `GRC`) — using
+> `temporale`; `diocesan_calendar:romamo_it` confirmed. Zitadel project roles `admin` + `calendar_editor`
+> both confirmed valid. This matrix is the single source of truth.
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `yarn playwright test e2e/rbac/support/users.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/users.test.ts --project=rbac-support`
 Expected: PASS (3 tests).
 
 - [ ] **Step 5: Commit**
@@ -192,12 +217,23 @@ git commit -m "test(rbac): user/permission seed matrix"
   (for role grants).
 - Produces a `ZitadelAdmin` class:
   - `findUserIdByEmail(email: string): Promise<string | null>`
+  - `findUserIdByUsername(userName: string): Promise<string | null>` — used to locate the `login-client`
+    machine user.
   - `createVerifiedUser(u: { email: string; password: string; firstName: string; lastName: string }):
     Promise<string>` — returns the new userId; email pre-verified, password set, not requiring change.
   - `grantProjectRole(userId: string, role: string): Promise<void>`
   - `deleteUser(userId: string): Promise<void>`
-  - all calls send `Authorization: Bearer <machine token>` and the org header
+  - `mintPat(userId: string): Promise<{ tokenId: string; token: string }>` — create a Personal Access
+    Token for a (machine) user via `POST /management/v1/users/{userId}/pats`.
+  - `deletePat(userId: string, tokenId: string): Promise<void>`
+  - all calls send `Authorization: Bearer <machine token>`, `Host: localhost` (Zitadel's ExternalDomain
+    is `localhost`; Node `fetch` CAN set the Host header), and the org header
     `x-zitadel-orgid: <ZITADEL_ORG_ID>`.
+
+> NOTE: The `ZITADEL_MACHINE_TOKEN` belongs to the `test-service-account` machine user. It can create
+> users / grant roles, but CANNOT create Zitadel sessions (lacks `IAM_LOGIN_CLIENT`). The login flow
+> (Task 5) needs a session-capable token; mint a fresh PAT for the `login-client` user with `mintPat`
+> and use that (the volume's `login-client.pat` is stale). Verified against the live stack 2026-06-21.
 
 - [ ] **Step 1: Write the failing test** (runs against the live Zitadel in the stack)
 
@@ -224,7 +260,7 @@ test('create, find, grant role, delete a verified user', async () => {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `yarn playwright test e2e/rbac/support/zitadel.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/zitadel.test.ts --project=rbac-support`
 Expected: FAIL — cannot find module `./zitadel`.
 
 - [ ] **Step 3: Implement `zitadel.ts`**
@@ -250,6 +286,7 @@ export class ZitadelAdmin {
                 Authorization: `Bearer ${this.token}`,
                 'Content-Type': 'application/json',
                 'x-zitadel-orgid': this.orgId,
+                Host: 'localhost',
             },
             body: body === undefined ? undefined : JSON.stringify(body),
         });
@@ -285,6 +322,25 @@ export class ZitadelAdmin {
     async deleteUser(userId: string): Promise<void> {
         await this.req('DELETE', `/v2/users/${userId}`);
     }
+
+    async findUserIdByUsername(userName: string): Promise<string | null> {
+        const data = await this.req('POST', '/v2/users', {
+            queries: [{ userNameQuery: { userName } }],
+        });
+        const u = (data.result ?? [])[0];
+        return u?.userId ?? null;
+    }
+
+    async mintPat(userId: string): Promise<{ tokenId: string; token: string }> {
+        const data = await this.req('POST', `/management/v1/users/${userId}/pats`, {
+            expirationDate: '2030-01-01T00:00:00Z',
+        });
+        return { tokenId: data.tokenId as string, token: data.token as string };
+    }
+
+    async deletePat(userId: string, tokenId: string): Promise<void> {
+        await this.req('DELETE', `/management/v1/users/${userId}/pats/${tokenId}`);
+    }
 }
 ```
 
@@ -294,7 +350,7 @@ export class ZitadelAdmin {
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `yarn playwright test e2e/rbac/support/zitadel.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/zitadel.test.ts --project=rbac-support`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -346,7 +402,7 @@ test('write, check true, delete, check false (idempotent)', async () => {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `yarn playwright test e2e/rbac/support/fga.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/fga.test.ts --project=rbac-support`
 Expected: FAIL — cannot find module `./fga`.
 
 - [ ] **Step 3: Implement `fga.ts`**
@@ -399,7 +455,7 @@ export class Fga {
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `yarn playwright test e2e/rbac/support/fga.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/fga.test.ts --project=rbac-support`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -424,8 +480,12 @@ git commit -m "test(rbac): openfga tuple client (write/delete/check)"
 - Produces:
   - `seedUser(id: string): Promise<string>` — upsert (delete-then-create) the Zitadel user, grant the
     role, write the FGA tuple (if any); returns the Zitadel userId.
-  - `loginAndSaveState(id: string, request: APIRequestContext, page: Page): Promise<void>` — log the
-    user in via `POST {api}/auth/login` and save `storageState` to `e2e/.auth/<id>.json`.
+  - `oidcLogin(email: string, password: string, loginClientToken: string): Promise<string>` — run the
+    headless Zitadel session→PKCE flow and return a Zitadel OIDC access token (JWT).
+  - `loginAndSaveState(id: string, loginClientToken: string): Promise<void>` — call `oidcLogin` and write
+    a Playwright `storageState` to `e2e/.auth/<id>.json` containing the `litcal_access_token` cookie
+    (domain `localhost`, HttpOnly). The `loginClientToken` is a session-capable PAT minted for the
+    `login-client` user in setup (Task 7).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -450,17 +510,23 @@ test('seedUser creates user, grants role, writes scoped tuple', async () => {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `yarn playwright test e2e/rbac/support/seed.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/seed.test.ts --project=rbac-support`
 Expected: FAIL — cannot find module `./seed`.
 
 - [ ] **Step 3: Implement `seed.ts`**
 
 ```typescript
-import { APIRequestContext, Page } from '@playwright/test';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { USERS } from './users';
 import { ZitadelAdmin } from './zitadel';
 import { Fga } from './fga';
+
+const ISSUER = (process.env.ZITADEL_ISSUER || 'http://localhost:8080').replace(/\/$/, '');
+const CLIENT_ID = process.env.ZITADEL_CLIENT_ID!;            // Frontend OIDC client (authorization_code + PKCE)
+const REDIRECT_URI = `${process.env.FRONTEND_URL || 'http://localhost:3000'}/auth/callback.php`;
+const b64url = (b: Buffer) => b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 
 export async function seedUser(id: string): Promise<string> {
     const u = USERS[id];
@@ -478,30 +544,84 @@ export async function seedUser(id: string): Promise<string> {
     return userId;
 }
 
-export async function loginAndSaveState(id: string, page: Page): Promise<void> {
+/**
+ * Obtain a Zitadel OIDC access token (JWT) for a user via the headless session→PKCE flow.
+ * `loginClientToken` is a session-capable PAT (minted for the `login-client` user in setup).
+ * Returns the access_token to be set as the `litcal_access_token` cookie.
+ */
+export async function oidcLogin(email: string, password: string, loginClientToken: string): Promise<string> {
+    const Hl = { Authorization: `Bearer ${loginClientToken}`, 'Content-Type': 'application/json', Host: 'localhost' };
+    const json = async (r: Response) => { const t = await r.text(); if (!r.ok) throw new Error(`${r.url} -> ${r.status}: ${t}`); return JSON.parse(t); };
+
+    // 1. Create a password-checked session (login-client token).
+    const s = await json(await fetch(`${ISSUER}/v2/sessions`, {
+        method: 'POST', headers: Hl,
+        body: JSON.stringify({ checks: { user: { loginName: email }, password: { password } } }),
+    }));
+
+    // 2. Start an OIDC auth request (Frontend client, PKCE S256) → 302 to login-v2 with ?authRequest=...
+    const verifier = b64url(crypto.randomBytes(32));
+    const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+    const qs = new URLSearchParams({
+        response_type: 'code', client_id: CLIENT_ID, redirect_uri: REDIRECT_URI,
+        scope: 'openid profile email', code_challenge: challenge, code_challenge_method: 'S256', state: id_state(),
+    });
+    const authResp = await fetch(`${ISSUER}/oauth/v2/authorize?${qs}`, { headers: { Host: 'localhost' }, redirect: 'manual' });
+    const loc = authResp.headers.get('location') || '';
+    const arMatch = loc.match(/authRequest(?:Id)?=([^&]+)/);
+    if (!arMatch) throw new Error(`authorize did not return an authRequest id: ${authResp.status} ${loc}`);
+    const authRequestId = decodeURIComponent(arMatch[1]);
+
+    // 3. Finalize the auth request with the session (login-client token) → callbackUrl with ?code=
+    const fin = await json(await fetch(`${ISSUER}/v2/oidc/auth_requests/${authRequestId}`, {
+        method: 'POST', headers: Hl,
+        body: JSON.stringify({ session: { sessionId: s.sessionId, sessionToken: s.sessionToken } }),
+    }));
+    const codeMatch = String(fin.callbackUrl || '').match(/[?&]code=([^&]+)/);
+    if (!codeMatch) throw new Error(`finalize returned no code: ${JSON.stringify(fin)}`);
+    const code = decodeURIComponent(codeMatch[1]);
+
+    // 4. Exchange the code for tokens (public client, PKCE — no client secret).
+    const form = new URLSearchParams({ grant_type: 'authorization_code', code, redirect_uri: REDIRECT_URI, client_id: CLIENT_ID, code_verifier: verifier });
+    const tok = await json(await fetch(`${ISSUER}/oauth/v2/token`, {
+        method: 'POST', headers: { Host: 'localhost', 'Content-Type': 'application/x-www-form-urlencoded' }, body: form,
+    }));
+    if (!tok.access_token) throw new Error(`token exchange returned no access_token: ${JSON.stringify(tok)}`);
+    return tok.access_token as string;
+}
+
+// state param need only be opaque/unique-ish; avoid Math.random for determinism-friendliness.
+function id_state(): string { return b64url(crypto.randomBytes(8)); }
+
+/**
+ * Log a user in headlessly and write a Playwright storageState file containing the
+ * `litcal_access_token` cookie. Cookie domain is `localhost` (port-agnostic) so it is sent to
+ * both the frontend (:3000) and the API (:8000). The real cookie is HttpOnly.
+ */
+export async function loginAndSaveState(id: string, loginClientToken: string): Promise<void> {
     const u = USERS[id];
-    const apiUrl = new URL(`${process.env.API_PROTOCOL || 'http'}://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || '8000'}`).origin;
-    await page.goto(`${process.env.FRONTEND_URL || 'http://localhost:3000'}/`);
-    const ok = await page.evaluate(async (args) => {
-        const r = await fetch(`${args.apiUrl}/auth/login`, {
-            method: 'POST', credentials: 'include',
-            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-            body: JSON.stringify({ username: args.email, password: args.password }),
-        });
-        return r.ok;
-    }, { apiUrl, email: u.email, password: u.password });
-    if (!ok) throw new Error(`login failed for ${id}`);
-    await page.context().storageState({ path: path.join(__dirname, '..', '..', '.auth', `${id}.json`) });
+    const accessToken = await oidcLogin(u.email, u.password, loginClientToken);
+    const storageState = {
+        cookies: [{
+            name: 'litcal_access_token', value: accessToken, domain: 'localhost', path: '/',
+            expires: -1, httpOnly: true, secure: false, sameSite: 'Lax' as const,
+        }],
+        origins: [],
+    };
+    const authPath = path.join(__dirname, '..', '..', '.auth', `${id}.json`);
+    fs.mkdirSync(path.dirname(authPath), { recursive: true });
+    fs.writeFileSync(authPath, JSON.stringify(storageState, null, 2));
 }
 ```
 
-> NOTE during execution: confirm `POST /auth/login` accepts the Zitadel-registered email+password (the
-> existing `auth.setup.ts` uses an admin password login; verify the API resolves a Zitadel user login the
-> same way, or switch to the OIDC password-grant / a token exchange if needed).
+> Validated end-to-end against the live frontend stack on 2026-06-21 (session 201 → finalize 200 → token
+> 200; frontend `/auth/me.php` returns `{authenticated:true, roles:[...]}`). `/auth/login` was confirmed
+> NOT usable for Zitadel users (it only authenticates the configured admin). All Zitadel calls require the
+> `Host: localhost` header.
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `yarn playwright test e2e/rbac/support/seed.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/seed.test.ts --project=rbac-support`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -550,7 +670,7 @@ test('truncateAppTables runs without error', async () => {
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `yarn playwright test e2e/rbac/support/cleanup.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/cleanup.test.ts --project=rbac-support`
 Expected: FAIL — cannot find module `./cleanup`.
 
 - [ ] **Step 3: Implement `cleanup.ts`**
@@ -583,13 +703,13 @@ export async function deleteAllSeededUsers(): Promise<void> {
 }
 ```
 
-> NOTE during execution: confirm the notification-state table name (`user_notification_state` vs actual)
-> from the API migrations; correct the TRUNCATE list. Confirm the psql user/db (`litcal`/`litcal`) against
-> `docker-compose.yml`.
+> RESOLVED (verified against the live db 2026-06-21): db/user are `litcal`/`litcal`; tables
+> `access_requests`, `audit_log`, `user_notification_state` all exist. The TRUNCATE list and psql
+> user/db in the code above are correct as written.
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `yarn playwright test e2e/rbac/support/cleanup.test.ts --project=rbac-setup`
+Run: `yarn playwright test e2e/rbac/support/cleanup.test.ts --project=rbac-support`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -621,14 +741,27 @@ import { test as setup } from '@playwright/test';
 import { truncateAppTables, deleteAllSeededUsers } from './support/cleanup';
 import { seedUser, loginAndSaveState } from './support/seed';
 import { SEEDED_USER_IDS } from './support/users';
+import { ZitadelAdmin } from './support/zitadel';
 
-setup('seed rbac users', async ({ page }) => {
+setup('seed rbac users', async () => {
     setup.setTimeout(180_000);
-    await deleteAllSeededUsers();
-    await truncateAppTables();
-    for (const id of SEEDED_USER_IDS) {
-        await seedUser(id);
-        await loginAndSaveState(id, page);
+    const z = new ZitadelAdmin();
+
+    // The session API needs IAM_LOGIN_CLIENT, which the machine token lacks. Mint a fresh,
+    // session-capable PAT for the `login-client` user and delete it when done.
+    const loginClientUserId = await z.findUserIdByUsername('login-client');
+    if (!loginClientUserId) throw new Error('login-client machine user not found in Zitadel');
+    const pat = await z.mintPat(loginClientUserId);
+
+    try {
+        await deleteAllSeededUsers();
+        await truncateAppTables();
+        for (const id of SEEDED_USER_IDS) {
+            await seedUser(id);
+            await loginAndSaveState(id, pat.token);
+        }
+    } finally {
+        await z.deletePat(loginClientUserId, pat.tokenId);
     }
 });
 ```
@@ -653,7 +786,7 @@ git commit -m "test(rbac): global setup seeds 9 users + saves sessions"
 **Files:**
 
 - Create: `e2e/rbac/support/actingAs.ts`
-- Test: `e2e/rbac/support/actingAs.test.ts`
+- Test: `e2e/rbac/support/actingAs.spec.ts`
 
 **Interfaces:**
 
@@ -667,18 +800,25 @@ git commit -m "test(rbac): global setup seeds 9 users + saves sessions"
 import { test, expect } from '@playwright/test';
 import { actingAs } from './actingAs';
 
-test('actingAs super-admin is authenticated', async ({ browser }) => {
+test('actingAs super-admin is authenticated with the admin role', async ({ browser }) => {
     const { context, page } = await actingAs(browser, 'super-admin');
-    const apiUrl = new URL(`${process.env.API_PROTOCOL || 'http'}://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || '8000'}`).origin;
-    const me = await page.evaluate(async (u) => (await fetch(`${u}/auth/me`, { credentials: 'include' })).status, apiUrl);
-    expect(me).toBe(200);
+    // In OIDC mode the frontend validates the litcal_access_token cookie via its own /auth/me.php
+    // (the API's /auth/me is HS256/admin-only and rejects Zitadel OIDC tokens).
+    await page.goto('/');
+    const me = await page.evaluate(async () => {
+        const r = await fetch('/auth/me.php', { credentials: 'include', headers: { Accept: 'application/json' } });
+        return { status: r.status, body: await r.json() };
+    });
+    expect(me.status).toBe(200);
+    expect(me.body.authenticated).toBe(true);
+    expect(me.body.user?.roles ?? me.body.roles).toContain('admin');
     await context.close();
 });
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `yarn playwright test e2e/rbac/support/actingAs.test.ts --project=rbac`
+Run: `yarn playwright test e2e/rbac/support/actingAs.spec.ts --project=rbac`
 Expected: FAIL — cannot find module `./actingAs`.
 
 - [ ] **Step 3: Implement `actingAs.ts`**
@@ -696,13 +836,13 @@ export async function actingAs(browser: Browser, id: string): Promise<{ context:
 
 - [ ] **Step 4: Run to verify it passes**
 
-Run: `yarn playwright test e2e/rbac/support/actingAs.test.ts --project=rbac`
+Run: `yarn playwright test e2e/rbac/support/actingAs.spec.ts --project=rbac`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add e2e/rbac/support/actingAs.ts e2e/rbac/support/actingAs.test.ts
+git add e2e/rbac/support/actingAs.ts e2e/rbac/support/actingAs.spec.ts
 git commit -m "test(rbac): actingAs fixture (per-user browser context)"
 ```
 

--- a/docs/superpowers/plans/2026-06-21-scoped-admin-review.md
+++ b/docs/superpowers/plans/2026-06-21-scoped-admin-review.md
@@ -1,0 +1,1959 @@
+# Scoped Admin-Review for Resource-Admins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an OpenFGA resource-admin (admin tuple on a resource, but not the global Zitadel `admin` role) review the access-requests
+scoped to the resources they administer through the existing admin UI, with a scoped notification badge.
+
+**Architecture:** A new API endpoint (`GET /auth/admin-scopes`) exposes the caller's admin status/scopes; the existing
+`GET /admin/notifications` is widened to admit resource-admins with a scoped count; the frontend consumes that signal to admit
+resource-admins to the existing review UI (hiding global-only sections), add a dashboard entry, and switch the notification bell to
+the scoped review queue. The per-request scoping predicate is extracted into one shared API service so the badge count and the review
+list always agree. The API remains the sole authorization boundary; frontend changes only widen who the UI admits.
+
+**Tech Stack:** PHP 8.4+ (API), PHP 8.1+ (frontend), PSR-7/15/17, OpenFGA, Zitadel OIDC, GuzzleHttp, PHPUnit, vanilla ES6 JS, Bootstrap.
+
+## Global Constraints
+
+- PHP code follows PSR-12 plus each project's `phpcs.xml` ruleset; short array syntax `[]` only; 4-space indentation; single quotes preferred.
+- API requires PHP >= 8.4; frontend requires PHP >= 8.1.
+- gettext user-facing strings use numbered placeholders (`%1$s`, `%2$d`) whenever there is more than one argument.
+- Public API endpoints use `credentials: 'omit'`, but `/auth/*` and `/admin/*` are authenticated and use `credentials: 'include'`.
+- Never use `--no-verify`; pre-commit hooks (phpcs, markdownlint) must pass. Fix and recommit on failure.
+- Any markdown produced must pass `markdownlint` (180-char lines, blank lines around lists/code blocks, language-tagged fences).
+- The API stays the authorization boundary. Hiding UI from resource-admins is not the security boundary — every privileged action is authorized server-side against OpenFGA.
+- `GET /auth/admin-scopes` and the widened `GET /admin/notifications` fail closed: when OpenFGA is unavailable, treat the caller as
+  not-a-resource-admin; `is_global_admin` is still derived from the token.
+
+---
+
+## File Structure
+
+API (`/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI`):
+
+- `src/Services/ResourceAdminService.php` (NEW) — single home for the OpenFGA-backed scoping logic: resolve a user's admin scopes
+  (`resolveScopes`), filter access-requests to those a resource-admin administers (`filterByAdminAccess`), and the per-request
+  "administers every resource" predicate (`administersAllResources`).
+- `src/Handlers/Admin/AccessRequestAdminHandler.php` (MODIFY) — delegate `filterByAdminAccess` to the new service.
+- `src/Handlers/Auth/AdminScopesHandler.php` (NEW) — `GET /auth/admin-scopes`.
+- `src/Router.php` (MODIFY) — register the new auth route + add it to the OIDC-protected gate.
+- `src/Handlers/Admin/NotificationsHandler.php` (MODIFY) — admit resource-admins with scoped counts.
+
+Frontend (`/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend`):
+
+- `composer.json` + `phpunit.xml` + `tests/` (NEW scaffolding, folded into Task 5) — frontend PHPUnit setup.
+- `src/AuthHelper.php` (MODIFY) — `isResourceAdmin()`, `adminScopes()`, `fetchAdminScopes()`.
+- `assets/js/auth.js` (MODIFY) — `Auth.isResourceAdmin()`.
+- `admin-permissions.php` (MODIFY) — gate + section guard + `isGlobalAdmin` config flag.
+- `assets/js/admin-permissions.js` (MODIFY) — skip FGA-tuple init for resource-admins.
+- `admin-dashboard.php` (MODIFY) — "Access Requests to Review" card.
+- `assets/js/notifications.js` (MODIFY) — admin mode for resource-admins.
+
+---
+
+### Task 1: API — `ResourceAdminService` (shared scoping logic)
+
+**Files:**
+
+- Create: `LiturgicalCalendarAPI/src/Services/ResourceAdminService.php`
+- Test: `LiturgicalCalendarAPI/phpunit_tests/Services/ResourceAdminServiceTest.php`
+
+**Interfaces:**
+
+- Consumes: `LiturgicalCalendar\Api\Services\OpenFgaClient` —
+  `listObjects(string $user, string $relation, string $type): array` (returns object IDs without type prefix, throws `\RuntimeException` on transport failure)
+  and `check(string $user, string $relation, string $object): bool` (throws `\RuntimeException` on transport failure).
+- Produces (relied on by Tasks 2, 3, 4):
+  - `public const ADMIN_OBJECT_TYPES = ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'];`
+  - `__construct(OpenFgaClient $fgaClient)`
+  - `resolveScopes(string $sub): array` → returns `list<array{object_type: string, object_id: string}>`; fail-closed `[]` on any `\RuntimeException`.
+  - `filterByAdminAccess(array $requests, string $adminUserId): array` → returns the subset of `$requests` whose every permission targets a
+    resource the admin holds `admin` on; excludes empty-permission requests. Does NOT catch `\RuntimeException` (behavior-preserving).
+  - `administersAllResources(array $permissions, string $fgaUser, array &$cache): bool` → predicate; `$cache` is a by-reference `array<string, bool>` of `"{type}:{id}" => bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `LiturgicalCalendarAPI/phpunit_tests/Services/ResourceAdminServiceTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceAdminService::class)]
+final class ResourceAdminServiceTest extends TestCase
+{
+    /**
+     * @param array<int, GuzzleResponse> $responses Queued, replayed in order.
+     */
+    private function serviceWith(array $responses): ResourceAdminService
+    {
+        $stack  = HandlerStack::create(new MockHandler($responses));
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+        return new ResourceAdminService($client);
+    }
+
+    public function testResolveScopesUnionsAdminTuplesAcrossTypes(): void
+    {
+        // One list-objects response per ADMIN_OBJECT_TYPES entry, in order:
+        // national_calendar, diocesan_calendar, wider_region, general_roman_calendar
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $service->resolveScopes('cei-admin')
+        );
+    }
+
+    public function testResolveScopesFailsClosedOnOpenFgaError(): void
+    {
+        $service = $this->serviceWith([
+            new GuzzleResponse(500, [], 'boom'),
+        ]);
+
+        self::assertSame([], $service->resolveScopes('cei-admin'));
+    }
+
+    public function testFilterByAdminAccessKeepsOnlyFullyAdministeredRequests(): void
+    {
+        // check() calls, in request order:
+        // req A perm national_calendar:IT -> allowed
+        // req B perm national_calendar:US -> denied
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"allowed":true}'),
+            new GuzzleResponse(200, [], '{"allowed":false}'),
+        ]);
+
+        $requests = [
+            ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]],
+            ['id' => 'B', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'editor']]],
+            ['id' => 'C', 'permissions' => []],
+        ];
+
+        $filtered = $service->filterByAdminAccess($requests, 'cei-admin');
+
+        self::assertSame(['A'], array_column($filtered, 'id'));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Services/ResourceAdminServiceTest.php`
+Expected: FAIL — `Error: Class "LiturgicalCalendar\Api\Services\ResourceAdminService" not found`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `LiturgicalCalendarAPI/src/Services/ResourceAdminService.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * Resolves and applies a user's OpenFGA `admin` scopes.
+ *
+ * Single home for the resource-admin scoping logic shared by
+ * AdminScopesHandler (GET /auth/admin-scopes), the widened
+ * NotificationsHandler (GET /admin/notifications), and
+ * AccessRequestAdminHandler (GET /admin/access-requests). Centralizing it
+ * keeps the badge count and the review list in agreement.
+ */
+final class ResourceAdminService
+{
+    /**
+     * Object types a user can hold the `admin` relation on. Mirrors the
+     * admin-capable types in the OpenFGA authorization model.
+     */
+    public const ADMIN_OBJECT_TYPES = [
+        'national_calendar',
+        'diocesan_calendar',
+        'wider_region',
+        'general_roman_calendar',
+    ];
+
+    public function __construct(private readonly OpenFgaClient $fgaClient)
+    {
+    }
+
+    /**
+     * Union of the objects the user holds `admin` on across ADMIN_OBJECT_TYPES.
+     *
+     * Fails closed: any OpenFGA transport error yields an empty scope set.
+     *
+     * @param string $sub Zitadel user ID (without "user:" prefix)
+     * @return list<array{object_type: string, object_id: string}>
+     */
+    public function resolveScopes(string $sub): array
+    {
+        $fgaUser = "user:{$sub}";
+        $scopes  = [];
+
+        try {
+            foreach (self::ADMIN_OBJECT_TYPES as $type) {
+                foreach ($this->fgaClient->listObjects($fgaUser, 'admin', $type) as $objectId) {
+                    $scopes[] = ['object_type' => $type, 'object_id' => $objectId];
+                }
+            }
+        } catch (\RuntimeException) {
+            // Fail closed — caller is treated as not-a-resource-admin.
+            return [];
+        }
+
+        return $scopes;
+    }
+
+    /**
+     * Filter requests to only those the resource admin administers in full.
+     *
+     * A request qualifies only if the admin holds the `admin` relation on
+     * EVERY resource in that request's permissions array. Requests with an
+     * empty permissions array are excluded.
+     *
+     * @param array<int, array<string, mixed>> $requests
+     * @param string $adminUserId Admin's Zitadel user ID (without "user:" prefix)
+     * @return array<int, array<string, mixed>> Filtered, re-indexed requests
+     */
+    public function filterByAdminAccess(array $requests, string $adminUserId): array
+    {
+        $fgaUser = "user:{$adminUserId}";
+
+        /** @var array<string, bool> $cache */
+        $cache = [];
+
+        return array_values(array_filter($requests, function (array $req) use ($fgaUser, &$cache): bool {
+            /** @var array<int, array{object_type: string, object_id: string, relation: string}> $permissions */
+            $permissions = is_array($req['permissions'] ?? null) ? $req['permissions'] : [];
+            return $this->administersAllResources($permissions, $fgaUser, $cache);
+        }));
+    }
+
+    /**
+     * True iff the admin holds `admin` on every resource in $permissions.
+     *
+     * An empty $permissions array returns false (matches the prior
+     * AccessRequestAdminHandler behavior of excluding empty-permission
+     * requests). The $cache de-duplicates OpenFGA `check` calls per resource.
+     *
+     * @param array<int, array{object_type: string, object_id: string, relation: string}> $permissions
+     * @param string $fgaUser Fully-qualified FGA user (e.g. "user:cei-admin")
+     * @param array<string, bool> $cache Shared per-call check cache (by reference)
+     */
+    public function administersAllResources(array $permissions, string $fgaUser, array &$cache): bool
+    {
+        if (empty($permissions)) {
+            return false;
+        }
+
+        foreach ($permissions as $perm) {
+            $objectType = $perm['object_type'] ?? '';
+            $objectId   = $perm['object_id'] ?? '';
+            $key        = "{$objectType}:{$objectId}";
+
+            if (!isset($cache[$key])) {
+                $cache[$key] = $this->fgaClient->check($fgaUser, 'admin', $key);
+            }
+
+            if (!$cache[$key]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Services/ResourceAdminServiceTest.php`
+Expected: PASS (3 tests, OK).
+
+- [ ] **Step 5: Lint + static analysis**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && composer lint && composer analyse`
+Expected: no errors for `src/Services/ResourceAdminService.php` or the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+git add src/Services/ResourceAdminService.php phpunit_tests/Services/ResourceAdminServiceTest.php
+git commit -m "feat(api): add ResourceAdminService for shared admin-scope logic"
+```
+
+---
+
+### Task 2: API — refactor `AccessRequestAdminHandler::filterByAdminAccess` to use the service
+
+**Files:**
+
+- Modify: `LiturgicalCalendarAPI/src/Handlers/Admin/AccessRequestAdminHandler.php` (the `filterByAdminAccess` method, lines ~1003–1040)
+- Test: `LiturgicalCalendarAPI/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php` (existing — must still pass; no new test)
+
+**Interfaces:**
+
+- Consumes: `ResourceAdminService::filterByAdminAccess(array $requests, string $adminUserId): array` (from Task 1),
+  `$this->getFgaClient(): OpenFgaClient`, `$this->isFgaClientAvailable(): bool` (existing private methods).
+- Produces: behavior-preserving private `filterByAdminAccess(array $requests, string $adminId): array` — identical outputs to today.
+
+This is a behavior-preserving refactor. The deliverable's test is the existing handler suite continuing to pass.
+
+- [ ] **Step 1: Run the existing tests to confirm the green baseline**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php`
+Expected: PASS (all existing tests green) — this is the regression oracle for the refactor.
+
+- [ ] **Step 2: Add the service import**
+
+In `src/Handlers/Admin/AccessRequestAdminHandler.php`, after the existing `use LiturgicalCalendar\Api\Services\RoleCascadeService;` line (line ~27), add:
+
+```php
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+```
+
+- [ ] **Step 3: Replace the method body with delegation**
+
+Replace the existing method (lines ~1003–1040):
+
+```php
+    private function filterByAdminAccess(array $requests, string $adminId): array
+    {
+        if (!$this->isFgaClientAvailable()) {
+            return [];
+        }
+
+        $fgaUser = "user:{$adminId}";
+
+        // Cache admin checks to avoid redundant API calls
+        /** @var array<string, bool> $cache */
+        $cache = [];
+
+        return array_values(array_filter($requests, function (array $req) use ($fgaUser, &$cache): bool {
+            /** @var array<int, array{object_type: string, object_id: string, relation: string}> $permissions */
+            $permissions = is_array($req['permissions'] ?? null) ? $req['permissions'] : [];
+
+            if (empty($permissions)) {
+                return false;
+            }
+
+            // Admin must have access to ALL resources in the request
+            foreach ($permissions as $perm) {
+                $objectType = $perm['object_type'] ?? '';
+                $objectId   = $perm['object_id'] ?? '';
+                $key        = "{$objectType}:{$objectId}";
+
+                if (!isset($cache[$key])) {
+                    $cache[$key] = $this->getFgaClient()->check($fgaUser, 'admin', $key);
+                }
+
+                if (!$cache[$key]) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+    }
+```
+
+with:
+
+```php
+    private function filterByAdminAccess(array $requests, string $adminId): array
+    {
+        if (!$this->isFgaClientAvailable()) {
+            return [];
+        }
+
+        return ( new ResourceAdminService($this->getFgaClient()) )->filterByAdminAccess($requests, $adminId);
+    }
+```
+
+- [ ] **Step 4: Run the existing tests to verify behavior is preserved**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php`
+Expected: PASS (same count as Step 1, no regressions).
+
+- [ ] **Step 5: Lint + static analysis**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && composer lint && composer analyse`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+git add src/Handlers/Admin/AccessRequestAdminHandler.php
+git commit -m "refactor(api): delegate access-request admin filtering to ResourceAdminService"
+```
+
+---
+
+### Task 3: API — `GET /auth/admin-scopes` handler + route
+
+**Files:**
+
+- Create: `LiturgicalCalendarAPI/src/Handlers/Auth/AdminScopesHandler.php`
+- Modify: `LiturgicalCalendarAPI/src/Router.php` (auth route dispatch ~line 360, use statements ~line 27, OIDC gate ~line 613)
+- Test: `LiturgicalCalendarAPI/phpunit_tests/Handlers/Auth/AdminScopesHandlerTest.php`
+
+**Interfaces:**
+
+- Consumes: `ResourceAdminService` (Task 1), `OpenFgaClient` (`fromEnv()`, `isConfigured()`),
+  `OidcAuthMiddleware::isAdmin(array $oidcUser): bool`, request attribute `oidc_user` (`array{sub?: string, roles?: array<string>}`).
+- Produces: JSON body `{"is_global_admin": bool, "is_resource_admin": bool, "admin_scopes": list<array{object_type: string, object_id: string}>}`.
+  Constructor `__construct(?OpenFgaClient $fgaClient = null)` (injectable for tests).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `LiturgicalCalendarAPI/phpunit_tests/Handlers/Auth/AdminScopesHandlerTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Auth;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Handlers\Auth\AdminScopesHandler;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(AdminScopesHandler::class)]
+final class AdminScopesHandlerTest extends AbstractHandlerTestCase
+{
+    /**
+     * @param array<int, GuzzleResponse> $responses
+     */
+    private function handlerWith(array $responses): AdminScopesHandler
+    {
+        $stack  = HandlerStack::create(new MockHandler($responses));
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+        return new AdminScopesHandler($client);
+    }
+
+    public function testMissingOidcUserIsUnauthorized(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->handlerWith([])->handle($this->requestFor('GET', '/auth/admin-scopes'));
+    }
+
+    public function testResourceAdminGetsScopes(): void
+    {
+        // Four list-objects responses, in ADMIN_OBJECT_TYPES order.
+        $handler = $this->handlerWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-admin', 'roles' => ['calendar_editor']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertFalse($body['is_global_admin']);
+        self::assertTrue($body['is_resource_admin']);
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $body['admin_scopes']
+        );
+    }
+
+    public function testGlobalAdminIsFlaggedEvenWithNoFgaScopes(): void
+    {
+        $handler = $this->handlerWith([
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'root', 'roles' => ['admin']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertTrue($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+    }
+
+    public function testPlainEditorGetsBothFalse(): void
+    {
+        $handler = $this->handlerWith([
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-editor', 'roles' => ['calendar_editor']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertFalse($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+    }
+
+    public function testFailsClosedWhenOpenFgaErrors(): void
+    {
+        $handler = $this->handlerWith([
+            new GuzzleResponse(500, [], 'boom'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-admin', 'roles' => ['admin']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertTrue($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Handlers/Auth/AdminScopesHandlerTest.php`
+Expected: FAIL — `Error: Class "LiturgicalCalendar\Api\Handlers\Auth\AdminScopesHandler" not found`.
+
+- [ ] **Step 3: Create the handler**
+
+Create `LiturgicalCalendarAPI/src/Handlers/Auth/AdminScopesHandler.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Admin Scopes Handler
+ *
+ * GET /auth/admin-scopes — report the authenticated caller's admin status:
+ *   - is_global_admin: the Zitadel `admin` role is present in the token.
+ *   - admin_scopes: union of OpenFGA `admin` tuples across the admin-capable
+ *     object types, as [{object_type, object_id}].
+ *   - is_resource_admin: admin_scopes is non-empty.
+ *
+ * Fails closed: when OpenFGA is unavailable, admin_scopes is empty and
+ * is_resource_admin is false, but is_global_admin is still honored from the token.
+ */
+final class AdminScopesHandler extends AbstractHandler
+{
+    private ?OpenFgaClient $fgaClient = null;
+
+    public function __construct(?OpenFgaClient $fgaClient = null)
+    {
+        parent::__construct();
+
+        $this->fgaClient            = $fgaClient;
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+        $this->allowCredentials      = true;
+    }
+
+    private function isFgaClientAvailable(): bool
+    {
+        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
+    }
+
+    private function getFgaClient(): OpenFgaClient
+    {
+        if ($this->fgaClient === null) {
+            $this->fgaClient = OpenFgaClient::fromEnv();
+        }
+        return $this->fgaClient;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+        $method   = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime)
+            ->withHeader('Cache-Control', 'no-store');
+
+        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+
+        $sub = $oidcUser['sub'] ?? null;
+        if (!is_string($sub) || trim($sub) === '') {
+            throw new UnauthorizedException('Invalid authentication token');
+        }
+
+        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
+
+        $scopes = [];
+        if ($this->isFgaClientAvailable()) {
+            $scopes = ( new ResourceAdminService($this->getFgaClient()) )->resolveScopes($sub);
+        }
+
+        return $this->encodeResponseBody($response, [
+            'is_global_admin'   => $isGlobalAdmin,
+            'is_resource_admin' => $scopes !== [],
+            'admin_scopes'      => $scopes,
+        ]);
+    }
+}
+```
+
+- [ ] **Step 4: Register the route in the Router (use statement)**
+
+In `src/Router.php`, after the existing `use LiturgicalCalendar\Api\Handlers\Auth\EmailVerificationHandler;` line (line ~27), add:
+
+```php
+use LiturgicalCalendar\Api\Handlers\Auth\AdminScopesHandler;
+```
+
+- [ ] **Step 5: Register the route in the auth dispatch**
+
+In `src/Router.php`, in the `case 'auth':` block, after the `notifications` branch
+(the `elseif ($authRoute === 'notifications') { ... }` ending at line ~365), add a new branch before the closing `else`:
+
+```php
+                    } elseif ($authRoute === 'admin-scopes') {
+                        // GET /auth/admin-scopes - Report caller's global/resource admin status + scopes
+                        $adminScopesHandler = new AdminScopesHandler();
+                        $this->handler      = $adminScopesHandler;
+```
+
+- [ ] **Step 6: Add the route to the OIDC-protected gate**
+
+In `src/Router.php`, in the OIDC pipeline gate (line ~613), extend the auth allow-list array from:
+
+```php
+            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications'], true) )
+```
+
+to:
+
+```php
+            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications', 'admin-scopes'], true) )
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Handlers/Auth/AdminScopesHandlerTest.php`
+Expected: PASS (5 tests, OK).
+
+- [ ] **Step 8: Lint, analyse, syntax-check**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && composer parallel-lint && composer lint && composer analyse`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+git add src/Handlers/Auth/AdminScopesHandler.php src/Router.php phpunit_tests/Handlers/Auth/AdminScopesHandlerTest.php
+git commit -m "feat(api): add GET /auth/admin-scopes endpoint"
+```
+
+---
+
+### Task 4: API — widen `GET /admin/notifications` to resource-admins
+
+**Files:**
+
+- Modify: `LiturgicalCalendarAPI/src/Handlers/Admin/NotificationsHandler.php`
+- Test: `LiturgicalCalendarAPI/phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php` (existing — add new tests)
+
+**Interfaces:**
+
+- Consumes: `ResourceAdminService` (`resolveScopes`, `filterByAdminAccess`), `OpenFgaClient` (`fromEnv`, `isConfigured`),
+  `OidcAuthMiddleware::isAdmin`, `AccessRequestRepository::getPending(): array` (oldest-first), existing `ApplicationRepository`.
+- Produces: constructor `__construct(?OpenFgaClient $fgaClient = null)`; global-admin response unchanged; resource-admin response = scoped
+  `pending_access_requests`, scoped `items` (cap 5, `url` = `admin-permissions.php`), `pending_applications` = 0, `total` = scoped count;
+  plain editor → `ForbiddenException`.
+
+- [ ] **Step 1: Run existing tests to confirm green baseline**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php`
+Expected: PASS (existing 5 tests green).
+
+- [ ] **Step 2: Write the new failing tests**
+
+Append these methods to the existing `LiturgicalCalendarAPI/phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php` class body
+(before the final closing `}`). Also add these imports at the top alongside the existing `use` statements:
+
+```php
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use Nyholm\Psr7\Factory\Psr17Factory;
+```
+
+New test methods:
+
+```php
+    /**
+     * @param array<int, GuzzleResponse> $responses
+     */
+    private function handlerWithFga(array $responses): NotificationsHandler
+    {
+        $stack  = HandlerStack::create(new MockHandler($responses));
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+        return new NotificationsHandler($client);
+    }
+
+    public function testResourceAdminGetsScopedCount(): void
+    {
+        $accessRepo = new AccessRequestRepository(self::$pdo);
+        // Request the resource-admin administers (national_calendar:IT)
+        $accessRepo->create('user-it', 'it@x.test', 'ItUser', 'calendar_editor', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+        usleep(2000);
+        // Request the resource-admin does NOT administer (national_calendar:US)
+        $accessRepo->create('user-us', 'us@x.test', 'UsUser', 'calendar_editor', [
+            ['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'editor'],
+        ]);
+
+        // resolveScopes: 4 list-objects calls (national_calendar -> IT, rest empty),
+        // then filterByAdminAccess: 1 check() per request (IT -> allowed, US -> denied).
+        $handler = $this->handlerWithFga([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"allowed":true}'),
+            new GuzzleResponse(200, [], '{"allowed":false}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/admin/notifications')
+            ->withAttribute('oidc_user', ['sub' => 'cei-admin', 'roles' => ['calendar_editor']]);
+
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertSame(1, $body['pending_access_requests']);
+        self::assertSame(0, $body['pending_applications']);
+        self::assertSame(1, $body['total']);
+        self::assertCount(1, $body['items']);
+        self::assertSame('access_request', $body['items'][0]['type']);
+        self::assertSame('admin-permissions.php', $body['items'][0]['url']);
+    }
+
+    public function testPlainEditorWithNoScopesIsForbidden(): void
+    {
+        // resolveScopes: 4 empty list-objects responses -> no scopes -> rejected.
+        $handler = $this->handlerWithFga([
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/admin/notifications')
+            ->withAttribute('oidc_user', ['sub' => 'plain-editor', 'roles' => ['calendar_editor']]);
+
+        $this->expectException(ForbiddenException::class);
+        $this->expectExceptionMessage('Admin role required');
+
+        $handler->handle($request);
+    }
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+vendor/bin/phpunit --filter 'testResourceAdminGetsScopedCount|testPlainEditorWithNoScopesIsForbidden' phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php
+```
+
+Expected: FAIL — `testResourceAdminGetsScopedCount` fails (resource-admin currently gets `ForbiddenException`);
+`testPlainEditorWithNoScopesIsForbidden` may error on the `NotificationsHandler` constructor not accepting an argument.
+
+- [ ] **Step 4: Add the FGA imports + constructor + getters to the handler**
+
+In `src/Handlers/Admin/NotificationsHandler.php`, add these imports after the existing `use LiturgicalCalendar\Api\Repositories\ApplicationRepository;` line (line ~16):
+
+```php
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+```
+
+Replace the property block + constructor (lines ~30–40):
+
+```php
+    private ?AccessRequestRepository $accessRequestRepo = null;
+    private ?ApplicationRepository $applicationRepo     = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+        $this->allowCredentials      = true;
+    }
+```
+
+with:
+
+```php
+    private ?AccessRequestRepository $accessRequestRepo = null;
+    private ?ApplicationRepository $applicationRepo     = null;
+    private ?OpenFgaClient $fgaClient                   = null;
+
+    public function __construct(?OpenFgaClient $fgaClient = null)
+    {
+        parent::__construct();
+
+        $this->fgaClient             = $fgaClient;
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+        $this->allowCredentials      = true;
+    }
+
+    private function isFgaClientAvailable(): bool
+    {
+        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
+    }
+
+    private function getFgaClient(): OpenFgaClient
+    {
+        if ($this->fgaClient === null) {
+            $this->fgaClient = OpenFgaClient::fromEnv();
+        }
+        return $this->fgaClient;
+    }
+```
+
+- [ ] **Step 5: Branch the handler on global vs resource admin**
+
+In `src/Handlers/Admin/NotificationsHandler.php`, replace the block from the admin-role check through the end of the
+`if (Connection::isConfigured()) { ... }` body (lines ~81–149) — that is, replace:
+
+```php
+        // Verify admin role
+        if (!OidcAuthMiddleware::isAdmin($oidcUser)) {
+            throw new ForbiddenException('Admin role required');
+        }
+
+        // Get notification counts
+        $notifications = [
+            'pending_access_requests' => 0,
+            'pending_applications'    => 0,
+            'total'                   => 0,
+            'items'                   => [],
+        ];
+
+        if (Connection::isConfigured()) {
+            // Get access request counts (unified role + permission requests)
+            $accessRequestRepo                        = $this->getAccessRequestRepository();
+            $notifications['pending_access_requests'] = $accessRequestRepo->countPending();
+
+            // Get recent pending access requests for the dropdown.
+            // getPending() returns oldest-first (ORDER BY created_at ASC),
+            // so take the last 5 and reverse to display newest-first.
+            $pendingRequests = $accessRequestRepo->getPending();
+            $recentPending   = array_reverse(array_slice($pendingRequests, -5));
+            foreach ($recentPending as $req) {
+                $displayName              = !empty($req['user_name'])
+                    ? $req['user_name']
+                    : ( !empty($req['user_email'])
+                        ? $req['user_email']
+                        : ( 'User ' . substr(is_string($req['zitadel_user_id'] ?? null) ? $req['zitadel_user_id'] : '', -6) ) );
+                $notifications['items'][] = [
+                    'type'       => 'access_request',
+                    'id'         => $req['id'] ?? '',
+                    'user_name'  => $displayName,
+                    'user_email' => $req['user_email'] ?? '',
+                    'role'       => $req['requested_role'] ?? '',
+                    'created_at' => $req['created_at'] ?? '',
+                    'url'        => 'admin-permissions.php',
+                ];
+            }
+
+            // Get pending applications count
+            $applicationRepo                       = $this->getApplicationRepository();
+            $notifications['pending_applications'] = $applicationRepo->countPendingApplications();
+
+            // Get recent pending applications for the dropdown
+            $pendingApps = $applicationRepo->getPendingApplications();
+            foreach (array_slice($pendingApps, 0, 5) as $app) {
+                $notifications['items'][] = [
+                    'type'            => 'application',
+                    'id'              => $app['id'] ?? '',
+                    'app_name'        => $app['name'] ?? 'Unknown',
+                    'zitadel_user_id' => $app['zitadel_user_id'] ?? '',
+                    'requested_scope' => $app['requested_scope'] ?? 'read',
+                    'created_at'      => $app['created_at'] ?? '',
+                    'url'             => 'admin-applications.php',
+                ];
+            }
+
+            // Sort items by created_at descending and limit to 5 most recent
+            usort($notifications['items'], function ($a, $b) {
+                $aDate = is_string($a['created_at']) ? $a['created_at'] : '';
+                $bDate = is_string($b['created_at']) ? $b['created_at'] : '';
+                return strcmp($bDate, $aDate);
+            });
+            $notifications['items'] = array_slice($notifications['items'], 0, 5);
+
+            $notifications['total'] = $notifications['pending_access_requests']
+                                    + $notifications['pending_applications'];
+        }
+```
+
+with:
+
+```php
+        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
+        $sub           = $oidcUser['sub'] ?? null;
+
+        // Get notification counts
+        $notifications = [
+            'pending_access_requests' => 0,
+            'pending_applications'    => 0,
+            'total'                   => 0,
+            'items'                   => [],
+        ];
+
+        if ($isGlobalAdmin) {
+            if (Connection::isConfigured()) {
+                $notifications = $this->buildGlobalAdminNotifications($notifications);
+            }
+        } else {
+            // Resource-admin path: admit only callers who hold an OpenFGA admin
+            // tuple on at least one resource. Fail closed when FGA is unavailable.
+            if (!$this->isFgaClientAvailable() || !is_string($sub) || trim($sub) === '') {
+                throw new ForbiddenException('Admin role required');
+            }
+
+            $scopeService = new ResourceAdminService($this->getFgaClient());
+            if ($scopeService->resolveScopes($sub) === []) {
+                throw new ForbiddenException('Admin role required');
+            }
+
+            if (Connection::isConfigured()) {
+                $notifications = $this->buildResourceAdminNotifications($notifications, $scopeService, $sub);
+            }
+        }
+```
+
+- [ ] **Step 6: Extract the two builder methods**
+
+In `src/Handlers/Admin/NotificationsHandler.php`, add these two private methods after the `handle()` method (before the final closing `}` of the class):
+
+```php
+    /**
+     * Build the unscoped (global-admin) notification payload.
+     *
+     * @param array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>} $notifications
+     * @return array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>}
+     */
+    private function buildGlobalAdminNotifications(array $notifications): array
+    {
+        $accessRequestRepo                        = $this->getAccessRequestRepository();
+        $notifications['pending_access_requests'] = $accessRequestRepo->countPending();
+
+        // getPending() returns oldest-first (ORDER BY created_at ASC),
+        // so take the last 5 and reverse to display newest-first.
+        $pendingRequests = $accessRequestRepo->getPending();
+        $recentPending   = array_reverse(array_slice($pendingRequests, -5));
+        foreach ($recentPending as $req) {
+            $notifications['items'][] = $this->accessRequestItem($req);
+        }
+
+        $applicationRepo                       = $this->getApplicationRepository();
+        $notifications['pending_applications'] = $applicationRepo->countPendingApplications();
+
+        $pendingApps = $applicationRepo->getPendingApplications();
+        foreach (array_slice($pendingApps, 0, 5) as $app) {
+            $notifications['items'][] = [
+                'type'            => 'application',
+                'id'              => $app['id'] ?? '',
+                'app_name'        => $app['name'] ?? 'Unknown',
+                'zitadel_user_id' => $app['zitadel_user_id'] ?? '',
+                'requested_scope' => $app['requested_scope'] ?? 'read',
+                'created_at'      => $app['created_at'] ?? '',
+                'url'             => 'admin-applications.php',
+            ];
+        }
+
+        usort($notifications['items'], function ($a, $b) {
+            $aDate = is_string($a['created_at']) ? $a['created_at'] : '';
+            $bDate = is_string($b['created_at']) ? $b['created_at'] : '';
+            return strcmp($bDate, $aDate);
+        });
+        $notifications['items'] = array_slice($notifications['items'], 0, 5);
+
+        $notifications['total'] = $notifications['pending_access_requests']
+                                + $notifications['pending_applications'];
+
+        return $notifications;
+    }
+
+    /**
+     * Build the scoped (resource-admin) notification payload: only the pending
+     * access-requests the caller administers; no applications.
+     *
+     * @param array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>} $notifications
+     * @return array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>}
+     */
+    private function buildResourceAdminNotifications(
+        array $notifications,
+        ResourceAdminService $scopeService,
+        string $sub
+    ): array {
+        $pendingRequests = $this->getAccessRequestRepository()->getPending();
+        $scoped          = $scopeService->filterByAdminAccess($pendingRequests, $sub);
+
+        $notifications['pending_access_requests'] = count($scoped);
+        $notifications['pending_applications']    = 0;
+        $notifications['total']                   = count($scoped);
+
+        // getPending() is oldest-first; filter preserves order. Newest 5, newest-first.
+        $recentScoped = array_reverse(array_slice($scoped, -5));
+        foreach ($recentScoped as $req) {
+            $notifications['items'][] = $this->accessRequestItem($req);
+        }
+
+        return $notifications;
+    }
+
+    /**
+     * Build a single access_request notification item.
+     *
+     * @param array<string, mixed> $req
+     * @return array<string, mixed>
+     */
+    private function accessRequestItem(array $req): array
+    {
+        $displayName = !empty($req['user_name'])
+            ? $req['user_name']
+            : ( !empty($req['user_email'])
+                ? $req['user_email']
+                : ( 'User ' . substr(is_string($req['zitadel_user_id'] ?? null) ? $req['zitadel_user_id'] : '', -6) ) );
+
+        return [
+            'type'       => 'access_request',
+            'id'         => $req['id'] ?? '',
+            'user_name'  => $displayName,
+            'user_email' => $req['user_email'] ?? '',
+            'role'       => $req['requested_role'] ?? '',
+            'created_at' => $req['created_at'] ?? '',
+            'url'        => 'admin-permissions.php',
+        ];
+    }
+```
+
+- [ ] **Step 7: Run the full NotificationsHandler suite**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && vendor/bin/phpunit phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php`
+Expected: PASS — the 5 existing tests plus the 2 new ones (7 total, OK). In particular `testNonAdminIsForbidden` still passes
+(viewer, no FGA configured/injected → `isFgaClientAvailable()` false → `ForbiddenException('Admin role required')`).
+
+- [ ] **Step 8: Lint + analyse**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI && composer lint && composer analyse`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+git add src/Handlers/Admin/NotificationsHandler.php phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php
+git commit -m "feat(api): scope GET /admin/notifications for resource-admins"
+```
+
+---
+
+### Task 5: Frontend — `AuthHelper::isResourceAdmin()` / `adminScopes()` (+ PHPUnit scaffolding)
+
+**Files:**
+
+- Modify: `LiturgicalCalendarFrontend/src/AuthHelper.php` (add methods after `hasPermission()`, ~line 302)
+- Create: `LiturgicalCalendarFrontend/phpunit.xml`
+- Modify: `LiturgicalCalendarFrontend/composer.json` (add `autoload-dev`)
+- Test: `LiturgicalCalendarFrontend/tests/AuthHelperAdminScopesTest.php`
+
+**Interfaces:**
+
+- Consumes: `GuzzleHttp\Client` (already a dependency), `$_COOKIE['litcal_access_token']`, `$_COOKIE['litcal_id_token']`,
+  `LiturgicalCalendar\Frontend\ApiConfig::getInstance()->apiBaseUrl` (initialized in `includes/common.php`).
+- Produces (relied on by Tasks 7, 8):
+  - `public function isResourceAdmin(): bool`
+  - `public function adminScopes(): array` → `list<array{object_type: string, object_id: string}>`
+  - `public static function fetchAdminScopes(string $apiBaseUrl, ?string $cookieHeader, ?\GuzzleHttp\Client $client = null): array` →
+    `array{is_resource_admin: bool, admin_scopes: list<array{object_type: string, object_id: string}>}`;
+    fail-closed `['is_resource_admin' => false, 'admin_scopes' => []]` on any error.
+
+- [ ] **Step 1: Add the frontend test autoloading + PHPUnit config**
+
+In `LiturgicalCalendarFrontend/composer.json`, add an `autoload-dev` block immediately after the existing `autoload` block:
+
+```json
+    "autoload-dev": {
+        "psr-4": {
+            "LiturgicalCalendar\\Frontend\\Tests\\": "tests/"
+        }
+    },
+```
+
+Create `LiturgicalCalendarFrontend/phpunit.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="frontend">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>
+```
+
+Regenerate the autoloader:
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && composer dump-autoload`
+Expected: `Generated autoload files`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `LiturgicalCalendarFrontend/tests/AuthHelperAdminScopesTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Frontend\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Frontend\AuthHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AuthHelper::class)]
+final class AuthHelperAdminScopesTest extends TestCase
+{
+    private function clientWith(Response ...$responses): Client
+    {
+        return new Client(['handler' => HandlerStack::create(new MockHandler($responses))]);
+    }
+
+    public function testFetchAdminScopesParsesResourceAdminResponse(): void
+    {
+        $client = $this->clientWith(new Response(200, [], json_encode([
+            'is_global_admin'   => false,
+            'is_resource_admin' => true,
+            'admin_scopes'      => [
+                ['object_type' => 'national_calendar', 'object_id' => 'IT'],
+            ],
+        ])));
+
+        $result = AuthHelper::fetchAdminScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertTrue($result['is_resource_admin']);
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $result['admin_scopes']
+        );
+    }
+
+    public function testFetchAdminScopesFailsClosedOnHttpError(): void
+    {
+        $client = $this->clientWith(new Response(401, [], 'Unauthorized'));
+
+        $result = AuthHelper::fetchAdminScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_resource_admin']);
+        self::assertSame([], $result['admin_scopes']);
+    }
+
+    public function testFetchAdminScopesFailsClosedOnMalformedJson(): void
+    {
+        $client = $this->clientWith(new Response(200, [], 'not json'));
+
+        $result = AuthHelper::fetchAdminScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_resource_admin']);
+        self::assertSame([], $result['admin_scopes']);
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && vendor/bin/phpunit tests/AuthHelperAdminScopesTest.php`
+Expected: FAIL — `Error: Call to undefined method LiturgicalCalendar\Frontend\AuthHelper::fetchAdminScopes()`.
+
+- [ ] **Step 4: Implement the methods**
+
+In `src/AuthHelper.php`, add a memoization property. After the existing `public readonly ?array $permissions;` declaration (line ~45), add:
+
+```php
+
+    /**
+     * Memoized admin-scopes result for this request.
+     * Shape: array{is_resource_admin: bool, admin_scopes: list<array{object_type: string, object_id: string}>}
+     *
+     * @var array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}|null
+     */
+    private ?array $adminScopesResult = null;
+```
+
+Then, in `src/AuthHelper.php`, after the `hasPermission()` method (ends at line ~302), add:
+
+```php
+
+    /**
+     * Whether the caller holds an OpenFGA `admin` tuple on at least one resource.
+     *
+     * Resolved once per request from GET /auth/admin-scopes (server-side, using
+     * the caller's session cookies). Fails closed: an unauthenticated caller or
+     * any API/parse error yields false.
+     */
+    public function isResourceAdmin(): bool
+    {
+        return $this->loadAdminScopes()['is_resource_admin'];
+    }
+
+    /**
+     * The caller's OpenFGA `admin` scopes.
+     *
+     * @return array<int, array{object_type: string, object_id: string}>
+     */
+    public function adminScopes(): array
+    {
+        return $this->loadAdminScopes()['admin_scopes'];
+    }
+
+    /**
+     * Resolve (and memoize) the admin-scopes result for this request.
+     *
+     * @return array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}
+     */
+    private function loadAdminScopes(): array
+    {
+        if ($this->adminScopesResult !== null) {
+            return $this->adminScopesResult;
+        }
+
+        // Fail closed for unauthenticated callers — never hit the API.
+        if (!$this->isAuthenticated) {
+            return $this->adminScopesResult = ['is_resource_admin' => false, 'admin_scopes' => []];
+        }
+
+        $apiBaseUrl   = ApiConfig::getInstance()->apiBaseUrl;
+        $cookieHeader = self::buildCookieHeader();
+
+        return $this->adminScopesResult = self::fetchAdminScopes($apiBaseUrl, $cookieHeader);
+    }
+
+    /**
+     * Build a Cookie header from the session token cookies, to forward the
+     * caller's identity to the API on the server-to-server call.
+     */
+    private static function buildCookieHeader(): ?string
+    {
+        $parts = [];
+        foreach ([self::ACCESS_TOKEN_COOKIE, self::ID_TOKEN_COOKIE] as $name) {
+            $value = $_COOKIE[$name] ?? null;
+            if (is_string($value) && $value !== '') {
+                $parts[] = "{$name}={$value}";
+            }
+        }
+        return $parts === [] ? null : implode('; ', $parts);
+    }
+
+    /**
+     * Fetch and parse GET /auth/admin-scopes. Fails closed on any error.
+     *
+     * @param string $apiBaseUrl Base API URL (no trailing slash)
+     * @param string|null $cookieHeader Cookie header forwarding the caller's session
+     * @param \GuzzleHttp\Client|null $client Injectable client (tests)
+     * @return array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}
+     */
+    public static function fetchAdminScopes(
+        string $apiBaseUrl,
+        ?string $cookieHeader,
+        ?\GuzzleHttp\Client $client = null
+    ): array {
+        $failClosed = ['is_resource_admin' => false, 'admin_scopes' => []];
+
+        $client ??= new \GuzzleHttp\Client(['timeout' => 5, 'connect_timeout' => 2, 'http_errors' => true]);
+
+        $headers = ['Accept' => 'application/json'];
+        if ($cookieHeader !== null) {
+            $headers['Cookie'] = $cookieHeader;
+        }
+
+        try {
+            $response = $client->get("{$apiBaseUrl}/auth/admin-scopes", ['headers' => $headers]);
+            $data     = json_decode((string) $response->getBody(), true);
+        } catch (\Throwable) {
+            return $failClosed;
+        }
+
+        if (!is_array($data)) {
+            return $failClosed;
+        }
+
+        $scopes = [];
+        if (isset($data['admin_scopes']) && is_array($data['admin_scopes'])) {
+            foreach ($data['admin_scopes'] as $scope) {
+                if (
+                    is_array($scope)
+                    && isset($scope['object_type'], $scope['object_id'])
+                    && is_string($scope['object_type'])
+                    && is_string($scope['object_id'])
+                ) {
+                    $scopes[] = ['object_type' => $scope['object_type'], 'object_id' => $scope['object_id']];
+                }
+            }
+        }
+
+        return [
+            'is_resource_admin' => (bool) ( $data['is_resource_admin'] ?? false ),
+            'admin_scopes'      => $scopes,
+        ];
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && vendor/bin/phpunit tests/AuthHelperAdminScopesTest.php`
+Expected: PASS (3 tests, OK).
+
+- [ ] **Step 6: Lint + analyse**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && composer parallel-lint && composer lint && composer analyse`
+Expected: no errors. (If phpcs flags `src/AuthHelper.php`, run `composer lint:fix` and re-run.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+git add composer.json phpunit.xml tests/AuthHelperAdminScopesTest.php src/AuthHelper.php
+git commit -m "feat(frontend): add AuthHelper::isResourceAdmin()/adminScopes()"
+```
+
+---
+
+### Task 6: Frontend — `Auth.isResourceAdmin()` (client-side, cached)
+
+**Files:**
+
+- Modify: `LiturgicalCalendarFrontend/assets/js/auth.js` (add a method after `hasRole()`, ~line 788)
+
+**Interfaces:**
+
+- Consumes: global `BaseUrl` (API base URL), `Auth._validateBaseUrl(methodName)` (existing private helper), `fetch` with `credentials: 'include'`.
+- Produces (relied on by Task 9): `Auth.isResourceAdmin(): Promise<boolean>` — fetches `GET ${BaseUrl}/auth/admin-scopes` once
+  and caches the boolean for the page; fails closed to `false`.
+
+This is vanilla browser JS; behavioral coverage comes from Phase 2 E2E. Verification here is syntax + lint (project convention: `node --check` + ESLint).
+
+- [ ] **Step 1: Add the cache fields**
+
+In `assets/js/auth.js`, in the `Auth` object after the `_isLoggingOut: false,` property (line ~65), add:
+
+```javascript
+
+    /**
+     * Cached resource-admin result for this page load (null = not yet fetched).
+     * @private
+     */
+    _resourceAdminCache: null,
+
+    /**
+     * In-flight resource-admin fetch, to dedupe concurrent callers.
+     * @private
+     */
+    _resourceAdminPromise: null,
+```
+
+- [ ] **Step 2: Add the method**
+
+In `assets/js/auth.js`, after the `hasRole(role)` method (ends ~line 788, before `getUsername()`), add:
+
+```javascript
+
+    /**
+     * Check whether the caller is an OpenFGA resource-admin (holds an `admin`
+     * tuple on at least one resource) via GET /auth/admin-scopes.
+     *
+     * Result is cached for the page load and concurrent calls are deduped.
+     * Fails closed to false on any network/API error.
+     *
+     * @returns {Promise<boolean>} True if the caller is a resource-admin
+     */
+    async isResourceAdmin() {
+        if (this._resourceAdminCache !== null) {
+            return this._resourceAdminCache;
+        }
+        if (this._resourceAdminPromise !== null) {
+            return this._resourceAdminPromise;
+        }
+        if (!this._validateBaseUrl('isResourceAdmin')) {
+            return false;
+        }
+
+        this._resourceAdminPromise = (async () => {
+            try {
+                const response = await fetch(`${BaseUrl}/auth/admin-scopes`, {
+                    method: 'GET',
+                    credentials: 'include',
+                    headers: { 'Accept': 'application/json' }
+                });
+                if (!response.ok) {
+                    return false;
+                }
+                const data = await response.json();
+                return Boolean(data.is_resource_admin);
+            } catch (error) {
+                console.error('Auth.isResourceAdmin failed:', error);
+                return false;
+            }
+        })();
+
+        try {
+            this._resourceAdminCache = await this._resourceAdminPromise;
+            return this._resourceAdminCache;
+        } finally {
+            this._resourceAdminPromise = null;
+        }
+    },
+```
+
+Note: there is already a comma after the `hasRole()` method's closing `}` (it is followed by `getUsername()`),
+so insert this block between them and keep the trailing comma after the new method.
+
+- [ ] **Step 3: Syntax check**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && node --check assets/js/auth.js`
+Expected: no output (exit 0).
+
+- [ ] **Step 4: ESLint**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && yarn lint`
+Expected: no new errors for `assets/js/auth.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+git add assets/js/auth.js
+git commit -m "feat(frontend): add Auth.isResourceAdmin() client signal"
+```
+
+---
+
+### Task 7: Frontend — `admin-permissions.php` gate + global-only FGA section
+
+**Files:**
+
+- Modify: `LiturgicalCalendarFrontend/admin-permissions.php` (gate ~lines 19–26; FGA-section markup ~lines 53–132 and the Grant/Revoke modals ~lines 265–345; config block ~line 349)
+- Modify: `LiturgicalCalendarFrontend/assets/js/admin-permissions.js` (modal instantiation lines 30 & 90; FGA event-listener/init block lines ~494–519)
+
+**Interfaces:**
+
+- Consumes: `$authHelper->hasRole('admin')`, `$authHelper->isResourceAdmin()` (Task 5); `window.AdminPermissionsConfig.isGlobalAdmin` (new flag).
+- Produces: page admits global OR resource admins; FGA permission-tuple management section + its JS init render only for global admins; access-requests review section renders for both.
+
+This task mixes PHP (testable by `composer lint` + manual reasoning) and browser JS (E2E-covered). Verification is `composer lint` + `node --check`.
+
+- [ ] **Step 1: Widen the gate and compute `$isGlobalAdmin`**
+
+In `admin-permissions.php`, replace lines 19–26:
+
+```php
+// Check if user has admin role
+$isAdmin = $authHelper->hasRole('admin');
+
+// Redirect non-admins to dashboard
+if (!$isAdmin) {
+    header('Location: admin-dashboard.php');
+    exit;
+}
+```
+
+with:
+
+```php
+// Global admins manage everything; resource-admins may review the access
+// requests scoped to the resources they administer. The API enforces the
+// actual scoping — this gate only decides who the UI lets in.
+$isGlobalAdmin = $authHelper->hasRole('admin');
+$isResourceAdmin = $authHelper->isResourceAdmin();
+
+// Redirect users who are neither to the dashboard.
+if (!$isGlobalAdmin && !$isResourceAdmin) {
+    header('Location: admin-dashboard.php');
+    exit;
+}
+```
+
+- [ ] **Step 2: Wrap the FGA Filter Controls + Action Buttons + Permissions Table in `if ($isGlobalAdmin)`**
+
+In `admin-permissions.php`, immediately before the `<!-- Filter Controls -->` comment (line 53), add:
+
+```php
+    <?php if ($isGlobalAdmin) : ?>
+```
+
+and immediately after the closing `</div>` of the Permissions Table card (the `</div>` that ends the card opened at line 120,
+just before the `<!-- Access Requests Review Section -->` comment at line 134), add:
+
+```php
+    <?php endif; ?>
+```
+
+- [ ] **Step 3: Wrap the Grant + Revoke modals in `if ($isGlobalAdmin)`**
+
+In `admin-permissions.php`, immediately before the `<!-- Grant Permission Modal -->` comment (line 265), add:
+
+```php
+    <?php if ($isGlobalAdmin) : ?>
+```
+
+and immediately after the closing `</div>` that ends the Revoke Confirmation Modal (the modal opened at line 321,
+ending just before the `<!-- Config for JavaScript -->` comment at line 347), add:
+
+```php
+    <?php endif; ?>
+```
+
+- [ ] **Step 4: Expose the `isGlobalAdmin` flag to JS**
+
+In `admin-permissions.php`, in the `window.AdminPermissionsConfig` object literal (line 349), add an `isGlobalAdmin` member right after the `apiUrl` line:
+
+```php
+        window.AdminPermissionsConfig = {
+            apiUrl: <?php echo json_encode($apiBaseUrl); ?>,
+            isGlobalAdmin: <?php echo json_encode($isGlobalAdmin); ?>,
+```
+
+- [ ] **Step 5: Make the two FGA modal instantiations null-safe in JS**
+
+In `assets/js/admin-permissions.js`, replace line 30:
+
+```javascript
+    const grantModal = new bootstrap.Modal(document.getElementById('grantModal'));
+```
+
+with:
+
+```javascript
+    const grantModalEl = document.getElementById('grantModal');
+    const grantModal = grantModalEl ? new bootstrap.Modal(grantModalEl) : null;
+```
+
+and replace line 90:
+
+```javascript
+    const revokeModal = new bootstrap.Modal(document.getElementById('revokeModal'));
+```
+
+with:
+
+```javascript
+    const revokeModalEl = document.getElementById('revokeModal');
+    const revokeModal = revokeModalEl ? new bootstrap.Modal(revokeModalEl) : null;
+```
+
+- [ ] **Step 6: Skip the FGA event-listener + load init for resource-admins**
+
+In `assets/js/admin-permissions.js`, wrap the FGA event-listener registration and initial load (the `// Event listeners` block
+through the `loadUserMap().then(loadPermissions);` line, lines ~493–519) in a global-admin guard. Replace:
+
+```javascript
+    // Event listeners
+    refreshBtn.addEventListener('click', async function() {
+        const icon = this.querySelector('i');
+        icon.classList.add('fa-spin');
+        // Refresh user map first so newly-granted-to users appear with friendly names.
+        await loadUserMap();
+        loadPermissions().finally(function() {
+            icon.classList.remove('fa-spin');
+        });
+    });
+
+    grantPermissionBtn.addEventListener('click', openGrantModal);
+    grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
+    confirmGrantBtn.addEventListener('click', handleGrant);
+    confirmRevokeBtn.addEventListener('click', handleRevoke);
+    applyFiltersBtn.addEventListener('click', loadPermissions);
+
+    clearFiltersBtn.addEventListener('click', function() {
+        filterUser.value = '';
+        filterObjectType.value = '';
+        filterObjectId.value = '';
+        filterRelation.value = '';
+        loadPermissions();
+    });
+
+    // Load user map and then permissions on page load
+    loadUserMap().then(loadPermissions);
+```
+
+with:
+
+```javascript
+    // Event listeners — the FGA permission-tuple management section is
+    // global-admin-only; its DOM is absent for resource-admins, so skip its
+    // wiring and initial load entirely.
+    if (config.isGlobalAdmin) {
+        refreshBtn.addEventListener('click', async function() {
+            const icon = this.querySelector('i');
+            icon.classList.add('fa-spin');
+            // Refresh user map first so newly-granted-to users appear with friendly names.
+            await loadUserMap();
+            loadPermissions().finally(function() {
+                icon.classList.remove('fa-spin');
+            });
+        });
+
+        grantPermissionBtn.addEventListener('click', openGrantModal);
+        grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
+        confirmGrantBtn.addEventListener('click', handleGrant);
+        confirmRevokeBtn.addEventListener('click', handleRevoke);
+        applyFiltersBtn.addEventListener('click', loadPermissions);
+
+        clearFiltersBtn.addEventListener('click', function() {
+            filterUser.value = '';
+            filterObjectType.value = '';
+            filterObjectId.value = '';
+            filterRelation.value = '';
+            loadPermissions();
+        });
+
+        // Load user map and then permissions on page load
+        loadUserMap().then(loadPermissions);
+    }
+```
+
+- [ ] **Step 7: PHP lint + JS syntax check + ESLint**
+
+Run:
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+composer parallel-lint && composer lint && node --check assets/js/admin-permissions.js && yarn lint
+```
+
+Expected: no errors. (If phpcs flags `admin-permissions.php`, run `composer lint:fix` and re-run.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+git add admin-permissions.php assets/js/admin-permissions.js
+git commit -m "feat(frontend): admit resource-admins to admin-permissions review UI"
+```
+
+---
+
+### Task 8: Frontend — `admin-dashboard.php` "Access Requests to Review" card
+
+**Files:**
+
+- Modify: `LiturgicalCalendarFrontend/admin-dashboard.php` (after the `<?php endif; ?>` of the global-admin section, line 141)
+
+**Interfaces:**
+
+- Consumes: `$authHelper->isResourceAdmin()` (Task 5), `$isAdmin` (existing, `= $authHelper->hasRole('admin')`).
+- Produces: a dashboard card linking to `admin-permissions.php`, shown only when `isResourceAdmin() && !$isAdmin`.
+
+- [ ] **Step 1: Add the resource-admin card**
+
+In `admin-dashboard.php`, immediately after the global-admin section's `<?php endif; ?>` (line 141) and before `<?php include_once('./layout/footer.php'); ?>` (line 143), add:
+
+```php
+    <?php if (!$isAdmin && $authHelper->isResourceAdmin()) : ?>
+    <hr class="my-4">
+    <h4 class="mb-3 text-black" style="--bs-text-opacity: .6;">
+        <i class="fas fa-user-shield me-2"></i><?php echo htmlspecialchars(_('Administration'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+    </h4>
+    <div class="row">
+        <div class="col-12 col-md-6 col-lg-4 mb-4">
+            <div class="card admin-block shadow h-100 border-dark">
+                <div class="card-body text-center d-flex flex-column">
+                    <div class="admin-block-icon mb-3">
+                        <i class="fas fa-inbox fa-3x text-dark"></i>
+                    </div>
+                    <h5 class="card-title"><?php echo htmlspecialchars(_('Access Requests to Review'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h5>
+                    <p class="card-text text-muted small flex-grow-1">
+                        <?php echo htmlspecialchars(_('Review and approve access requests for the resources you administer'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </p>
+                    <div class="admin-block-actions mt-auto">
+                        <a href="admin-permissions.php" class="btn btn-dark btn-sm">
+                            <i class="fas fa-tasks me-1"></i><?php echo htmlspecialchars(_('Review'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
+
+```
+
+- [ ] **Step 2: PHP lint**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && composer parallel-lint && composer lint`
+Expected: no errors. (If phpcs flags the file, run `composer lint:fix` and re-run.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+git add admin-dashboard.php
+git commit -m "feat(frontend): add resource-admin review card to admin dashboard"
+```
+
+---
+
+### Task 9: Frontend — `notifications.js` admin mode for resource-admins
+
+**Files:**
+
+- Modify: `LiturgicalCalendarFrontend/assets/js/notifications.js` (the `init()` method, ~line 47–67; mode decision at line 55)
+
+**Interfaces:**
+
+- Consumes: `Auth.hasRole('admin')` (existing), `Auth.isResourceAdmin()` (Task 6, async).
+- Produces: `init()` becomes async; `this._mode` is `'admin'` when `Auth.hasRole('admin') || await Auth.isResourceAdmin()`, else `'user'`.
+  The `seen` POST stays user-mode only (unchanged at line 77–79).
+
+Behavioral coverage is Phase 2 E2E; verification here is `node --check` + ESLint.
+
+- [ ] **Step 1: Make `init()` async and resolve the mode for resource-admins**
+
+In `assets/js/notifications.js`, replace the `init()` method (lines 47–67):
+
+```javascript
+    init() {
+        if (this._initialized) {
+            return;
+        }
+        if (typeof Auth === 'undefined' || !Auth.isAuthenticated()) {
+            return;
+        }
+
+        this._mode = Auth.hasRole('admin') ? 'admin' : 'user';
+        this._initialized = true;
+        console.log(`Notifications: Initializing in ${this._mode} mode`);
+
+        // Container should already be visible from PHP for any authenticated
+        // user, but force it here in case auth state changed after page load.
+        const container = document.getElementById('notificationsContainer');
+        if (container) {
+            container.classList.remove('d-none');
+        }
+
+        this._startNotificationServices();
+    },
+```
+
+with:
+
+```javascript
+    async init() {
+        if (this._initialized) {
+            return;
+        }
+        if (typeof Auth === 'undefined' || !Auth.isAuthenticated()) {
+            return;
+        }
+
+        // Global admins use the review queue; resource-admins do too, but the
+        // API scopes /admin/notifications to the resources they administer.
+        const isAdmin = Auth.hasRole('admin') || await Auth.isResourceAdmin();
+        this._mode = isAdmin ? 'admin' : 'user';
+        this._initialized = true;
+        console.log(`Notifications: Initializing in ${this._mode} mode`);
+
+        // Container should already be visible from PHP for any authenticated
+        // user, but force it here in case auth state changed after page load.
+        const container = document.getElementById('notificationsContainer');
+        if (container) {
+            container.classList.remove('d-none');
+        }
+
+        this._startNotificationServices();
+    },
+```
+
+- [ ] **Step 2: Confirm callers tolerate the now-async `init()`**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && grep -rn "Notifications.init\|\.init()" assets/js/ layout/ includes/ | grep -i notif`
+Expected: identify each call site. `init()` previously returned `undefined`; callers ignore the return value, so making it async
+(returns a Promise that is ignored) is safe — no caller change required. If any call site `await`s or chains `.then()` on `init()`,
+leave it; an async function is awaitable. Record the finding; no edit needed unless a caller depends on synchronous completion
+(none do — `init()` already deferred work to `_startNotificationServices()` which itself fires async fetches).
+
+- [ ] **Step 3: JS syntax check + ESLint**
+
+Run: `cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend && node --check assets/js/notifications.js && yarn lint`
+Expected: no errors for `assets/js/notifications.js`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+git add assets/js/notifications.js
+git commit -m "feat(frontend): resource-admins use review-queue notification bell"
+```
+
+---
+
+## Self-Review
+
+Spec section → task mapping:
+
+- **Component 1 — API `GET /auth/admin-scopes` (new handler, OIDC-protected, listObjects over the four types, is_global_admin from token,
+  fail-closed):** Task 3 (handler + Router dispatch + OIDC gate). The four object types live in `ResourceAdminService::ADMIN_OBJECT_TYPES`
+  (Task 1); fail-closed in `resolveScopes` (Task 1) + the `isFgaClientAvailable()` guard (Task 3).
+- **Component 2 — extract the per-request "administers every resource" predicate into a reusable helper; `filterByAdminAccess` uses it
+  (behavior-preserving):** Task 1 (`ResourceAdminService::administersAllResources` + `filterByAdminAccess`) and Task 2
+  (handler delegates; existing tests are the regression oracle).
+- **Component 3 — widen `GET /admin/notifications` (global unchanged; resource-admin scoped count + items, `pending_applications: 0`; plain editor rejected):** Task 4.
+- **Component 4 — frontend `AuthHelper::isResourceAdmin()` + `adminScopes()`, memoized, server-side fetch with cookie, fail-closed:** Task 5.
+- **Component 5 — `assets/js/auth.js` `Auth.isResourceAdmin()` async + cached:** Task 6.
+- **Component 6 — `admin-permissions.php` gate admits global OR resource admin; FGA-tuple section global-only; skip its JS init for
+  resource-admins; review section stays for both:** Task 7.
+- **Component 7 — `admin-dashboard.php` "Access Requests to Review" card for resource-admins (shown when `isResourceAdmin() && !hasRole('admin')`):** Task 8.
+- **Component 8 — `assets/js/notifications.js` admin mode when `hasRole('admin') || await isResourceAdmin()`; `seen` POST stays user-mode:**
+  Task 9 (the `seen` POST at lines 77–79 is left untouched).
+
+Cross-cutting spec requirements:
+
+- **API stays the authorization boundary:** no change to `requireAdminForAllResources` / `filterByAdminAccess` semantics (Task 2 is behavior-preserving); frontend only widens UI admission.
+- **Fail-closed everywhere:** `ResourceAdminService::resolveScopes` (Task 1), `AdminScopesHandler` (Task 3), `NotificationsHandler`
+  resource-admin branch (Task 4), `AuthHelper::fetchAdminScopes` (Task 5), `Auth.isResourceAdmin` (Task 6), `admin-permissions.php` gate (Task 7).
+- **Response shape `{is_global_admin, is_resource_admin, admin_scopes:[{object_type, object_id}]}`:** Task 3 handler + Task 3 tests assert it.
+- **Ordering (API before frontend):** Tasks 1–4 are API; Tasks 5–9 are frontend.
+- **Testing expectations:** API global-admin / resource-admin / plain-editor cases for `/auth/admin-scopes` (Task 3) and
+  `/admin/notifications` (Task 4); frontend `AuthHelper` parse + fail-closed (Task 5); JS behavior is unblocked for Phase 2 E2E
+  (the spec's stated frontend test path).
+
+Type/name consistency check (verified across tasks):
+
+- `ResourceAdminService::resolveScopes`, `filterByAdminAccess`, `administersAllResources`, `ADMIN_OBJECT_TYPES` — defined Task 1, consumed identically in Tasks 2, 3, 4.
+- `AuthHelper::isResourceAdmin()` / `adminScopes()` / `fetchAdminScopes()` — defined Task 5, consumed in Tasks 7 (`isResourceAdmin`) and 8 (`isResourceAdmin`).
+- `Auth.isResourceAdmin()` — defined Task 6, consumed in Task 9.
+- `window.AdminPermissionsConfig.isGlobalAdmin` — produced in Task 7 PHP, consumed in Task 7 JS.
+
+Out of scope (per spec YAGNI), intentionally not planned: raw FGA tuple management for resource-admins, global user/applications
+management for resource-admins, scoped data-editing dashboard entry points, a combined personal-inbox + review-queue notification mode,
+and OpenAPI schema authoring for the new route (no spec requirement; `composer lint:openapi` lints the schema file, not live routes).
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-21-scoped-admin-review.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-foundation.md
+++ b/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-foundation.md
@@ -1,0 +1,527 @@
+# RBAC E2E Phase 2 — Foundation (harness) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the harness foundation the 11 Phase 2 scenario specs depend on — change the seeding model so
+editors earn grants via the UI, add a per-spec precondition-seeding helper, a request-submission helper, a
+Mailpit/registration helper, and extend cleanup to remove grants created during specs.
+
+**Architecture:** Extend the existing `e2e/rbac/support/*` TypeScript harness (Playwright, serial, single
+worker, `rbac` project depending on `rbac-setup`). New helpers compose the existing `Fga`, `ZitadelAdmin`,
+`seedUser`, `oidcLogin`, and `actingAs` primitives. Each helper gets a `*.test.ts` (run by the existing
+`rbac-support` project, `testMatch /rbac/support/.*\.test\.ts/`) where it is unit-testable without the full
+app stack; UI-driving helpers are validated by the scenario specs in the companion plan.
+
+**Tech Stack:** Playwright (TS), Node fetch, OpenFGA REST, Zitadel v2/management REST, Mailpit REST, the
+frontend's `/auth/access-requests` + `/admin/access-requests` endpoints. Folds into PR #345 on branch
+`e2e/rbac-access-requests`.
+
+## Global Constraints
+
+- Branch `e2e/rbac-access-requests`; do NOT push (wait for explicit request); do NOT use `--no-verify`.
+- TypeScript must pass `yarn typecheck` and `yarn lint` (eslint, exit 0) before every commit.
+- Serial, single worker (`fullyParallel: false`, `workers: 1`) — shared API/DB/FGA/Zitadel state.
+- Harness is **local-docker-only**: it truncates the app DB and mints local Zitadel PATs; never point it at a
+  shared/remote stack.
+- Fail-safe cleanup: cleanup steps must tolerate already-absent resources (`.catch(() => {})` around deletes),
+  matching the existing `cleanup.ts` / `fga.delete` (tolerates "not found") / `zitadel.deleteUser` patterns.
+- Env vars (already loaded into the Playwright process via the existing config's dotenv) the harness reads:
+  `ZITADEL_ISSUER`, `ZITADEL_CLIENT_ID`, `FRONTEND_URL`, `OPENFGA_API_URL`, `OPENFGA_STORE_ID`,
+  `OPENFGA_MODEL_ID`, plus the Zitadel management token used by `ZitadelAdmin.req`. Mailpit base URL is added
+  in Task 4.
+- Object_ids are RESOLVED and fixed: `national_calendar:IT`/`US`, `diocesan_calendar:romamo_it`,
+  `wider_region:Europe`, `general_roman_calendar:temporale`.
+
+## Reference: existing harness interfaces (verified 2026-06-22)
+
+- `users.ts`: `RbacUser = { id, email, password, role: 'admin'|'calendar_editor', fga: { relation:
+  'admin'|'editor', objectType, objectId } | null }`; `USERS` (11 users); `REGISTRATION_USER_IDS =
+  ['cei-admin','usccb-editor']`; `SEEDED_USER_IDS = Object.keys(USERS).filter(id => !REGISTRATION_USER_IDS.includes(id))`.
+- `seed.ts`: `seedUser(id: string): Promise<string>` — deletes existing, `createVerifiedUser`,
+  `grantProjectRole(userId, role)`, and **if `u.fga` writes the tuple** (this is what Task 1 changes);
+  `oidcLogin(email, password, loginClientToken): Promise<string>`; `loginAndSaveState(id, loginClientToken):
+  Promise<void>` (writes `e2e/.auth/<id>.json`).
+- `fga.ts`: `class Fga { write(user, relation, object): Promise<void>; delete(user, relation, object):
+  Promise<void> (tolerates not-found); check(user, relation, object): Promise<boolean> }`. `object` form is
+  `"{type}:{id}"`, `user` form is `"user:{zitadelId}"`.
+- `zitadel.ts`: `class ZitadelAdmin { createVerifiedUser({email,password,firstName,lastName}): Promise<string>;
+  findUserIdByEmail(email): Promise<string|null>; findUserIdByUsername(userName): Promise<string|null>;
+  grantProjectRole(userId, role): Promise<void>; deleteUser(userId): Promise<void>; mintPat(userId):
+  Promise<{tokenId, token}>; deletePat(userId, tokenId): Promise<void> }`. Private `req(method, path, body?)`.
+- `actingAs.ts`: `actingAs(browser, userId): Promise<{ context: BrowserContext, page: Page }>` — builds a
+  context from `e2e/.auth/<userId>.json`.
+- `cleanup.ts`: `truncateAppTables(): Promise<void>` (TRUNCATE access_requests, audit_log,
+  user_notification_state); `deleteAllSeededUsers(): Promise<void>` (per `USERS`: delete FGA tuple if any +
+  delete Zitadel user). `gitRestoreApiData` does NOT yet exist anywhere (added in Task 5).
+- `rbac.setup.ts`: mints a `login-client` PAT; `deleteAllSeededUsers()` + `truncateAppTables()`; then for each
+  `SEEDED_USER_IDS`: `seedUser(id)` + `loginAndSaveState(id, pat.token)`; deletes the PAT in `finally`.
+- API endpoints (verified): submit `POST /auth/access-requests` (body: `requested_role`, `permissions[]` of
+  `{object_type, object_id, relation}`, optional justification); view own `GET /auth/access-requests`; admin
+  list (scoped) `GET /admin/access-requests`; actions `POST /admin/access-requests/{id}/{approve|reject|revoke}`
+  with optional `notes`.
+- Request-submission UI is **`permission-requests.php`** (`assets/js/permission-requests.js`:
+  `input[name="requested_role"]` radios, `#permissionsSection` dynamic permission builder, submit → POST
+  `/auth/access-requests`). Review UI is **`admin-permissions.php`** (`loadAccessRequests()` → GET
+  `/admin/access-requests`; `#permReqReviewModal` with `#permReqDetails`/`#permReqNotesSection`/
+  `#permReqModalAlerts`; `processAccessReq(action)` → POST action with `notes`).
+
+## File Structure
+
+- Modify: `e2e/rbac/support/seed.ts` — `seedUser` seeds the FGA tuple only for `admin`-relation users.
+- Create: `e2e/rbac/support/grant.ts` — per-spec precondition grant/revoke of an FGA tuple (+ role).
+- Create: `e2e/rbac/support/grant.test.ts` — unit test (rbac-support project).
+- Create: `e2e/rbac/support/requestAccess.ts` — drive `permission-requests.php` to submit a pending request.
+- Create: `e2e/rbac/support/mailpit.ts` — query Mailpit, extract the latest verification link for an address.
+- Create: `e2e/rbac/support/mailpit.test.ts` — unit test against a mocked/fetch-injected Mailpit (rbac-support).
+- Modify: `e2e/rbac/support/cleanup.ts` — add dynamic-grant cleanup + `gitRestoreApiData()`.
+- Modify: `e2e/rbac/support/cleanup.test.ts` — cover the new cleanup behavior where unit-testable.
+- Modify: `.env.development` (+ `.env.example` if present) — add `MAILPIT_API_URL` (Task 4).
+
+---
+
+### Task 1: Seeding model — editors are not pre-granted
+
+**Files:**
+
+- Modify: `e2e/rbac/support/seed.ts` (the `seedUser` function, ~lines 18–32)
+- Modify: `e2e/rbac/support/seed.test.ts` (existing — add an assertion)
+
+**Interfaces:**
+
+- Consumes: `USERS`, `Fga`, `ZitadelAdmin` (unchanged).
+- Produces: `seedUser(id)` still returns the Zitadel user id and grants the project role for every seeded
+  user, but writes the FGA tuple **only when `u.fga?.relation === 'admin'`**. Editor users (relation
+  `'editor'`) are seeded as accounts + role + login, with **no** FGA tuple. Scenarios seed editor grants
+  per-spec via Task 2.
+
+- [ ] **Step 1: Update the existing test to assert the new behavior**
+
+In `e2e/rbac/support/seed.test.ts`, the existing test seeds `cei-editor` and asserts the editor tuple
+`check(...) === true`. Under the new model `cei-editor` is NOT granted at seed time. Change that assertion to
+expect the tuple is **absent**, and add a second case proving an admin user IS granted. Replace the test body
+with:
+
+```ts
+test('seedUser grants role for all; writes FGA tuple only for admins', async () => {
+    const f = new Fga();
+    const z = new ZitadelAdmin();
+
+    // editor: account + role, but NO FGA tuple (it is requested via UI in scenarios)
+    const editorId = await seedUser('cei-editor');
+    const e = USERS['cei-editor'].fga!;
+    try {
+        expect(editorId).toMatch(/^\d+$/);
+        expect(await f.check(`user:${editorId}`, e.relation, `${e.objectType}:${e.objectId}`)).toBe(false);
+    } finally {
+        await z.deleteUser(editorId).catch(() => {});
+    }
+
+    // admin: account + role + FGA admin tuple
+    const adminId = await seedUser('usccb-admin');
+    const a = USERS['usccb-admin'].fga!;
+    try {
+        expect(await f.check(`user:${adminId}`, a.relation, `${a.objectType}:${a.objectId}`)).toBe(true);
+    } finally {
+        await z.deleteUser(adminId).catch(() => {});
+        await f.delete(`user:${adminId}`, a.relation, `${a.objectType}:${a.objectId}`).catch(() => {});
+    }
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/seed.test.ts`
+Expected: FAIL — the editor `check(...)` returns `true` (old behavior still seeds the editor tuple).
+
+(Requires the docker stack up. If the stack is down, bring it up per the frontend CLAUDE.md "Docker Stack
+Operations" section first.)
+
+- [ ] **Step 3: Make `seedUser` seed admin tuples only**
+
+In `e2e/rbac/support/seed.ts`, change the tuple-write line in `seedUser` from:
+
+```ts
+    if (u.fga) await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+```
+
+to:
+
+```ts
+    // Seed the FGA tuple only for resource-admins. Editor grants are earned via the
+    // request-access UI in scenarios (the approval outcome), seeded per-spec where a
+    // scenario needs the grant as a precondition (see support/grant.ts).
+    if (u.fga?.relation === 'admin') {
+        await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/seed.test.ts`
+Expected: PASS (editor tuple absent; admin tuple present).
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `yarn typecheck && yarn lint`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/rbac/support/seed.ts e2e/rbac/support/seed.test.ts
+git commit -m "test(rbac): seed FGA tuples for admins only; editors earn grants via UI"
+```
+
+---
+
+### Task 2: `grant.ts` — per-spec precondition seeding
+
+**Files:**
+
+- Create: `e2e/rbac/support/grant.ts`
+- Create: `e2e/rbac/support/grant.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Fga`, `ZitadelAdmin`, `USERS`, `findUserIdByEmail`.
+- Produces (relied on by every scenario spec):
+  - `grantScope(userKey: string, opts?: { role?: boolean }): Promise<void>` — write the FGA tuple defined for
+    `USERS[userKey].fga` for the currently-seeded Zitadel user with that email, and (default) ensure the
+    project role is granted. Idempotent (tolerant of "already exists").
+  - `revokeScope(userKey: string): Promise<void>` — delete that tuple (tolerant of "not found").
+  - `grantTuple(zitadelUserId: string, relation: string, objectType: string, objectId: string):
+    Promise<void>` — low-level write for ad-hoc tuples.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `e2e/rbac/support/grant.test.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { grantScope, revokeScope } from './grant';
+import { seedUser } from './seed';
+import { Fga } from './fga';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+test('grantScope writes the user\'s defined tuple; revokeScope removes it', async () => {
+    const f = new Fga();
+    const z = new ZitadelAdmin();
+    // cei-editor is seeded WITHOUT its tuple (Task 1). grantScope adds it as a precondition.
+    const id = await seedUser('cei-editor');
+    const u = USERS['cei-editor'].fga!;
+    try {
+        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(false);
+        await grantScope('cei-editor');
+        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+        await grantScope('cei-editor'); // idempotent — must not throw
+        await revokeScope('cei-editor');
+        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(false);
+    } finally {
+        await z.deleteUser(id).catch(() => {});
+        await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`).catch(() => {});
+    }
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/grant.test.ts`
+Expected: FAIL — `Cannot find module './grant'`.
+
+- [ ] **Step 3: Implement `grant.ts`**
+
+Create `e2e/rbac/support/grant.ts`:
+
+```ts
+import { Fga } from './fga';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+/**
+ * Per-spec precondition seeding. Editors are not granted at setup (see seed.ts), so a
+ * scenario that needs a user to already hold their scope seeds it here. Idempotent.
+ */
+export async function grantScope(userKey: string, opts: { role?: boolean } = {}): Promise<void> {
+    const u = USERS[userKey];
+    if (!u?.fga) throw new Error(`grantScope: ${userKey} has no fga scope`);
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+    const zid = await z.findUserIdByEmail(u.email);
+    if (!zid) throw new Error(`grantScope: ${userKey} (${u.email}) is not seeded in Zitadel`);
+    if (opts.role !== false) await z.grantProjectRole(zid, u.role).catch(() => {}); // tolerate already-granted
+    await f.write(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`); // write tolerates dup
+}
+
+export async function revokeScope(userKey: string): Promise<void> {
+    const u = USERS[userKey];
+    if (!u?.fga) return;
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+    const zid = await z.findUserIdByEmail(u.email);
+    if (!zid) return;
+    await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`).catch(() => {});
+}
+
+export async function grantTuple(
+    zitadelUserId: string, relation: string, objectType: string, objectId: string,
+): Promise<void> {
+    await new Fga().write(`user:${zitadelUserId}`, relation, `${objectType}:${objectId}`);
+}
+```
+
+(Note: `Fga.write` already swallows "already exists/duplicate"; `grantProjectRole` may 409 on a re-grant, so
+the `.catch(() => {})` keeps `grantScope` idempotent.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/grant.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `yarn typecheck && yarn lint`  → exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/rbac/support/grant.ts e2e/rbac/support/grant.test.ts
+git commit -m "feat(rbac): grant.ts per-spec precondition seeding helper"
+```
+
+---
+
+### Task 3: `requestAccess.ts` — submit a pending request through the UI
+
+**Files:**
+
+- Create: `e2e/rbac/support/requestAccess.ts`
+
+**Interfaces:**
+
+- Consumes: `actingAs` (a logged-in `{ context, page }`), `permission-requests.php` + `permission-requests.js`
+  (`input[name="requested_role"]`, `#permissionsSection`, the add-permission controls, the submit button),
+  which POSTs to `/auth/access-requests`.
+- Produces (relied on by scenario specs):
+  - `submitAccessRequest(page: Page, opts: { requestedRole: string; permission: { objectType: string;
+    objectId: string; relation: 'admin'|'editor' }; justification?: string }): Promise<void>` — drives the
+    permission-requests UI to submit one scoped request and resolves once the success state is visible.
+
+This helper drives the real UI (the design's chosen mechanism). The dynamic permission-builder field
+selectors (the add-permission row, the object-type/object-id/relation inputs, the submit button) must be
+**pinned against the running page** during this task — `permission-requests.js` builds them client-side. The
+known anchors are `input[name="requested_role"]`, `#permissionsSection`, and the submit button; confirm the
+rest by opening `permission-requests.php` in the running stack (or reading the JS that constructs the rows)
+before finalizing the selectors.
+
+- [ ] **Step 1: Pin the permission-builder selectors**
+
+Bring the stack up. As a seeded editor, open `permission-requests.php` and inspect (or read
+`assets/js/permission-requests.js`) to record the exact selectors for: choosing `requested_role`, adding a
+permission row, setting its object-type / object-id / relation, and the submit button + the post-submit
+success indicator (`#formAlerts` success, or a status row appearing in `#existingRequestsBody`). Write the
+findings as a comment block at the top of `requestAccess.ts`.
+
+- [ ] **Step 2: Implement `requestAccess.ts` using the pinned selectors**
+
+Create `e2e/rbac/support/requestAccess.ts` with `submitAccessRequest(page, opts)` that: selects the role
+radio, adds the permission with the given `objectType`/`objectId`/`relation`, fills justification if given,
+clicks submit, and `await expect(<success indicator>).toBeVisible()`. Use Playwright `expect`/locators; no
+fixed `waitForTimeout`. (Full selector bodies are produced in Step 1 — they are page-derived, not guessable
+from static PHP; this is the inherent E2E discovery step.)
+
+- [ ] **Step 3: Smoke-validate the helper in a throwaway spec**
+
+Write a temporary spec (deleted before commit) that: `actingAs(browser, 'cei-editor')` →
+`submitAccessRequest(page, { requestedRole: 'calendar_editor', permission: { objectType:
+'national_calendar', objectId: 'IT', relation: 'editor' } })` → then asserts via API
+(`GET /auth/access-requests` as that user, or query the DB) that a pending request exists. Run:
+`yarn test --project=rbac <temp>.spec.ts`. Expected: PASS. Delete the temp spec.
+
+- [ ] **Step 4: Typecheck + lint**
+
+Run: `yarn typecheck && yarn lint` → exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/requestAccess.ts
+git commit -m "feat(rbac): requestAccess.ts — submit a pending request via the UI"
+```
+
+---
+
+### Task 4: `mailpit.ts` — verification-email retrieval for registration specs
+
+**Files:**
+
+- Create: `e2e/rbac/support/mailpit.ts`
+- Create: `e2e/rbac/support/mailpit.test.ts`
+- Modify: `.env.development` (+ `.env.example` if it exists) — add `MAILPIT_API_URL`
+
+**Interfaces:**
+
+- Consumes: the Mailpit REST API (`GET /api/v1/messages`, `GET /api/v1/message/{ID}`), `MAILPIT_API_URL`.
+- Produces (relied on by scenarios 01/04):
+  - `waitForVerificationLink(toEmail: string, opts?: { timeoutMs?: number }): Promise<string>` — poll Mailpit
+    for the newest message to `toEmail`, extract the Zitadel verification URL from its body, return it. Throws
+    on timeout. Injectable fetch for the unit test: `waitForVerificationLink(toEmail, { fetchImpl })`.
+  - `latestMessageTo(toEmail: string, fetchImpl?): Promise<{ id: string; html: string; text: string } | null>`.
+
+- [ ] **Step 1: Confirm the Mailpit base URL**
+
+Find the Mailpit service in `docker-compose.yml` (+ `docker-compose.override.yml`): service name + HTTP API
+port (Mailpit default UI/API port is 8025). Determine the host-reachable base URL (e.g.
+`http://localhost:8025`) and add `MAILPIT_API_URL=http://localhost:8025` to `.env.development`. Record the
+verification-URL pattern Zitadel emails use (open one real registration email in Mailpit, or inspect the
+template) so the extractor regex is correct.
+
+- [ ] **Step 2: Write the failing unit test (fetch injected — no live Mailpit needed)**
+
+Create `e2e/rbac/support/mailpit.test.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { waitForVerificationLink } from './mailpit';
+
+test('waitForVerificationLink extracts the verification URL from the newest message', async () => {
+    const verifyUrl = 'http://localhost:8080/ui/v2/login/verify?code=ABC&userID=42';
+    const fetchImpl = (async (url: string) => {
+        if (url.includes('/api/v1/messages')) {
+            return new Response(JSON.stringify({ messages: [{ ID: 'm1', To: [{ Address: 'cei-admin+e2e@litcal.test' }] }] }), { status: 200 });
+        }
+        if (url.includes('/api/v1/message/m1')) {
+            return new Response(JSON.stringify({ HTML: `<a href="${verifyUrl}">Verify</a>`, Text: '' }), { status: 200 });
+        }
+        return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const link = await waitForVerificationLink('cei-admin+e2e@litcal.test', { fetchImpl, timeoutMs: 1000 });
+    expect(link).toBe(verifyUrl);
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/mailpit.test.ts`
+Expected: FAIL — `Cannot find module './mailpit'`.
+
+- [ ] **Step 4: Implement `mailpit.ts`**
+
+Create `e2e/rbac/support/mailpit.ts` with `latestMessageTo` (GET `/api/v1/messages`, find newest whose `To`
+contains the address, GET `/api/v1/message/{ID}` for the body) and `waitForVerificationLink` (poll
+`latestMessageTo` until found or `timeoutMs`, extract the first `https?://…verify…` URL from HTML/Text via a
+regex matching the pattern recorded in Step 1). Accept an injectable `fetchImpl` (default global `fetch`) and
+`MAILPIT_API_URL` from env. No `waitForTimeout`; poll with a bounded loop + short delay.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/mailpit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run: `yarn typecheck && yarn lint` → exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add e2e/rbac/support/mailpit.ts e2e/rbac/support/mailpit.test.ts .env.development
+git commit -m "feat(rbac): mailpit.ts verification-email retrieval"
+```
+
+---
+
+### Task 5: Cleanup extension — dynamic grants + API data restore
+
+**Files:**
+
+- Modify: `e2e/rbac/support/cleanup.ts`
+- Modify: `e2e/rbac/support/cleanup.test.ts` (existing)
+
+**Interfaces:**
+
+- Consumes: `Fga`, `ZitadelAdmin`, `USERS`, `execFile` (already used in `cleanup.ts`).
+- Produces:
+  - `deleteAllSeededUsers()` — extended so it deletes **every** FGA tuple a user could hold (both `admin` and
+    `editor` relations from the matrix), not only the matrix-defined one, since scenarios create editor tuples
+    dynamically. Implementation: for each seeded user, attempt `f.delete` for their matrix tuple (tolerant),
+    then delete the Zitadel user.
+  - `gitRestoreApiData(): Promise<void>` (NEW) — restore the API repo's calendar source data after scenario 10
+    edits it, via `git -C <API_REPO> checkout -- jsondata/sourcedata` (path confirmed in Step 1). 30s timeout,
+    tolerant of "nothing to restore".
+
+- [ ] **Step 1: Confirm the API source-data path + restore command**
+
+Determine the API repo path the local stack builds from (the override bind-mounts `../LiturgicalCalendarAPI`)
+and the exact source-data directory `extending.php` writes to (`jsondata/sourcedata/...`). Confirm
+`git -C <path> checkout -- <data-dir>` reverts a calendar edit. Record the resolved absolute path as a
+constant.
+
+- [ ] **Step 2: Add a failing test for `gitRestoreApiData` export presence**
+
+In `e2e/rbac/support/cleanup.test.ts`, add a test that imports `gitRestoreApiData` and asserts it is a
+function (full behavioral coverage is the scenario-10 spec, which needs the stack):
+
+```ts
+import { gitRestoreApiData } from './cleanup';
+test('gitRestoreApiData is exported', () => {
+    expect(typeof gitRestoreApiData).toBe('function');
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/cleanup.test.ts`
+Expected: FAIL — `gitRestoreApiData` is not exported.
+
+- [ ] **Step 4: Implement the cleanup extensions**
+
+In `e2e/rbac/support/cleanup.ts`: add the `gitRestoreApiData()` export (using the path from Step 1, an
+`execFile('git', ['-C', API_REPO, 'checkout', '--', dataDir], { timeout: 30000 })` wrapped in
+`.catch(() => {})`), and make `deleteAllSeededUsers()` tolerant of every user's tuple being present or absent
+(it already deletes the matrix tuple; ensure the `f.delete` is `.catch(()=>{})`-guarded so a dynamically-
+revoked tuple doesn't error).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `yarn test --project=rbac-support e2e/rbac/support/cleanup.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run: `yarn typecheck && yarn lint` → exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add e2e/rbac/support/cleanup.ts e2e/rbac/support/cleanup.test.ts
+git commit -m "feat(rbac): cleanup — dynamic grant teardown + gitRestoreApiData"
+```
+
+---
+
+## Self-Review
+
+Spec coverage (against `2026-06-22-rbac-e2e-phase2-execution-design.md`):
+
+- "Seeding model — editors get no FGA tuple by default" → Task 1.
+- New harness piece `grant.ts` (per-spec precondition seeding) → Task 2.
+- New harness piece `requestAccess.ts` (real-UI request submission) → Task 3.
+- New harness piece `mailpit.ts` (registration verification) → Task 4.
+- Cleanup extensions (dynamic grants + `gitRestoreApiData`) → Task 5.
+
+The four stable resource-admin tuples still seed at setup (Task 1 keeps `admin`-relation writes); the two
+registration users remain in `REGISTRATION_USER_IDS` (untouched by setup) — no code change needed, they are
+simply not in `SEEDED_USER_IDS`.
+
+Out of scope here (lives in the companion Scenarios plan): the 11 `NN-*.spec.ts` files, the registration
+UI-driving helper, and the notification-badge/dashboard-card assertions.
+
+## Execution Handoff
+
+Plan complete. The companion **Scenarios** plan (the 11 `NN-*.spec.ts`) is authored after this foundation
+lands, when `requestAccess.ts`/`grant.ts`/`mailpit.ts` signatures are final and selectors can be pinned
+against the running stack. Recommended execution: **subagent-driven-development** — each foundation task is a
+fresh subagent + review. Note Tasks 1–5 require the local docker stack up for their `rbac-support` runs.

--- a/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-scenarios.md
+++ b/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-scenarios.md
@@ -1,0 +1,411 @@
+# RBAC E2E Phase 2 — Scenario Specs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **PREREQUISITE:** the Foundation plan (`2026-06-22-rbac-e2e-phase2-foundation.md`) must be fully landed —
+> this plan consumes `seedUser` (admins-only tuples), `grantScope`/`revokeScope`/`grantTuple` (grant.ts),
+> `submitAccessRequest` (requestAccess.ts), `waitForVerificationLink` (mailpit.ts), and the cleanup extensions.
+
+**Goal:** Implement the 11 Playwright scenario specs that prove the registration → access-request → review →
+approval → RBAC-scoping lifecycle through the real UI, exercising the merged scoped-admin-review feature.
+
+**Architecture:** Each spec is an independent `e2e/rbac/NN-<name>.spec.ts` in the `rbac` project (serial,
+single worker, depends on `rbac-setup`). Specs compose the foundation helpers plus two new UI-driver helpers
+(`support/review.ts` for the admin review UI, `support/register.ts` for Zitadel self-registration). Specs
+seed their own preconditions and clean up after themselves.
+
+**Tech Stack:** Playwright (TS), the foundation helpers, `actingAs`, `Fga`/`ZitadelAdmin` for assertions, the
+`/auth/access-requests` + `/admin/access-requests` endpoints, `permission-requests.php` (submit) and
+`admin-permissions.php` (review).
+
+## Global Constraints
+
+- Branch `e2e/rbac-access-requests`; do NOT push without explicit request; never `--no-verify`.
+- `yarn typecheck` + `yarn lint` exit 0 before every commit. Specs run via `yarn test --project=rbac <file>`.
+- Serial, single worker; the local docker stack must be up (and built from the API branch/`development` that
+  contains the scoped-admin-review feature — recreate `litcal-api`/`litcal-frontend` if needed).
+- No fixed `waitForTimeout`; use Playwright `expect`/locator auto-waiting and the helpers' bounded polling.
+- Each spec is INDEPENDENT and order-free: it seeds its own preconditions and cleans up in `afterEach`/
+  `finally`. Never depend on another spec having run.
+- Scoping facts the specs assert (from the feature design): a resource-admin sees only requests whose every
+  permission targets a resource they hold `admin` on; the global admin (`super-admin`) sees all; a request is
+  scoped to its permission's `{object_type, object_id}`.
+- Fixed object_ids: `national_calendar:IT`/`US`, `diocesan_calendar:romamo_it`, `wider_region:Europe`,
+  `general_roman_calendar:temporale`. Registration users: `cei-admin`, `usccb-editor`.
+
+## Shared spec conventions (apply to every scenario task)
+
+Every spec file follows this skeleton (imports trimmed per spec):
+
+```ts
+import { test, expect } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+import { grantScope, revokeScope } from './support/grant';
+import { submitAccessRequest } from './support/requestAccess';
+import { findRequestRow, requestVisible, actOnRequest } from './support/review';
+import { Fga } from './support/fga';
+import { ZitadelAdmin } from './support/zitadel';
+import { USERS } from './support/users';
+import { truncateAppTables, gitRestoreApiData } from './support/cleanup';
+
+test.afterEach(async () => {
+    // Remove any pending/approved requests created this spec; revoke dynamic editor grants;
+    // restore API data if a scenario edited it. Seeded users + admin tuples persist across the suite.
+    await truncateAppTables();
+    // revokeScope(...) for any editor whose grant this spec created (per-spec list);
+    // gitRestoreApiData() only in scenario 10.
+});
+```
+
+**Assertion primitives (used throughout):**
+
+- "User X sees request R" → act as X, `await page.goto('/admin-permissions.php')`,
+  `expect(await requestVisible(page, { requesterEmail: USERS[r].email })).toBe(true)` (and `false` for the
+  negative case). `requestVisible`/`findRequestRow` are pinned in Task 1.
+- "FGA tuple + role now exist for user U at scope" — resolve the Zitadel id by email, then assert the tuple
+  (`.toBe(true)`; after revoke, `.toBe(false)`):
+
+  ```ts
+  const zid = await new ZitadelAdmin().findUserIdByEmail(USERS[U].email);
+  expect(await new Fga().check(`user:${zid}`, relation, `${type}:${id}`)).toBe(true);
+  ```
+
+- "Request has status S in the list" → `requestVisible(page, { requesterEmail, status: S })` (the review list
+  supports a status filter via `GET /admin/access-requests?status=...`).
+
+---
+
+### Task 1: `support/review.ts` — admin review-UI driver
+
+**Files:**
+
+- Create: `e2e/rbac/support/review.ts`
+
+**Interfaces:**
+
+- Consumes: `admin-permissions.php` review section + `assets/js/admin-permissions.js`
+  (`loadAccessRequests()` → `GET /admin/access-requests`; the review list container; per-request rows;
+  `#permReqReviewModal` with `#permReqDetails`, `#permReqNotesSection` (the notes textarea),
+  `#permReqModalAlerts`; the approve/reject/revoke buttons; `processAccessReq(action)` → `POST
+  /admin/access-requests/{id}/{action}` with `notes`).
+- Produces (relied on by Tasks 2–13):
+  - `requestVisible(page: Page, q: { requesterEmail: string; status?: string }): Promise<boolean>` — navigate/
+    reload the review list (optionally with the status filter) and return whether a row for that requester is
+    present.
+  - `findRequestRow(page: Page, q: { requesterEmail: string }): Promise<Locator>` — the row locator.
+  - `actOnRequest(page: Page, q: { requesterEmail: string; action: 'approve'|'reject'|'revoke'; notes?:
+    string }): Promise<void>` — open the row's review modal, fill notes if given, click the action button,
+    and await the success state + list refresh.
+
+- [ ] **Step 1: Pin the review-UI selectors**
+
+With the stack up, act as `super-admin`, seed one pending request (`actingAs('cei-editor')` +
+`submitAccessRequest(... editor@IT)`), open `admin-permissions.php`, and record the exact selectors: the
+review-list container, the per-row selector + how a row encodes/identifies the request (requester email text,
+`data-*` id), the control that opens `#permReqReviewModal` for a row, the modal's approve/reject/revoke
+buttons, the notes textarea inside `#permReqNotesSection`, and the post-action success indicator
+(`#permReqModalAlerts` success / the row disappearing). Read `admin-permissions.js`
+`loadAccessRequests()`/`renderAccessReqDetails()`/`processAccessReq()` to confirm DOM structure. Record as a
+header comment.
+
+- [ ] **Step 2: Implement `review.ts` with the pinned selectors**
+
+Create `e2e/rbac/support/review.ts` exporting `requestVisible`, `findRequestRow`, `actOnRequest` per the
+Interfaces, using Playwright locators + `expect` auto-wait (reload the list via `page.goto`/a refresh control;
+no fixed sleeps). `actOnRequest` opens the modal, fills `#permReqNotesSection` textarea when `notes` is given,
+clicks the action, and `await expect(<success>).toBeVisible()`.
+
+- [ ] **Step 3: Smoke-validate in a throwaway spec**
+
+Temp spec: seed a pending `editor@IT` request as `cei-editor`; act as `super-admin`;
+`expect(await requestVisible(page, { requesterEmail: USERS['cei-editor'].email })).toBe(true)`;
+`actOnRequest(page, { requesterEmail: USERS['cei-editor'].email, action: 'approve', notes: 'ok' })`; assert
+the FGA tuple now exists. Run `yarn test --project=rbac <temp>.spec.ts` → PASS. Delete the temp spec.
+
+- [ ] **Step 4: Typecheck + lint + commit**
+
+```bash
+yarn typecheck && yarn lint
+git add e2e/rbac/support/review.ts
+git commit -m "feat(rbac): review.ts — admin access-request review-UI driver"
+```
+
+---
+
+### Task 2: Scenario 02 — `cei-editor` requests edit@IT (headline scoped review lifecycle)
+
+**Files:**
+
+- Create: `e2e/rbac/02-cei-editor-edit-request.spec.ts`
+
+**Interfaces:** consumes `grantScope`, `submitAccessRequest`, `actingAs`, `review.ts`, `Fga`, `ZitadelAdmin`,
+`USERS`.
+
+This is the headline spec — exercise it first to validate `review.ts` + the whole loop.
+
+- [ ] **Step 1: Write the spec**
+
+Precondition: seed `cei-admin = admin@IT` (`grantScope('cei-admin')` — cei-admin is a registration user, so
+this seeds the precondition admin tuple + role for an already-existing Zitadel account; if cei-admin is not
+present as a Zitadel account in this independent spec, create+login it first via the foundation seeding path).
+Then:
+
+1. `actingAs('cei-editor')` → `submitAccessRequest(page, { requestedRole: 'calendar_editor', permission: {
+   objectType: 'national_calendar', objectId: 'IT', relation: 'editor' } })`.
+2. Assert visibility: act as `super-admin` → `requestVisible(cei-editor)` true; act as `cei-admin` →
+   `requestVisible(cei-editor)` true; act as `usccb-admin` → `requestVisible(cei-editor)` **false**.
+3. `cei-admin` rejects: `actOnRequest({ requesterEmail: cei-editor, action: 'reject', notes: 'fix scope' })`.
+4. `super-admin` sees the rejection: `requestVisible(cei-editor, { status: 'rejected' })` true.
+5. `cei-editor` revises + resubmits (re-`submitAccessRequest`, or the revise affordance — pin during impl).
+6. `cei-admin` grants: `actOnRequest({ requesterEmail: cei-editor, action: 'approve', notes: 'ok' })`.
+7. Assert the FGA tuple `editor@national_calendar:IT` + the role now exist for cei-editor.
+8. `super-admin` sees the grant: `requestVisible(cei-editor, { status: 'approved' })` true.
+
+`afterEach`: `truncateAppTables()`; `revokeScope('cei-editor')`; `revokeScope('cei-admin')`.
+
+- [ ] **Step 2: Run the spec**
+
+Run: `yarn test --project=rbac e2e/rbac/02-cei-editor-edit-request.spec.ts`
+Expected: PASS. Iterate selectors/timing against the live stack until green (the E2E red-green loop).
+
+- [ ] **Step 3: Typecheck + lint + commit**
+
+```bash
+yarn typecheck && yarn lint
+git add e2e/rbac/02-cei-editor-edit-request.spec.ts
+git commit -m "test(rbac): 02 — cei-editor edit@IT scoped review lifecycle"
+```
+
+---
+
+### Task 3: `support/register.ts` — Zitadel self-registration driver
+
+**Files:**
+
+- Create: `e2e/rbac/support/register.ts`
+
+**Interfaces:**
+
+- Consumes: the registration entry point (from `request-access.php`/login — pinned in Step 1), `mailpit.ts`
+  `waitForVerificationLink`, the cross-org env (`ZITADEL_ORG_ID`, org-domain-suffix login-name setting).
+- Produces (relied on by scenarios 01/04):
+  - `registerAndVerify(page: Page, user: { email: string; password: string; firstName: string; lastName:
+    string }): Promise<void>` — drive the Zitadel self-registration UI, retrieve the verification link from
+    Mailpit, complete verification, and leave the user able to log in.
+
+- [ ] **Step 1: Pin the registration flow**
+
+With the stack up, manually walk the self-registration UI a registration user would use (from
+`request-access.php` or the login page's "register" link): record the form field selectors (email, password,
+given/family name), the submit control, and how the Zitadel verification email's link completes verification
+(does it auto-verify on visit, or require a code entry?). Confirm the cross-org registration succeeds for an
+email pattern `<id>+e2e@litcal.test`. Record as a header comment.
+
+- [ ] **Step 2: Implement `register.ts`** using the pinned selectors + `waitForVerificationLink(email)` to
+  fetch + visit/complete the verification link.
+
+- [ ] **Step 3: Smoke-validate** in a temp spec: `registerAndVerify(page, USERS['cei-admin'])` then assert the
+  user can log in (e.g. `oidcLogin` succeeds, or `findUserIdByEmail` returns an id and a login lands an
+  authenticated `/auth/me.php`). Run → PASS. Delete temp spec. Clean up the created user.
+
+- [ ] **Step 4: Typecheck + lint + commit**
+
+```bash
+yarn typecheck && yarn lint
+git add e2e/rbac/support/register.ts
+git commit -m "feat(rbac): register.ts — Zitadel self-registration + Mailpit verify driver"
+```
+
+---
+
+### Task 4: Scenario 01 — `cei-admin` registers, requests admin@IT
+
+**Files:**
+
+- Create: `e2e/rbac/01-cei-admin-register-request.spec.ts`
+
+- [ ] **Step 1: Write the spec** (real registration; cei-admin is NOT seeded):
+
+1. `registerAndVerify(page, USERS['cei-admin'])`; log in (save state or drive login UI).
+2. As cei-admin, `submitAccessRequest(page, { requestedRole: 'calendar_editor', permission: { objectType:
+   'national_calendar', objectId: 'IT', relation: 'admin' } })`.
+3. Assert **only `super-admin`** sees it (cei-admin is not yet an IT admin): act as `super-admin` →
+   `requestVisible(cei-admin)` true; act as `usccb-admin` → false. (cei-admin cannot review their own request
+   into existence — they have no admin tuple yet.)
+4. `super-admin` rejects (`notes`), cei-admin revises + resubmits, `super-admin` approves.
+5. Assert the FGA tuple `admin@national_calendar:IT` + role now exist for cei-admin.
+
+`afterEach`: `truncateAppTables()`; delete the cei-admin Zitadel user + its tuple (it was created in-spec).
+
+- [ ] **Step 2: Run** `yarn test --project=rbac e2e/rbac/01-cei-admin-register-request.spec.ts` → PASS
+  (iterate; registration is the most timing-sensitive — allow Mailpit polling).
+
+- [ ] **Step 3: Typecheck + lint + commit**
+
+```bash
+git add e2e/rbac/01-cei-admin-register-request.spec.ts
+git commit -m "test(rbac): 01 — cei-admin registration + admin@IT request lifecycle"
+```
+
+---
+
+### Task 5: Scenario 03 — `usccb-admin` requests admin@USA
+
+**Files:** Create `e2e/rbac/03-usccb-admin-request.spec.ts`
+
+- [ ] **Step 1: Write the spec.** usccb-admin is a seeded resource-admin (already admin@US). For a *pending*
+  admin@US **request**, use a not-yet-US-admin requester (per the original design's intent, usccb-admin
+  requesting *additional* admin scope; if that's not meaningful, request as a fresh applicant for admin@US).
+  Concretely: act as a seeded editor without US scope (e.g. `grc-editor`) and
+  `submitAccessRequest(... admin@national_calendar:US)`. Assert **`cei-admin` does NOT see it** (IT admin),
+  only `super-admin` does → `super-admin` approves → assert the tuple now exists for the requester.
+  `afterEach`: truncate + revoke the requester's US tuple.
+
+  (Resolve the "who requests admin@US" requester during impl so the request is in-scope for usccb-admin/
+  super-admin but out-of-scope for cei-admin — the assertion target is the cei-admin-can't-see scoping.)
+
+- [ ] **Step 2: Run → PASS.**
+- [ ] **Step 3: commit** `test(rbac): 03 — admin@USA request not visible to cei-admin`.
+
+---
+
+### Task 6: Scenario 04 — `usccb-editor` registers, requests edit@USA
+
+**Files:** Create `e2e/rbac/04-usccb-editor-register-request.spec.ts`
+
+- [ ] **Step 1: Write the spec.** Precondition: seed `usccb-admin = admin@US` (already seeded at setup).
+  `registerAndVerify(page, USERS['usccb-editor'])` (registration user) → request `edit@US` → assert
+  `usccb-admin` + `super-admin` see it, `cei-admin` does not → `usccb-admin` grants → assert tuple+role exist
+  → `super-admin` sees the grant. `afterEach`: truncate + delete usccb-editor user/tuple.
+- [ ] **Step 2: Run → PASS.**
+- [ ] **Step 3: commit** `test(rbac): 04 — usccb-editor registration + edit@USA grant`.
+
+---
+
+### Task 7: Scenario 05 — `rome-admin` requests admin@romamo_it
+
+**Files:** Create `e2e/rbac/05-rome-admin-request.spec.ts`
+
+- [ ] **Step 1:** Pending admin@`diocesan_calendar:romamo_it` request (requester per the same pattern as Task
+  5). Assert only `super-admin` sees it → grants → tuple exists. `afterEach`: truncate + revoke.
+- [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 05 — admin@romamo_it request, super-admin only`.
+
+---
+
+### Task 8: Scenario 06 — `rome-editor` requests edit@romamo_it
+
+**Files:** Create `e2e/rbac/06-rome-editor-request.spec.ts`
+
+- [ ] **Step 1:** Precondition `rome-admin = admin@romamo_it` (seeded at setup). `actingAs('rome-editor')` →
+  request `edit@romamo_it` → assert `super-admin` + `rome-admin` see it, `cei-admin`/`usccb-admin` do not →
+  `rome-admin` grants → `super-admin` sees the grant. `afterEach`: truncate + `revokeScope('rome-editor')`.
+- [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 06 — rome-editor edit@romamo_it scoped review`.
+
+---
+
+### Task 9: Scenario 07 — dashboard card scoping matrix
+
+**Files:** Create `e2e/rbac/07-dashboard-card-scoping.spec.ts`
+
+**Interfaces:** consumes `actingAs`, the `.admin-block` card selectors + the resource-admin "Access Requests
+to Review" card (from `admin-dashboard.php`/`admin-blocks.php`), `Auth`/page DOM.
+
+- [ ] **Step 1: Pin the card selectors + per-role expectations.** Read `admin-dashboard.php` +
+  `admin-blocks.php`: record each card's `data-block-id`/href and the gating conditional (`$isAdmin`,
+  `$isResourceAdmin`, `$hasCalendarRole`, scope checks). Build the expected per-user matrix: which cards each
+  of `super-admin`, `cei-admin`, `cei-editor`, `usccb-admin`, `grc-admin`, `europe-admin` sees, scope
+  narrowing (National → IT vs USA; Diocesan → romamo_it; GRC; Europe), and that resource-admins see the
+  "Access Requests to Review" card while editors do not and the global FGA-tuple section is hidden.
+- [ ] **Step 2: Write the spec** asserting the matrix per user (extends the existing
+  `00-smoke-dashboard-scoping.spec.ts` patterns; this is the full matrix). Precondition: `grantScope` for any
+  editor whose card-visibility depends on holding a scope. `afterEach`: revoke those.
+- [ ] **Step 3: Run → PASS.** **Step 4: commit** `test(rbac): 07 — dashboard card scoping matrix`.
+
+---
+
+### Task 10: Scenario 08 — negative authorization
+
+**Files:** Create `e2e/rbac/08-negative-auth.spec.ts`
+
+- [ ] **Step 1: Write the spec.** Seed a pending `edit@US` request (requester as in Task 5). As `cei-admin`
+  (IT admin): (a) attempt to approve the US request via the API the UI uses
+  (`POST /admin/access-requests/{id}/approve` through `page.request` with cei-admin's session) → expect 403;
+  (b) assert the US request is **not visible** in cei-admin's review list; (c) attempt to open a USA-scoped
+  dashboard card / edit the USA calendar via `extending.php` → denied/hidden. `afterEach`: truncate + revoke.
+- [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 08 — negative authorization (cei-admin vs USA)`.
+
+---
+
+### Task 11: Scenario 09 — revoke-after-grant lifecycle
+
+**Files:** Create `e2e/rbac/09-revoke-after-grant.spec.ts`
+
+- [ ] **Step 1: Write the spec.** Precondition: `grantScope('cei-editor')` (cei-editor already edit@IT) and a
+  corresponding approved request row (seed via submit+approve, or seed the approved request). As `cei-admin`
+  (or `super-admin`), `actOnRequest({ requesterEmail: cei-editor, action: 'revoke', notes: 'revoked' })`.
+  Assert: the FGA tuple + role are **removed** (`Fga.check(...) === false`); cei-editor's dashboard cards for
+  IT disappear (act as cei-editor, assert the National-IT card is gone); a `revoked` notification is delivered
+  (assert via cei-editor's notification surface — `/auth/access-requests/status` or the bell — pin during
+  impl). `afterEach`: truncate + ensure tuple removed.
+- [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 09 — revoke-after-grant lifecycle`.
+
+---
+
+### Task 12: Scenario 10 — scoped data editing
+
+**Files:** Create `e2e/rbac/10-scoped-data-editing.spec.ts`
+
+**Interfaces:** consumes `grantScope`, `actingAs`, `extending.php` edit flow, `gitRestoreApiData`.
+
+- [ ] **Step 1: Pin the `extending.php` edit flow** (calendar selection, an edit, save, success indicator) for
+  the IT national calendar; confirm the same against USA is blocked for a user scoped only to IT.
+- [ ] **Step 2: Write the spec.** Precondition `grantScope('cei-editor')` (edit@IT). As cei-editor: edit the
+  IT national calendar via `extending.php` → assert success; attempt the same edit against USA → assert
+  failure (403/hidden). `afterEach`: `truncateAppTables()`; `revokeScope('cei-editor')`; **`gitRestoreApiData()`**.
+- [ ] **Step 3: Run → PASS** (verify `gitRestoreApiData` reverts the edit — re-run must start clean).
+- [ ] **Step 4: commit** `test(rbac): 10 — scoped data editing (IT ok, USA denied)`.
+
+---
+
+### Task 13: Scenario 11 — session/token resilience
+
+**Files:** Create `e2e/rbac/11-session-resilience.spec.ts`
+
+- [ ] **Step 1: Write the spec.** (a) Cookie/session expiry + refresh mid-flow: clear/expire the
+  `litcal_access_token` cookie and assert the app refreshes or redirects to re-auth correctly; (b) logout then
+  log in as a different user (act as A, log out, act as B) — assert no stale auth state; (c) a grant/revoke is
+  reflected on the next `/auth/me` without stale caching: `grantScope`/`revokeScope` a user mid-session and
+  assert the change surfaces after a reload. `afterEach`: truncate + revoke any dynamic grants.
+- [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 11 — session/token resilience`.
+
+---
+
+## Self-Review
+
+Spec coverage — every scenario in `2026-06-22-rbac-e2e-phase2-execution-design.md` maps to a task:
+01→Task 4, 02→Task 2, 03→Task 5, 04→Task 6, 05→Task 7, 06→Task 8, 07→Task 9, 08→Task 10, 09→Task 11,
+10→Task 12, 11→Task 13; the review-UI driver (Task 1) and registration driver (Task 3) are the shared helpers
+the design's "new harness pieces" implied beyond the foundation. Build order matches the design: review.ts +
+scenario 02 first, then register.ts + scenario 01, then the rest.
+
+Interface consistency: every spec consumes only foundation exports (`grantScope`/`revokeScope`/`grantTuple`,
+`submitAccessRequest`, `waitForVerificationLink`, `truncateAppTables`/`gitRestoreApiData`) + the two new
+drivers (`requestVisible`/`findRequestRow`/`actOnRequest`, `registerAndVerify`) + `Fga`/`ZitadelAdmin`/`USERS`.
+Names match across tasks.
+
+Known E2E discovery points (not placeholders — the inherent red-green loop): the exact DOM selectors for the
+review list/modal (Task 1 Step 1), the permission-builder (Foundation Task 3), the registration UI (Task 3
+Step 1), the `extending.php` edit flow (Task 12 Step 1), and the revoke notification surface (Task 11) are
+pinned against the running stack in the cited steps, then frozen in the helper/spec.
+
+Open item to resolve at impl: the "who requests admin@US / admin@romamo_it" requester for scenarios 03/05
+(must be in-scope for the target admin + super-admin, out-of-scope for cei-admin) — pick a seeded editor
+lacking that scope; noted in each task.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-scenarios.md`. Execute **after**
+the Foundation plan lands, via **subagent-driven-development** (fresh subagent per task + review), with the
+docker stack up. Tasks 1 and 3 (the UI drivers) gate the scenarios that consume them — do them in the listed
+order (review.ts → 02 → register.ts → 01 → 03–11).

--- a/docs/superpowers/specs/2026-06-21-frontend-rbac-e2e-design.md
+++ b/docs/superpowers/specs/2026-06-21-frontend-rbac-e2e-design.md
@@ -1,0 +1,167 @@
+# Frontend RBAC / Access-Request E2E Test Suite — Design
+
+**Date:** 2026-06-21
+**Repo:** LiturgicalCalendarFrontend
+**Branch:** `e2e/rbac-access-requests` (worktree, based on PR #339 `feat/general-roman-calendar-object-type`)
+
+## Goal
+
+A Playwright end-to-end suite that exercises the full **registration → access-request → approval →
+RBAC-scoping** lifecycle through the real UI, proving that resource-admin scoping (who sees / can act on
+which request, and which admin-dashboard cards each user sees) behaves correctly across national,
+diocesan, wider-region, and General Roman calendar resources.
+
+The suite also regression-guards the cross-org Zitadel registration fix (`ZITADEL_ORG_ID` org scope +
+the org-domain-suffix login-name setting) that unblocked registering an email already present in another
+organization.
+
+## Context (current state)
+
+- The frontend already uses **Playwright** (`e2e/`, `playwright.config.ts`) with a `setup` project
+  (`auth.setup.ts`) that logs in **one** user via `POST /auth/login` with `TEST_USERNAME`/`TEST_PASSWORD`,
+  saving `storageState` to `e2e/.auth/user.json`. It **bypasses Zitadel registration** entirely.
+- The stack is the API's `docker-compose` (Postgres, Zitadel, OpenFGA, Mailpit, Adminer) plus the API and
+  frontend PHP servers (started by Playwright's `webServer`).
+- Resource-admin scoping of "who sees which access request" is implemented in the API by
+  `AccessRequestAdminHandler::filterByAdminAccess` (FGA `check` fan-out) on `GET /admin/access-requests`,
+  already covered by PHPUnit tests (issue #633). This suite exercises the same logic through the UI.
+- **PR #339** adds the `general_roman_calendar` object type and touches `permission-requests.php/js` and
+  `admin-permissions.php/js`. This suite is based on PR #339 so the GRC scenarios are testable now; it
+  rebases onto `development` after PR #339 merges.
+
+## Decisions (from brainstorming)
+
+- **User provisioning:** hybrid — seed most users programmatically; drive the real Zitadel registration UI
+  for a couple of representative users.
+- **Run target:** local-first now, structured to be CI-ready later (no CI workflow built in this round).
+- **Worktree base:** off PR #339's branch so GRC works immediately.
+- **Extra coverage (all selected):** negative authorization, revoke-after-grant lifecycle, scoped data
+  editing, session/token resilience.
+
+## Architecture
+
+```text
+e2e/
+  rbac/
+    support/
+      users.ts        the 11-user matrix — single source of truth (id, email, role, FGA tuple, scope)
+      seed.ts         thin TS client → invokes the PHP seeder over HTTP/CLI; returns created identities
+      actingAs.ts     fixture: open a BrowserContext from a given user's saved storageState
+      mailpit.ts      query the Mailpit API; extract verification links for registration specs
+      cleanup.ts      truncate app tables, delete seeded Zitadel users + FGA tuples
+    rbac.setup.ts     global setup: seed users, log each in, save per-user storageState
+    01-cei-admin-request.spec.ts ... 11-session-resilience.spec.ts
+  .auth/<user>.json   per-user sessions (gitignored)
+```
+
+- A **new Playwright project `rbac`** with its own setup dependency (`rbac.setup.ts`), leaving the existing
+  single-user specs and `auth.setup.ts` untouched.
+- The **seeder lives in the API repo** as a small PHP script that reuses `ZitadelService`, `OpenFgaClient`,
+  and the repositories — Zitadel/FGA logic stays in one place instead of being reimplemented in TypeScript.
+  `seed.ts` invokes it and receives the created user identities (ids, emails).
+- `actingAs(user)` returns a `BrowserContext` built from that user's `storageState`; a spec acting as
+  several users opens several contexts.
+
+## Seed matrix (`users.ts`)
+
+All users live in the **LiturgicalCalendar Zitadel org**. Project role is `calendar_editor` unless noted.
+"FGA tuple" is the scoped permission written to OpenFGA.
+
+| User            | Zitadel role     | FGA tuple                                  | Scope            |
+|-----------------|------------------|--------------------------------------------|------------------|
+| `super-admin`   | `admin` (global) | —                                          | everything       |
+| `cei-admin`     | calendar_editor  | `admin`  @ `national_calendar:IT`          | IT national      |
+| `cei-editor`    | calendar_editor  | `editor` @ `national_calendar:IT`          | IT national      |
+| `usccb-admin`   | calendar_editor  | `admin`  @ `national_calendar:USA`         | USA national     |
+| `usccb-editor`  | calendar_editor  | `editor` @ `national_calendar:USA`         | USA national     |
+| `rome-admin`    | calendar_editor  | `admin`  @ `diocesan_calendar:romamo_it`   | Rome diocese     |
+| `rome-editor`   | calendar_editor  | `editor` @ `diocesan_calendar:romamo_it`   | Rome diocese     |
+| `grc-admin`     | calendar_editor  | `admin`  @ `general_roman_calendar`        | GRC (PR 339)     |
+| `grc-editor`    | calendar_editor  | `editor` @ `general_roman_calendar`        | GRC (PR 339)     |
+| `europe-admin`  | calendar_editor  | `admin`  @ `wider_region:EU`               | Europe region    |
+| `europe-editor` | calendar_editor  | `editor` @ `wider_region:EU`               | Europe region    |
+
+Exact object_ids (`EU` vs `Europe`, the GRC key and whether GRC has sub-resources such as `temporale` /
+`decrees` / Latin-edition missals) are pinned from the API source data and PR #339 during implementation.
+
+## Seeding & registration mechanism
+
+- **Seeded users (9 of 11):** the seeder creates the Zitadel user (email pre-verified, known password),
+  writes the FGA tuple, and grants the role. `rbac.setup.ts` logs each in via `POST /auth/login` and saves
+  `storageState`. Deterministic and fast.
+- **Real-registration specs (2):** `cei-admin` and `usccb-editor` are NOT pre-seeded. Their specs drive the
+  actual Zitadel self-registration UI, read the verification email from **Mailpit**, and complete first
+  login — regression-guarding the cross-org registration fix. Requires the org-domain-suffix login-name
+  setting (already enabled) and a reachable Mailpit.
+- **Idempotency:** the seeder is upsert-style (delete-then-create by email) so re-runs start clean.
+
+## Scenario specs
+
+Each spec is **independent**: it seeds its own precondition grants rather than depending on a prior spec
+having run, so order does not matter and any spec runs alone.
+
+1. **01 — cei-admin requests `admin`@IT** (real registration): register → request → assert **only
+   super-admin** sees it (cei-admin is not yet an IT admin) → (a) super-admin rejects → (b) cei-admin
+   revises + resubmits → (c) super-admin approves → assert the FGA tuple and role now exist.
+2. **02 — cei-editor requests `edit`@IT** (precondition: cei-admin is admin@IT): assert **both** super-admin
+   and cei-admin see it, usccb-admin does not → (a) cei-admin rejects → (b) super-admin sees the rejection →
+   (c) cei-editor revises → (d) cei-admin grants → (e) super-admin sees the grant.
+3. **03 — usccb-admin requests `admin`@USA**: assert **cei-admin does NOT see it**, only super-admin →
+   super-admin grants.
+4. **04 — usccb-editor requests `edit`@USA**: usccb-admin + super-admin see it, cei-admin does not →
+   usccb-admin grants → super-admin sees the grant.
+5. **05 — rome-admin requests `admin`@romamo_it**: only super-admin sees → grants.
+6. **06 — rome-editor requests `edit`@romamo_it**: super-admin + rome-admin see it, cei-admin/usccb-admin do
+   not → rome-admin grants → super-admin sees the grant.
+7. **07 — dashboard card scoping**: per-user matrix assertions on the `.admin-block` cards: which render,
+   narrowing (Sanctorale → `IT_` / `US_` / Latin missals; National → IT / USA; Diocesan → romamo_it), and
+   that **admins additionally see Users + Permissions cards scoped to their resource** while editors do not;
+   super-admin sees all cards unrestricted. Includes the GRC (Temporale/Decrees/Latin missals) and Europe
+   rows.
+8. **08 — negative authorization**: cei-admin attempts to approve/grant a USA request, open a USA-scoped
+   card, and edit the USA calendar → all denied (403 / hidden). The mirror of scenarios 3–6.
+9. **09 — revoke-after-grant lifecycle**: an admin revokes a granted permission → the user's FGA tuple/role
+   is removed, their dashboard cards disappear, and they receive a `revoked` notification.
+10. **10 — scoped data editing**: cei-editor edits the IT national calendar via `extending.php` and it
+    succeeds; the same edit against USA fails. Reuses the existing `gitRestoreApiData()` cleanup.
+11. **11 — session/token resilience**: cookie/session expiry + refresh mid-flow; logout then login as a
+    different user; a grant/revoke is reflected on the next `/auth/me` without stale caching.
+
+## Determinism, cleanup, isolation
+
+- **Serial, single worker** (matches the existing config — shared API/DB/FGA state).
+- **`globalSetup` seeds; `globalTeardown` + per-spec `afterEach` clean:** truncate `access_requests`,
+  notification-state, and `audit_log`; delete the run's FGA tuples and Zitadel test users; run
+  `gitRestoreApiData()` for any calendar edits.
+- **Namespacing:** all seeded emails use a dedicated test pattern (e.g. `<role>+e2e@<test-domain>`) so
+  cleanup targets them precisely and never touches real users.
+- **Independent specs** via per-spec precondition seeding (no inter-spec ordering dependency).
+
+## Worktree, structure, CI-readiness
+
+- **Worktree:** new branch `e2e/rbac-access-requests` based on PR #339's tip, in a sibling directory; the
+  other agent's checkout is untouched. Rebase onto `development` after PR #339 merges and retarget the PR to
+  `development`.
+- **Env:** new `.env` keys for the seeder (Zitadel mgmt token + org id, FGA store/model ids, Mailpit URL) —
+  all already present in the stack configuration.
+- **CI-ready:** seeding is fully scripted and idempotent and the stack is the existing `docker-compose`, so a
+  later CI job is "boot compose → seed → `playwright test --project=rbac`" with no rewrite. The CI workflow
+  is not built in this round.
+
+## Risks & dependencies
+
+1. **GRC specs depend on PR #339** — green only on this branch until PR #339 merges.
+2. **Admin notification surfacing:** confirm during implementation which endpoint the admin bell uses
+   (`/admin/access-requests` scoped list vs a notifications route); the scoping logic itself is the
+   #633-tested `filterByAdminAccess`.
+3. **Real-registration specs** depend on the org-domain-suffix login-name setting (enabled) and a reachable
+   Mailpit.
+4. **Europe / GRC object_ids** need pinning from the API source data and PR #339.
+
+## Out of scope (this round)
+
+- Building a CI workflow / required check.
+- Performance/load testing.
+- Testing Zitadel itself (only our integration with it).
+- API-level assertions already covered by the API PHPUnit suite (e.g. `filterByAdminAccess` unit coverage
+  from #633) — those are exercised here only indirectly through the UI.

--- a/docs/superpowers/specs/2026-06-21-frontend-rbac-e2e-design.md
+++ b/docs/superpowers/specs/2026-06-21-frontend-rbac-e2e-design.md
@@ -67,22 +67,23 @@ e2e/
 All users live in the **LiturgicalCalendar Zitadel org**. Project role is `calendar_editor` unless noted.
 "FGA tuple" is the scoped permission written to OpenFGA.
 
-| User            | Zitadel role     | FGA tuple                                  | Scope            |
-|-----------------|------------------|--------------------------------------------|------------------|
-| `super-admin`   | `admin` (global) | —                                          | everything       |
-| `cei-admin`     | calendar_editor  | `admin`  @ `national_calendar:IT`          | IT national      |
-| `cei-editor`    | calendar_editor  | `editor` @ `national_calendar:IT`          | IT national      |
-| `usccb-admin`   | calendar_editor  | `admin`  @ `national_calendar:USA`         | USA national     |
-| `usccb-editor`  | calendar_editor  | `editor` @ `national_calendar:USA`         | USA national     |
-| `rome-admin`    | calendar_editor  | `admin`  @ `diocesan_calendar:romamo_it`   | Rome diocese     |
-| `rome-editor`   | calendar_editor  | `editor` @ `diocesan_calendar:romamo_it`   | Rome diocese     |
-| `grc-admin`     | calendar_editor  | `admin`  @ `general_roman_calendar`        | GRC (PR 339)     |
-| `grc-editor`    | calendar_editor  | `editor` @ `general_roman_calendar`        | GRC (PR 339)     |
-| `europe-admin`  | calendar_editor  | `admin`  @ `wider_region:EU`               | Europe region    |
-| `europe-editor` | calendar_editor  | `editor` @ `wider_region:EU`               | Europe region    |
+| User            | Zitadel role     | FGA tuple                                     | Scope         |
+| --------------- | ---------------- | --------------------------------------------- | ------------- |
+| `super-admin`   | `admin` (global) | —                                             | everything    |
+| `cei-admin`     | calendar_editor  | `admin` @ `national_calendar:IT`              | IT national   |
+| `cei-editor`    | calendar_editor  | `editor` @ `national_calendar:IT`             | IT national   |
+| `usccb-admin`   | calendar_editor  | `admin` @ `national_calendar:US`              | US national   |
+| `usccb-editor`  | calendar_editor  | `editor` @ `national_calendar:US`             | US national   |
+| `rome-admin`    | calendar_editor  | `admin` @ `diocesan_calendar:romamo_it`       | Rome diocese  |
+| `rome-editor`   | calendar_editor  | `editor` @ `diocesan_calendar:romamo_it`      | Rome diocese  |
+| `grc-admin`     | calendar_editor  | `admin` @ `general_roman_calendar:temporale`  | GRC temporale |
+| `grc-editor`    | calendar_editor  | `editor` @ `general_roman_calendar:temporale` | GRC temporale |
+| `europe-admin`  | calendar_editor  | `admin` @ `wider_region:Europe`               | Europe region |
+| `europe-editor` | calendar_editor  | `editor` @ `wider_region:Europe`              | Europe region |
 
-Exact object_ids (`EU` vs `Europe`, the GRC key and whether GRC has sub-resources such as `temporale` /
-`decrees` / Latin-edition missals) are pinned from the API source data and PR #339 during implementation.
+Object_ids are RESOLVED (verified against API source data + the live stack on 2026-06-21): national
+`IT`/`US`, `diocesan_calendar:romamo_it`, `wider_region:Europe`, and `general_roman_calendar:temporale`
+(GRC enumerated ids: `temporale,EDITIO_TYPICA_1970,EDITIO_TYPICA_2002,EDITIO_TYPICA_2008,decrees`).
 
 ## Seeding & registration mechanism
 
@@ -98,7 +99,7 @@ Exact object_ids (`EU` vs `Europe`, the GRC key and whether GRC has sub-resource
 ## Scenario specs
 
 Each spec is **independent**: it seeds its own precondition grants rather than depending on a prior spec
-having run, so order does not matter and any spec runs alone.
+having run, so specs can run in any order, including in isolation.
 
 1. **01 — cei-admin requests `admin`@IT** (real registration): register → request → assert **only
    super-admin** sees it (cei-admin is not yet an IT admin) → (a) super-admin rejects → (b) cei-admin
@@ -156,7 +157,8 @@ having run, so order does not matter and any spec runs alone.
    #633-tested `filterByAdminAccess`.
 3. **Real-registration specs** depend on the org-domain-suffix login-name setting (enabled) and a reachable
    Mailpit.
-4. **Europe / GRC object_ids** need pinning from the API source data and PR #339.
+4. **Europe / GRC object_ids** — RESOLVED (verified against the live stack 2026-06-21): `wider_region:Europe`
+   and `general_roman_calendar:temporale`. No longer a risk.
 
 ## Out of scope (this round)
 

--- a/docs/superpowers/specs/2026-06-21-scoped-admin-review-design.md
+++ b/docs/superpowers/specs/2026-06-21-scoped-admin-review-design.md
@@ -1,0 +1,202 @@
+# Scoped Admin-Review for Resource-Admins — Design
+
+**Date:** 2026-06-21
+**Repos:** LiturgicalCalendarAPI (PHP API) + LiturgicalCalendarFrontend (PHP frontend)
+**Related:** unblocks the Phase 2 RBAC E2E suite (`docs/superpowers/specs/2026-06-21-frontend-rbac-e2e-design.md`)
+
+## Goal
+
+Let a **resource-admin** — a user who holds an OpenFGA `admin` tuple on some resource (e.g. `cei-admin` →
+`admin@national_calendar:IT`) but does **not** hold the global Zitadel `admin` role — review the
+access-requests scoped to the resources they administer: view them, and approve / reject / revoke them,
+through the existing admin UI, with a notification badge for their pending review queue.
+
+## Context (why this is needed)
+
+The API already supports resource-admins end-to-end:
+
+- `GET /admin/access-requests` filters the list to what the caller administers via
+  `AccessRequestAdminHandler::filterByAdminAccess()` (`src/Handlers/Admin/AccessRequestAdminHandler.php`
+  ~lines 1003–1040): a global admin sees all; a resource-admin sees only requests whose every permission
+  tuple targets a resource they hold `admin` on; a plain editor sees none.
+- approve / reject / revoke enforce the same via `requireAdminForAllResources()` (~lines 957–991).
+
+The **frontend** is the only thing locking resource-admins out:
+
+- `admin-permissions.php` (the sole access-request review UI) redirects anyone without the global `admin`
+  role (lines 20–26: `$isAdmin = $authHelper->hasRole('admin'); if (!$isAdmin) { header('Location:
+  admin-dashboard.php'); exit; }`).
+- `admin-dashboard.php` renders the admin section (incl. the "Role Requests" / "Permissions" cards that
+  link to `admin-permissions.php`) only inside `if ($isAdmin)` — so resource-admins see no entry point.
+- `notifications.js` fixes its mode at init to `Auth.hasRole('admin') ? 'admin' : 'user'`, so a
+  resource-admin gets the personal-inbox bell, never the review-queue bell.
+- Nothing exposes a user's resource-admin status to the frontend: `auth/me.php` returns roles only.
+
+This feature closes that frontend gap. No new authorization model is introduced — the API's existing
+FGA-scoped checks remain the enforcement boundary.
+
+## Capability scope
+
+Resource-admins get **access-request review only**: view + approve / reject / revoke the requests scoped
+to resources they administer, plus a scoped pending-review notification badge. They do **not** get the raw
+FGA permission-tuple management UI, global user management, or scoped data-editing entry points.
+
+## Architecture
+
+A small API addition exposes the caller's admin status/scopes; the existing admin notifications endpoint is
+widened to resource-admins with a scoped count; the frontend uses that signal to admit resource-admins to
+the existing review UI (hiding the global-only sections), add a dashboard entry, and switch the
+notification bell to the scoped review queue.
+
+```text
+LiturgicalCalendarAPI
+  GET /auth/admin-scopes            (NEW)  → { is_global_admin, is_resource_admin, admin_scopes[] }
+  GET /admin/notifications          (WIDEN) → resource-admins allowed; scoped pending count + items
+
+LiturgicalCalendarFrontend
+  src/AuthHelper.php                 → isResourceAdmin(): bool, adminScopes(): array   (calls /auth/admin-scopes)
+  assets/js/auth.js                  → Auth.isResourceAdmin(): Promise<bool>           (calls /auth/admin-scopes)
+  admin-permissions.php              → gate admits global OR resource admin; FGA-tuple section global-only
+  admin-dashboard.php                → "Access Requests to Review" card for resource-admins
+  assets/js/notifications.js         → mode = (admin role || resource-admin) ? 'admin' : 'user'
+```
+
+## Components
+
+### 1. API — `GET /auth/admin-scopes` (new)
+
+OIDC-protected (same middleware group as the other `/auth/*` routes). Computes, for the authenticated
+user (`oidc_user['sub']`):
+
+- `is_global_admin`: the `admin` role is present in the token (reuse `OidcAuthMiddleware::isAdmin` /
+  `hasRole($oidcUser, 'admin')`).
+- `admin_scopes`: union of `OpenFgaClient::listObjects("user:{sub}", "admin", $type)` over the
+  admin-capable object types `national_calendar`, `diocesan_calendar`, `wider_region`,
+  `general_roman_calendar`, returned as `[{ object_type, object_id }]`.
+- `is_resource_admin`: `admin_scopes` is non-empty.
+
+Response shape:
+
+```json
+{
+  "is_global_admin": false,
+  "is_resource_admin": true,
+  "admin_scopes": [
+    { "object_type": "national_calendar", "object_id": "IT" }
+  ]
+}
+```
+
+New handler `src/Handlers/Auth/AdminScopesHandler.php`, registered in the Router's OIDC-protected `auth`
+group alongside `access-requests` / `notifications`. If OpenFGA is unavailable, return
+`is_resource_admin: false` with an empty `admin_scopes` (fail closed) and `is_global_admin` still derived
+from the token.
+
+### 2. API — widen `GET /admin/notifications`
+
+Today `src/Handlers/Admin/NotificationsHandler.php` requires the global `admin` role and counts ALL pending
+access-requests (`countPending()`, unscoped) plus applications. Change:
+
+- **Admit resource-admins** (global admin OR resource-admin); others stay rejected.
+- **Global admin:** behavior unchanged (unscoped `pending_access_requests`, `pending_applications`, items).
+- **Resource-admin:** `pending_access_requests` = count of pending requests they administer (scoped via the
+  same logic as `filterByAdminAccess`); `items` = those scoped requests (capped at 5, `url` =
+  `admin-permissions.php`); `pending_applications` = 0 (applications stay a global-admin concern);
+  `total` = the scoped access-request count.
+
+The scoping logic is shared so the badge count and the review list agree. Extract the per-request
+"does this admin administer every resource in the request" predicate (currently inside
+`AccessRequestAdminHandler::filterByAdminAccess`) into a reusable helper (e.g. a method on
+`AccessRequestRepository` or a small service) consumed by both handlers, rather than duplicating it.
+
+### 3. Frontend — `src/AuthHelper.php`
+
+Add two methods, memoized per request, that call `GET /auth/admin-scopes` server-side with the user's
+session cookie:
+
+- `isResourceAdmin(): bool`
+- `adminScopes(): array` (list of `['object_type' => ..., 'object_id' => ...]`)
+
+These sit beside the existing `hasRole()` / `hasPermission()` (`src/AuthHelper.php` ~lines 282–296). A
+single fetch populates both; on error, fail closed (`false` / `[]`).
+
+### 4. Frontend — `assets/js/auth.js`
+
+Add `Auth.isResourceAdmin(): Promise<boolean>` that fetches `GET /auth/admin-scopes` once and caches the
+result (mirroring the existing auth-state caching). Used by `notifications.js`.
+
+### 5. Frontend — `admin-permissions.php` gate + section guard
+
+- Gate: admit when `$authHelper->hasRole('admin') || $authHelper->isResourceAdmin()` (else redirect to
+  `admin-dashboard.php` as today). Compute `$isGlobalAdmin = $authHelper->hasRole('admin')` for use below.
+- The page has two sections. The **FGA permission-tuple management** section stays global-admin-only:
+  wrap its markup in `if ($isGlobalAdmin)` and skip its JS initialization for resource-admins. The
+  **access-requests review** section renders for both; its data (`GET /admin/access-requests`) and actions
+  (approve / reject / revoke) are already scoped by the API for resource-admins, so no logic change beyond
+  not assuming a global admin.
+
+### 6. Frontend — `admin-dashboard.php` entry card
+
+Add an "Access Requests to Review" card linking to `admin-permissions.php`, shown when
+`$authHelper->isResourceAdmin() && !$authHelper->hasRole('admin')` (global admins already have the full
+admin section with its "Role Requests" / "Permissions" cards, so the new card is for resource-admins only).
+Resource-admins are `calendar_editor`, so they already pass the dashboard's `$hasCalendarRole` gate.
+
+### 7. Frontend — `assets/js/notifications.js` mode
+
+Change the init mode decision (currently `this._mode = Auth.hasRole('admin') ? 'admin' : 'user'`,
+~line 55) to: `'admin'` when `Auth.hasRole('admin') || await Auth.isResourceAdmin()`, else `'user'`.
+Resource-admins thus poll `/admin/notifications` (now scoped) and get the review-queue bell + badge. This
+mirrors the existing trade-off for global admins (review queue instead of personal inbox; a resource-admin
+still sees their own request outcomes on `permission-requests.php`). The `seen` POST remains user-mode only.
+
+## Data flow
+
+1. On any authenticated page, the frontend `AuthHelper` resolves `isResourceAdmin()` from
+   `GET /auth/admin-scopes` (server-side).
+2. `admin-dashboard.php` shows the review card to resource-admins; `admin-permissions.php` admits them and
+   hides the global-only tuple section.
+3. The review section calls `GET /admin/access-requests` → API returns the scoped list. Approve / reject /
+   revoke call the existing endpoints → API enforces `requireAdminForAllResources`.
+4. `notifications.js` resolves `Auth.isResourceAdmin()`, enters admin mode, and polls
+   `/admin/notifications` → API returns the scoped pending count + items.
+
+## Error handling
+
+- `/auth/admin-scopes` and the widened `/admin/notifications` fail closed when OpenFGA is unavailable
+  (treat as not-a-resource-admin; global-admin status still honored from the token).
+- Frontend gates fail closed: if `isResourceAdmin()` cannot be resolved, the user is treated as a
+  non-admin (redirected from `admin-permissions.php`, no card, user-mode bell).
+
+## Security
+
+Hiding the FGA-tuple UI from resource-admins is **not** the security boundary — the API
+(`PermissionAdminHandler`, which already checks `isResourceAdmin` per tuple op) and the access-request
+admin endpoints (`filterByAdminAccess` / `requireAdminForAllResources`) remain the enforcement points. The
+frontend changes only widen *who the UI lets in* and *what it shows*; every privileged action is still
+authorized server-side against OpenFGA. `/auth/admin-scopes` returns scopes for the authenticated caller
+only.
+
+## Testing
+
+- **API (PHPUnit):** `/auth/admin-scopes` for a global admin (`is_global_admin: true`), a resource-admin
+  (`is_resource_admin: true` + correct `admin_scopes`), and a plain editor (both false, empty scopes).
+  Widened `/admin/notifications`: resource-admin gets a scoped count (only their requests, no
+  applications); global admin unchanged; plain editor rejected.
+- **Frontend:** this feature **unblocks Phase 2 E2E** — resource-admin scoping becomes UI-testable
+  (cei-admin sees + approves cei-editor's IT request; usccb-admin does not see it; the review-queue badge
+  reflects only scoped pending requests).
+
+## Out of scope (YAGNI)
+
+- Raw FGA permission-tuple management for resource-admins (stays global-admin-only).
+- Global user management / applications review for resource-admins.
+- Scoped data-editing entry points (calendar editing) gated by FGA scope on the dashboard.
+- A combined notification mode showing both personal inbox and review queue (resource-admins get the
+  review-queue bell, matching global-admin behavior).
+
+## Enables
+
+With resource-admins able to review through the UI, the Phase 2 RBAC E2E scenarios (resource-admin
+request-visibility scoping, approve/reject/revise/revoke lifecycle across scopes) become testable through
+the real UI as the design spec intended.

--- a/docs/superpowers/specs/2026-06-22-rbac-e2e-phase2-execution-design.md
+++ b/docs/superpowers/specs/2026-06-22-rbac-e2e-phase2-execution-design.md
@@ -1,0 +1,149 @@
+# RBAC E2E Phase 2 — Execution Design
+
+**Date:** 2026-06-22
+**Repo:** LiturgicalCalendarFrontend
+**Branch:** `e2e/rbac-access-requests` (folds into PR #345)
+**Supersedes/extends:** [`2026-06-21-frontend-rbac-e2e-design.md`](2026-06-21-frontend-rbac-e2e-design.md) (original 11-scenario design)
+**Depends on:** scoped-admin-review feature — API merged to `development` (PR #656); frontend on PR #345
+(see [`2026-06-21-scoped-admin-review-design.md`](2026-06-21-scoped-admin-review-design.md))
+
+## Goal
+
+Implement the full **11-scenario** Playwright suite from the original E2E design through the **real UI**,
+proving the registration → access-request → review → approval → RBAC-scoping lifecycle and the
+resource-admin scoping the scoped-admin-review feature now enables. The suite folds into PR #345.
+
+## Why this is now buildable
+
+The original design's scenarios assumed resource-admins could *review through the UI*. They could not — the
+frontend locked them out — which is why Phase 2 paused to build the scoped-admin-review feature. That
+feature is now merged (API on `development` via #656; frontend on #345), so every scenario that depends on a
+resource-admin seeing/acting on a scoped request is unblocked. This document records the decisions that turn
+the original design into an executable plan; the scenario *intent* is unchanged from the original design.
+
+## Decisions (this round)
+
+- **Scope:** all 11 scenarios from the original design's "Scenario specs" section.
+- **Request creation: real UI flow.** When a scenario says "X requests Y", X logs in and submits through
+  `request-access.php`. The requested grant is the **approval outcome**, not a pre-seeded tuple. Requester
+  users are therefore **not** pre-seeded with the grant they request.
+- **Per-spec precondition seeding** (already the original design's principle): each spec seeds only the
+  grants it needs as preconditions (e.g. scenario 02 seeds `cei-admin = admin@IT` so an IT admin exists to
+  review), then drives the UI. Specs remain independent and order-free.
+- **Target:** fold into PR #345 (same branch). Accepted tradeoff: #345 becomes a large PR.
+- **Run mode:** serial, single worker (shared API/DB/FGA/Zitadel state), matching the existing config.
+
+## Seeding model
+
+Three user classes in the `users.ts` matrix (11 users — unchanged matrix; what changes is *what gets
+seeded when*):
+
+The 11 users split by **how they enter the system** (the two `REGISTRATION_USER_IDS` —
+`cei-admin`, `usccb-editor` — are never seeded; everyone else is) and **whether their FGA grant is seeded
+or earned via the UI**:
+
+- **Global admin** — `super-admin`. Seeded: Zitadel account + `admin` role + login session. Grant: n/a
+  (global role).
+- **Seeded resource-admins** — `usccb-admin`, `rome-admin`, `grc-admin`, `europe-admin`. Seeded: account +
+  `calendar_editor` role + login + their `admin` FGA tuple (stable, seeded at setup; lets them review).
+- **Seeded requester-editors** — `cei-editor`, `rome-editor`, `grc-editor`, `europe-editor`. Seeded:
+  account + `calendar_editor` role + login, **no FGA tuple**. Grant is earned via `request-access.php`
+  in-spec (the approval outcome); a spec needing it as a *precondition* (e.g. scenario 10) seeds it
+  explicitly.
+- **Registration users** — `cei-admin`, `usccb-editor`. **Not seeded at all**: they drive the real Zitadel
+  self-registration UI + Mailpit verification in-spec (scenarios 01/04). When a *later* spec needs
+  `cei-admin` to already be an IT admin (e.g. scenario 02), it seeds `cei-admin = admin@IT` as a
+  precondition.
+
+`rbac.setup.ts` seeds accounts + roles + per-user `storageState` (so `actingAs(user)` works for every
+seeded user); it stops pre-seeding editor FGA tuples; it seeds the four stable resource-admin tuples and
+leaves the two registration users untouched.
+
+## New / changed harness pieces
+
+1. **`support/requestAccess.ts`** (new) — submit a pending request as a logged-in user by driving
+   `request-access.php` (select resource/role, submit, assert it lands as pending). The precondition for
+   every review scenario. Returns the created request's identifying info where the UI/DOM exposes it.
+2. **`support/grant.ts`** (new, or extend `seed.ts`) — per-spec precondition seeding of an arbitrary
+   `(user, relation, objectType, objectId)` FGA tuple + the project role, composing the existing
+   `Fga.write()` and `ZitadelAdmin.grantProjectRole()` primitives. Idempotent.
+3. **`support/mailpit.ts`** (new) — query the Mailpit REST API, find the latest verification email for an
+   address, extract the verification link. Used by the 2 real-registration scenarios. **Highest-risk piece**
+   (real registration UI + cross-org Zitadel fix + email round-trip).
+4. **`cleanup.ts`** (extend) — beyond truncating `access_requests`/`audit_log`/`user_notification_state`
+   and deleting seeded users + their *seeded* tuples, it must remove FGA tuples + role grants **created
+   during specs** (approval outcomes) and run `gitRestoreApiData()` to revert scenario 10's calendar edits.
+   Approach: derive tuples-to-delete from the matrix + any per-spec grants, and reset API source data via the
+   existing git-restore mechanism the original design references.
+
+## Scenarios (11)
+
+Intent per the original design's "Scenario specs"; adjustments noted for the now-built feature. Each spec is
+independent and seeds its own preconditions.
+
+1. **01 — `cei-admin` requests `admin`@IT (real registration).** Register via UI → Mailpit verify → first
+   login → request `admin`@IT → assert **only `super-admin`** sees it (cei-admin is not yet an IT admin) →
+   (a) super-admin rejects → (b) cei-admin revises + resubmits → (c) super-admin approves → assert the FGA
+   tuple + role now exist.
+2. **02 — `cei-editor` requests `edit`@IT** (precond: seed `cei-admin = admin@IT`). Assert **both**
+   `super-admin` and `cei-admin` see it via the scoped review UI, `usccb-admin` does **not** → cei-admin
+   rejects → super-admin sees the rejection → cei-editor revises → cei-admin grants → super-admin sees the
+   grant. *(Exercises the scoped-admin-review feature head-on.)*
+3. **03 — `usccb-admin` requests `admin`@USA** (real or seeded-precondition admin). Assert **`cei-admin`
+   does NOT see it**, only `super-admin` → super-admin grants.
+4. **04 — `usccb-editor` requests `edit`@USA (real registration).** Register via UI + Mailpit → request →
+   `usccb-admin` + `super-admin` see it, `cei-admin` does not → usccb-admin grants → super-admin sees it.
+5. **05 — `rome-admin` requests `admin`@romamo_it.** Only `super-admin` sees → grants.
+6. **06 — `rome-editor` requests `edit`@romamo_it** (precond: seed `rome-admin = admin@romamo_it`).
+   `super-admin` + `rome-admin` see it, `cei-admin`/`usccb-admin` do not → rome-admin grants → super-admin
+   sees it.
+7. **07 — dashboard card scoping.** Per-user matrix assertions on `.admin-block` cards: which render, scope
+   narrowing (Sanctorale → `IT_`/`US_`/Latin; National → IT/USA; Diocesan → romamo_it; GRC; Europe), and the
+   resource-admin **"Access Requests to Review"** card + that the global-only FGA-tuple section is hidden for
+   resource-admins (the feature's dashboard/gate behavior). Extends the existing smoke spec.
+8. **08 — negative authorization.** `cei-admin` attempts to approve a USA request, open a USA-scoped card,
+   and edit the USA calendar → all denied (403 / hidden). Mirror of 03–06.
+9. **09 — revoke-after-grant lifecycle.** An admin revokes a granted permission → FGA tuple/role removed,
+   dashboard cards disappear, a `revoked` notification is delivered.
+10. **10 — scoped data editing** (precond: seed `cei-editor = edit@IT`). cei-editor edits the IT national
+    calendar via `extending.php` and succeeds; the same edit against USA fails. Reverted by
+    `gitRestoreApiData()`.
+11. **11 — session/token resilience.** Cookie/session expiry + refresh mid-flow; logout then login as a
+    different user; a grant/revoke is reflected on the next `/auth/me` without stale caching.
+
+## Determinism, cleanup, isolation
+
+- Serial, single worker. `rbac.setup.ts` seeds accounts + logins; per-spec hooks seed preconditions and
+  create requests via UI; `globalTeardown` + per-spec `afterEach` clean.
+- Cleanup removes: truncated app tables, the run's FGA tuples (seeded **and** approval-created), Zitadel test
+  users, and reverts API source data (`gitRestoreApiData()`).
+- Namespacing: all seeded emails use the `<role>+e2e@litcal.test` pattern so cleanup never touches real data.
+
+## Risks & sequencing
+
+1. **Registration specs (01/04)** are the fragile, highest-effort part (real Zitadel registration UI +
+   cross-org fix + Mailpit). Build `mailpit.ts` and one registration spec first to de-risk before the rest.
+2. **Cleanup of approval-created grants** must be reliable or state leaks between specs — build/verify the
+   cleanup extension early.
+3. **Scenario 10** mutates API source data; depends on `gitRestoreApiData()` working against the running
+   stack (API built from the local repo).
+4. **Stack readiness:** the local docker stack must run the scoped-admin-review feature (API now on
+   `development` via #656; frontend branch has it) — recreate `litcal-api`/`litcal-frontend` before running.
+5. **PR size:** folding 11 specs + 3 new helpers + cleanup changes into #345 makes it large; reviewers should
+   expect that.
+
+## Build order (for the plan)
+
+1. Seeding-model change (`rbac.setup.ts` stops seeding editor tuples) + `grant.ts` precondition helper +
+   cleanup extension. **Foundation — everything depends on it.**
+2. `requestAccess.ts` + scenario 02 (the headline scoped-review lifecycle) as the first real scenario.
+3. `mailpit.ts` + scenario 01 (registration) to de-risk the fragile path early.
+4. Remaining scoped-review scenarios (03–06), then dashboard cards (07), negative auth (08), revoke (09),
+   scoped data editing (10), session resilience (11).
+
+## Out of scope (this round)
+
+- A CI workflow / required check (suite stays local-run; structured to be CI-ready).
+- Performance/load testing; testing Zitadel itself.
+- API-level assertions already covered by the API PHPUnit suite (exercised here only through the UI).
+- Any new product behavior — this is test coverage of the already-built feature.

--- a/e2e/rbac/00-smoke-dashboard-scoping.spec.ts
+++ b/e2e/rbac/00-smoke-dashboard-scoping.spec.ts
@@ -7,17 +7,23 @@ test('super-admin sees the admin section; cei-editor does not', async ({ browser
     // Applications, Role Requests cards) only when $isAdmin is true (line 62).
     // The Users card always contains a[href="admin-users.php"] (line 79).
     const sa = await actingAs(browser, 'super-admin');
-    await sa.page.goto('/admin-dashboard.php');
-    await expect(sa.page.locator('a[href="admin-users.php"]')).toBeVisible();
-    await sa.context.close();
+    try {
+        await sa.page.goto('/admin-dashboard.php');
+        await expect(sa.page.locator('a[href="admin-users.php"]')).toBeVisible();
+    } finally {
+        await sa.context.close();
+    }
 
     // ── cei-editor (Zitadel role: calendar_editor, FGA editor@national_calendar:IT)
     // $isAdmin is false → the Administration section is NOT rendered.
     // But $hasCalendarRole is true → the calendar blocks (admin-blocks.php) ARE rendered,
     // including the National card with data-block-id="national" (line 87 of admin-blocks.php).
     const ed = await actingAs(browser, 'cei-editor');
-    await ed.page.goto('/admin-dashboard.php');
-    await expect(ed.page.locator('a[href="admin-users.php"]')).toHaveCount(0);
-    await expect(ed.page.locator('.admin-block[data-block-id="national"]')).toBeVisible();
-    await ed.context.close();
+    try {
+        await ed.page.goto('/admin-dashboard.php');
+        await expect(ed.page.locator('a[href="admin-users.php"]')).toHaveCount(0);
+        await expect(ed.page.locator('.admin-block[data-block-id="national"]')).toBeVisible();
+    } finally {
+        await ed.context.close();
+    }
 });

--- a/e2e/rbac/00-smoke-dashboard-scoping.spec.ts
+++ b/e2e/rbac/00-smoke-dashboard-scoping.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+
+test('super-admin sees the admin section; cei-editor does not', async ({ browser }) => {
+    // ── super-admin (Zitadel role: admin) ────────────────────────────────────
+    // admin-dashboard.php renders the Administration section (Users, Permissions,
+    // Applications, Role Requests cards) only when $isAdmin is true (line 62).
+    // The Users card always contains a[href="admin-users.php"] (line 79).
+    const sa = await actingAs(browser, 'super-admin');
+    await sa.page.goto('/admin-dashboard.php');
+    await expect(sa.page.locator('a[href="admin-users.php"]')).toBeVisible();
+    await sa.context.close();
+
+    // ── cei-editor (Zitadel role: calendar_editor, FGA editor@national_calendar:IT)
+    // $isAdmin is false → the Administration section is NOT rendered.
+    // But $hasCalendarRole is true → the calendar blocks (admin-blocks.php) ARE rendered,
+    // including the National card with data-block-id="national" (line 87 of admin-blocks.php).
+    const ed = await actingAs(browser, 'cei-editor');
+    await ed.page.goto('/admin-dashboard.php');
+    await expect(ed.page.locator('a[href="admin-users.php"]')).toHaveCount(0);
+    await expect(ed.page.locator('.admin-block[data-block-id="national"]')).toBeVisible();
+    await ed.context.close();
+});

--- a/e2e/rbac/02-cei-editor-edit-request.spec.ts
+++ b/e2e/rbac/02-cei-editor-edit-request.spec.ts
@@ -140,20 +140,27 @@ test('02 — cei-editor edit@IT: scoped review lifecycle', async ({ browser }) =
 });
 
 test.afterEach(async () => {
-    // Remove app-table rows created by this scenario.
-    await truncateAppTables();
-
-    // Revoke any FGA editor tuple that the approval may have written for cei-editor.
-    await revokeScope('cei-editor');
-
-    // Delete cei-admin — it was created on-demand by seedAndLogin and must be torn
-    // down so it does not bleed into other specs.
+    // Tear down everything this scenario created. Run every step regardless of individual
+    // failures (a thrown truncate must not skip the identity/tuple cleanup, or state leaks
+    // into other specs), and surface failures rather than swallowing them.
     const z = new ZitadelAdmin();
-    const ceiAdminId = await z.findUserIdByEmail(USERS['cei-admin'].email);
-    if (ceiAdminId) {
-        await z.deleteUser(ceiAdminId).catch(() => {});
-        await new Fga()
-            .delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
-            .catch(() => {});
+    const ceiAdminId = await z.findUserIdByEmail(USERS['cei-admin'].email).catch(() => null);
+
+    const results = await Promise.allSettled([
+        truncateAppTables(), // app-table rows created by this scenario
+        revokeScope('cei-editor'), // FGA editor tuple the approval may have written
+        // cei-admin was created on-demand by seedAndLogin — delete it + its admin tuple.
+        ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
+        ceiAdminId
+            ? new Fga().delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            : Promise.resolve(),
+    ]);
+
+    const failures = results.filter((r) => r.status === 'rejected');
+    if (failures.length > 0) {
+        console.warn(
+            'scenario 02 afterEach: cleanup failures:',
+            failures.map((f) => String((f as PromiseRejectedResult).reason)),
+        );
     }
 });

--- a/e2e/rbac/02-cei-editor-edit-request.spec.ts
+++ b/e2e/rbac/02-cei-editor-edit-request.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+import { submitAccessRequest, resubmitAccessRequest } from './support/requestAccess';
+import { requestVisible, actOnRequest } from './support/review';
+import { revokeScope } from './support/grant';
+import { seedAndLogin } from './support/seed';
+import { truncateAppTables } from './support/cleanup';
+import { Fga } from './support/fga';
+import { ZitadelAdmin } from './support/zitadel';
+import { USERS } from './support/users';
+
+/**
+ * Scenario 02 — cei-editor requests editor@national_calendar:IT
+ *
+ * Full scoped-review lifecycle:
+ *   submit → scoped visibility → reject → resubmit → approve → FGA/role assert
+ *
+ * Preconditions (seeded by rbac-setup):
+ *   - super-admin:  Zitadel admin role, no FGA scope
+ *   - cei-editor:   Zitadel calendar_editor role, NO FGA tuple (earned via request)
+ *   - usccb-admin:  Zitadel calendar_editor role, FGA admin@national_calendar:US
+ *
+ * Precondition (created on-demand):
+ *   - cei-admin: Zitadel calendar_editor role, FGA admin@national_calendar:IT
+ *     (REGISTRATION_USER — not seeded by rbac-setup; seedAndLogin creates it)
+ */
+
+test('02 — cei-editor edit@IT: scoped review lifecycle', async ({ browser }) => {
+    // ── Precondition: seed cei-admin (IT admin) ──────────────────────────────
+    // cei-admin is a REGISTRATION_USER; rbac-setup does not create it.
+    // seedAndLogin provisions the Zitadel account + admin FGA tuple + login state.
+    await seedAndLogin('cei-admin');
+
+    // ── Step 1: cei-editor submits a request for editor@national_calendar:IT ─
+    const ceied = await actingAs(browser, 'cei-editor');
+    try {
+        await submitAccessRequest(ceied.page, {
+            requestedRole: 'calendar_editor',
+            permission: { objectType: 'national_calendar', objectId: 'IT', relation: 'editor' },
+        });
+    } finally {
+        await ceied.context.close();
+    }
+
+    // ── Step 2: Scoped visibility ─────────────────────────────────────────────
+    // super-admin (global admin) → should see the request
+    const sa = await actingAs(browser, 'super-admin');
+    try {
+        expect(
+            await requestVisible(sa.page, { requesterEmail: USERS['cei-editor'].email }),
+        ).toBe(true);
+    } finally {
+        await sa.context.close();
+    }
+
+    // cei-admin (admin@IT) → should see the request (scoped to IT)
+    const ceiadm = await actingAs(browser, 'cei-admin');
+    try {
+        expect(
+            await requestVisible(ceiadm.page, { requesterEmail: USERS['cei-editor'].email }),
+        ).toBe(true);
+
+        // ── Step 3: cei-admin rejects the request ────────────────────────────
+        await actOnRequest(ceiadm.page, {
+            requesterEmail: USERS['cei-editor'].email,
+            action: 'reject',
+            notes: 'fix scope',
+        });
+    } finally {
+        await ceiadm.context.close();
+    }
+
+    // usccb-admin (admin@US) → must NOT see the IT request (different scope)
+    const usccbadm = await actingAs(browser, 'usccb-admin');
+    try {
+        expect(
+            await requestVisible(usccbadm.page, { requesterEmail: USERS['cei-editor'].email }),
+        ).toBe(false);
+    } finally {
+        await usccbadm.context.close();
+    }
+
+    // ── Step 4: super-admin sees the rejection ────────────────────────────────
+    const sa2 = await actingAs(browser, 'super-admin');
+    try {
+        expect(
+            await requestVisible(sa2.page, {
+                requesterEmail: USERS['cei-editor'].email,
+                status: 'rejected',
+            }),
+        ).toBe(true);
+    } finally {
+        await sa2.context.close();
+    }
+
+    // ── Step 5: cei-editor revises and resubmits the rejected request ─────────
+    // The resubmit flow: goto permission-requests.php, click .resubmit-btn on the
+    // rejected row (openResubmitForm pre-fills form + sets #submitBtn to Resubmit
+    // mode), click #submitBtn → POSTs to /auth/access-requests/{id}/resubmit →
+    // request returns to pending (same row, no new row added).
+    const ceied2 = await actingAs(browser, 'cei-editor');
+    try {
+        await resubmitAccessRequest(ceied2.page);
+    } finally {
+        await ceied2.context.close();
+    }
+
+    // ── Step 6: cei-admin approves the resubmitted request ───────────────────
+    const ceiadm2 = await actingAs(browser, 'cei-admin');
+    try {
+        await actOnRequest(ceiadm2.page, {
+            requesterEmail: USERS['cei-editor'].email,
+            action: 'approve',
+            notes: 'ok',
+        });
+    } finally {
+        await ceiadm2.context.close();
+    }
+
+    // ── Step 7: Assert FGA tuple + role now exist for cei-editor ─────────────
+    const z = new ZitadelAdmin();
+    const zid = await z.findUserIdByEmail(USERS['cei-editor'].email);
+    expect(zid).not.toBeNull();
+    expect(
+        await new Fga().check(`user:${zid}`, 'editor', 'national_calendar:IT'),
+    ).toBe(true);
+
+    // ── Step 8: super-admin sees the approval ─────────────────────────────────
+    const sa3 = await actingAs(browser, 'super-admin');
+    try {
+        expect(
+            await requestVisible(sa3.page, {
+                requesterEmail: USERS['cei-editor'].email,
+                status: 'approved',
+            }),
+        ).toBe(true);
+    } finally {
+        await sa3.context.close();
+    }
+});
+
+test.afterEach(async () => {
+    // Remove app-table rows created by this scenario.
+    await truncateAppTables();
+
+    // Revoke any FGA editor tuple that the approval may have written for cei-editor.
+    await revokeScope('cei-editor');
+
+    // Delete cei-admin — it was created on-demand by seedAndLogin and must be torn
+    // down so it does not bleed into other specs.
+    const z = new ZitadelAdmin();
+    const ceiAdminId = await z.findUserIdByEmail(USERS['cei-admin'].email);
+    if (ceiAdminId) {
+        await z.deleteUser(ceiAdminId).catch(() => {});
+        await new Fga()
+            .delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            .catch(() => {});
+    }
+});

--- a/e2e/rbac/rbac.setup.ts
+++ b/e2e/rbac/rbac.setup.ts
@@ -1,0 +1,27 @@
+import { test as setup } from '@playwright/test';
+import { truncateAppTables, deleteAllSeededUsers } from './support/cleanup';
+import { seedUser, loginAndSaveState } from './support/seed';
+import { SEEDED_USER_IDS } from './support/users';
+import { ZitadelAdmin } from './support/zitadel';
+
+setup('seed rbac users', async () => {
+    setup.setTimeout(180_000);
+    const z = new ZitadelAdmin();
+
+    // The session API needs IAM_LOGIN_CLIENT, which the machine token lacks. Mint a fresh,
+    // session-capable PAT for the `login-client` user and delete it when done.
+    const loginClientUserId = await z.findUserIdByUsername('login-client');
+    if (!loginClientUserId) throw new Error('login-client machine user not found in Zitadel');
+    const pat = await z.mintPat(loginClientUserId);
+
+    try {
+        await deleteAllSeededUsers();
+        await truncateAppTables();
+        for (const id of SEEDED_USER_IDS) {
+            await seedUser(id);
+            await loginAndSaveState(id, pat.token);
+        }
+    } finally {
+        await z.deletePat(loginClientUserId, pat.tokenId);
+    }
+});

--- a/e2e/rbac/rbac.setup.ts
+++ b/e2e/rbac/rbac.setup.ts
@@ -22,6 +22,10 @@ setup('seed rbac users', async () => {
             await loginAndSaveState(id, pat.token);
         }
     } finally {
-        await z.deletePat(loginClientUserId, pat.tokenId);
+        try {
+            await z.deletePat(loginClientUserId, pat.tokenId);
+        } catch (e) {
+            console.warn('rbac.setup: failed to delete ephemeral PAT (token may persist):', e);
+        }
     }
 });

--- a/e2e/rbac/support/actingAs.spec.ts
+++ b/e2e/rbac/support/actingAs.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import { actingAs } from './actingAs';
+
+test('actingAs super-admin is authenticated with the admin role', async ({ browser }) => {
+    const { context, page } = await actingAs(browser, 'super-admin');
+    // In OIDC mode the frontend validates the litcal_access_token cookie via its own /auth/me.php
+    // (the API's /auth/me is HS256/admin-only and rejects Zitadel OIDC tokens).
+    await page.goto('/');
+    const me = await page.evaluate(async () => {
+        const r = await fetch('/auth/me.php', { credentials: 'include', headers: { Accept: 'application/json' } });
+        return { status: r.status, body: await r.json() };
+    });
+    expect(me.status).toBe(200);
+    expect(me.body.authenticated).toBe(true);
+    expect(me.body.user?.roles ?? me.body.roles).toContain('admin');
+    await context.close();
+});

--- a/e2e/rbac/support/actingAs.spec.ts
+++ b/e2e/rbac/support/actingAs.spec.ts
@@ -3,15 +3,18 @@ import { actingAs } from './actingAs';
 
 test('actingAs super-admin is authenticated with the admin role', async ({ browser }) => {
     const { context, page } = await actingAs(browser, 'super-admin');
-    // In OIDC mode the frontend validates the litcal_access_token cookie via its own /auth/me.php
-    // (the API's /auth/me is HS256/admin-only and rejects Zitadel OIDC tokens).
-    await page.goto('/');
-    const me = await page.evaluate(async () => {
-        const r = await fetch('/auth/me.php', { credentials: 'include', headers: { Accept: 'application/json' } });
-        return { status: r.status, body: await r.json() };
-    });
-    expect(me.status).toBe(200);
-    expect(me.body.authenticated).toBe(true);
-    expect(me.body.user?.roles ?? me.body.roles).toContain('admin');
-    await context.close();
+    try {
+        // In OIDC mode the frontend validates the litcal_access_token cookie via its own /auth/me.php
+        // (the API's /auth/me is HS256/admin-only and rejects Zitadel OIDC tokens).
+        await page.goto('/');
+        const me = await page.evaluate(async () => {
+            const r = await fetch('/auth/me.php', { credentials: 'include', headers: { Accept: 'application/json' } });
+            return { status: r.status, body: await r.json() };
+        });
+        expect(me.status).toBe(200);
+        expect(me.body.authenticated).toBe(true);
+        expect(me.body.user?.roles ?? me.body.roles).toContain('admin');
+    } finally {
+        await context.close();
+    }
 });

--- a/e2e/rbac/support/actingAs.ts
+++ b/e2e/rbac/support/actingAs.ts
@@ -1,0 +1,8 @@
+import { Browser, BrowserContext, Page } from '@playwright/test';
+import * as path from 'path';
+
+export async function actingAs(browser: Browser, id: string): Promise<{ context: BrowserContext; page: Page }> {
+    const context = await browser.newContext({ storageState: path.join(__dirname, '..', '..', '.auth', `${id}.json`) });
+    const page = await context.newPage();
+    return { context, page };
+}

--- a/e2e/rbac/support/cleanup.test.ts
+++ b/e2e/rbac/support/cleanup.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { truncateAppTables, deleteAllSeededUsers } from './cleanup';
+import { truncateAppTables, deleteAllSeededUsers, gitRestoreApiData } from './cleanup';
 import { seedUser } from './seed';
 import { ZitadelAdmin } from './zitadel';
 import { USERS } from './users';
@@ -12,4 +12,10 @@ test('deleteAllSeededUsers removes a seeded user', async () => {
 
 test('truncateAppTables runs without error', async () => {
     await truncateAppTables();
+});
+
+test('gitRestoreApiData is exported and runs without throwing', async () => {
+    expect(typeof gitRestoreApiData).toBe('function');
+    // Tolerant no-op when the API repo's source data has no pending edits.
+    await gitRestoreApiData();
 });

--- a/e2e/rbac/support/cleanup.test.ts
+++ b/e2e/rbac/support/cleanup.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { truncateAppTables, deleteAllSeededUsers } from './cleanup';
+import { seedUser } from './seed';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+test('deleteAllSeededUsers removes a seeded user', async () => {
+	await seedUser('rome-editor');
+	await deleteAllSeededUsers();
+	expect(await new ZitadelAdmin().findUserIdByEmail(USERS['rome-editor'].email)).toBeNull();
+});
+
+test('truncateAppTables runs without error', async () => {
+	await truncateAppTables();
+});

--- a/e2e/rbac/support/cleanup.test.ts
+++ b/e2e/rbac/support/cleanup.test.ts
@@ -5,11 +5,11 @@ import { ZitadelAdmin } from './zitadel';
 import { USERS } from './users';
 
 test('deleteAllSeededUsers removes a seeded user', async () => {
-	await seedUser('rome-editor');
-	await deleteAllSeededUsers();
-	expect(await new ZitadelAdmin().findUserIdByEmail(USERS['rome-editor'].email)).toBeNull();
+    await seedUser('rome-editor');
+    await deleteAllSeededUsers();
+    expect(await new ZitadelAdmin().findUserIdByEmail(USERS['rome-editor'].email)).toBeNull();
 });
 
 test('truncateAppTables runs without error', async () => {
-	await truncateAppTables();
+    await truncateAppTables();
 });

--- a/e2e/rbac/support/cleanup.ts
+++ b/e2e/rbac/support/cleanup.ts
@@ -1,0 +1,26 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { USERS } from './users';
+import { ZitadelAdmin } from './zitadel';
+import { Fga } from './fga';
+
+const exec = promisify(execFile);
+
+export async function truncateAppTables(): Promise<void> {
+	// The active docker stack is the FRONTEND compose project (this repo root), not the API repo's.
+	// Run `docker compose exec` from the frontend repo root so it targets the running `db` service.
+	const sql = 'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
+	await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql]);
+}
+
+export async function deleteAllSeededUsers(): Promise<void> {
+	const z = new ZitadelAdmin();
+	const f = new Fga();
+	for (const id of Object.keys(USERS)) {
+		const u = USERS[id];
+		const zid = await z.findUserIdByEmail(u.email);
+		if (!zid) continue;
+		if (u.fga) await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+		await z.deleteUser(zid);
+	}
+}

--- a/e2e/rbac/support/cleanup.ts
+++ b/e2e/rbac/support/cleanup.ts
@@ -27,11 +27,14 @@ export async function deleteAllSeededUsers(): Promise<void> {
         const zid = await z.findUserIdByEmail(u.email);
         if (!zid) continue;
         // Tolerant of tuples a scenario dynamically granted/revoked (Fga.delete already swallows
-        // not-found, but guard so one stray tuple can't abort the whole teardown).
+        // not-found), but log real failures rather than swallowing them so a deletion that
+        // genuinely fails (and could contaminate later specs) is visible — while still letting
+        // the rest of the teardown continue.
         if (u.fga) {
-            await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`).catch(() => {});
+            await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`)
+                .catch((e) => console.warn(`cleanup: failed to delete tuple for ${u.email}:`, String(e)));
         }
-        await z.deleteUser(zid).catch(() => {});
+        await z.deleteUser(zid).catch((e) => console.warn(`cleanup: failed to delete user ${u.email}:`, String(e)));
     }
 }
 

--- a/e2e/rbac/support/cleanup.ts
+++ b/e2e/rbac/support/cleanup.ts
@@ -41,6 +41,12 @@ export async function deleteAllSeededUsers(): Promise<void> {
  * (Untracked new files are not removed — scenario 10 edits existing calendar files.)
  */
 export async function gitRestoreApiData(): Promise<void> {
-    await exec('git', ['-C', API_REPO, 'checkout', '--', 'jsondata/sourcedata'], { timeout: 30000 })
-        .catch(() => {});
+    try {
+        await exec('git', ['-C', API_REPO, 'checkout', '--', 'jsondata/sourcedata'], { timeout: 30000 });
+    } catch (e) {
+        // A clean working tree exits 0 (no throw). A throw means a real failure (bad
+        // API_REPO_PATH, not a git repo, checkout error) that left scenario-10 edits
+        // unreverted — surface it rather than hiding a dirty tree across runs.
+        console.warn(`gitRestoreApiData: failed to restore API source data (edits may persist): ${String(e)}`);
+    }
 }

--- a/e2e/rbac/support/cleanup.ts
+++ b/e2e/rbac/support/cleanup.ts
@@ -7,20 +7,20 @@ import { Fga } from './fga';
 const exec = promisify(execFile);
 
 export async function truncateAppTables(): Promise<void> {
-	// The active docker stack is the FRONTEND compose project (this repo root), not the API repo's.
-	// Run `docker compose exec` from the frontend repo root so it targets the running `db` service.
-	const sql = 'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
-	await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql]);
+    // The active docker stack is the FRONTEND compose project (this repo root), not the API repo's.
+    // Run `docker compose exec` from the frontend repo root so it targets the running `db` service.
+    const sql = 'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
+    await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql]);
 }
 
 export async function deleteAllSeededUsers(): Promise<void> {
-	const z = new ZitadelAdmin();
-	const f = new Fga();
-	for (const id of Object.keys(USERS)) {
-		const u = USERS[id];
-		const zid = await z.findUserIdByEmail(u.email);
-		if (!zid) continue;
-		if (u.fga) await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
-		await z.deleteUser(zid);
-	}
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+    for (const id of Object.keys(USERS)) {
+        const u = USERS[id];
+        const zid = await z.findUserIdByEmail(u.email);
+        if (!zid) continue;
+        if (u.fga) await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+        await z.deleteUser(zid);
+    }
 }

--- a/e2e/rbac/support/cleanup.ts
+++ b/e2e/rbac/support/cleanup.ts
@@ -1,10 +1,15 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import * as path from 'path';
 import { USERS } from './users';
 import { ZitadelAdmin } from './zitadel';
 import { Fga } from './fga';
 
 const exec = promisify(execFile);
+
+// The local stack bind-mounts the API repo, so calendar edits made via extending.php land in
+// the host API repo's jsondata/sourcedata. Override with API_REPO_PATH if your checkout differs.
+const API_REPO = process.env.API_REPO_PATH || path.resolve(__dirname, '../../../../LiturgicalCalendarAPI');
 
 export async function truncateAppTables(): Promise<void> {
     // The active docker stack is the FRONTEND compose project (this repo root), not the API repo's.
@@ -21,7 +26,21 @@ export async function deleteAllSeededUsers(): Promise<void> {
         const u = USERS[id];
         const zid = await z.findUserIdByEmail(u.email);
         if (!zid) continue;
-        if (u.fga) await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
-        await z.deleteUser(zid);
+        // Tolerant of tuples a scenario dynamically granted/revoked (Fga.delete already swallows
+        // not-found, but guard so one stray tuple can't abort the whole teardown).
+        if (u.fga) {
+            await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`).catch(() => {});
+        }
+        await z.deleteUser(zid).catch(() => {});
     }
+}
+
+/**
+ * Revert calendar source-data edits made by scenario 10 (scoped data editing). `git checkout`
+ * discards unstaged modifications under jsondata/sourcedata; tolerant of nothing-to-restore.
+ * (Untracked new files are not removed — scenario 10 edits existing calendar files.)
+ */
+export async function gitRestoreApiData(): Promise<void> {
+    await exec('git', ['-C', API_REPO, 'checkout', '--', 'jsondata/sourcedata'], { timeout: 30000 })
+        .catch(() => {});
 }

--- a/e2e/rbac/support/cleanup.ts
+++ b/e2e/rbac/support/cleanup.ts
@@ -10,7 +10,8 @@ export async function truncateAppTables(): Promise<void> {
     // The active docker stack is the FRONTEND compose project (this repo root), not the API repo's.
     // Run `docker compose exec` from the frontend repo root so it targets the running `db` service.
     const sql = 'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
-    await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql]);
+    // 30s timeout so a stalled docker process can't hang the cleanup pipeline.
+    await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql], { timeout: 30000 });
 }
 
 export async function deleteAllSeededUsers(): Promise<void> {

--- a/e2e/rbac/support/fga.test.ts
+++ b/e2e/rbac/support/fga.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { Fga } from './fga';
+
+test('write, check true, delete, check false (idempotent)', async () => {
+    const f = new Fga();
+    const user = 'user:fga-probe-e2e';
+    const obj = 'national_calendar:ZZ';
+    await f.delete(user, 'admin', obj); // clean slate, must not throw
+    expect(await f.check(user, 'admin', obj)).toBe(false);
+    await f.write(user, 'admin', obj);
+    await f.write(user, 'admin', obj); // idempotent
+    expect(await f.check(user, 'admin', obj)).toBe(true);
+    await f.delete(user, 'admin', obj);
+    expect(await f.check(user, 'admin', obj)).toBe(false);
+});

--- a/e2e/rbac/support/fga.ts
+++ b/e2e/rbac/support/fga.ts
@@ -4,12 +4,20 @@ export class Fga {
     private model = process.env.OPENFGA_MODEL_ID!;
 
     private async post(path: string, body: unknown): Promise<{ status: number; text: string }> {
-        const res = await fetch(`${this.url}/stores/${this.store}${path}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-        });
-        return { status: res.status, text: await res.text() };
+        // Abort after 10s so a hung OpenFGA call can't block setup/cleanup indefinitely.
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10000);
+        try {
+            const res = await fetch(`${this.url}/stores/${this.store}${path}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+                signal: controller.signal,
+            });
+            return { status: res.status, text: await res.text() };
+        } finally {
+            clearTimeout(timeout);
+        }
     }
 
     async write(user: string, relation: string, object: string): Promise<void> {

--- a/e2e/rbac/support/fga.ts
+++ b/e2e/rbac/support/fga.ts
@@ -1,0 +1,43 @@
+export class Fga {
+    private url = process.env.OPENFGA_API_URL!.replace(/\/$/, '');
+    private store = process.env.OPENFGA_STORE_ID!;
+    private model = process.env.OPENFGA_MODEL_ID!;
+
+    private async post(path: string, body: unknown): Promise<{ status: number; text: string }> {
+        const res = await fetch(`${this.url}/stores/${this.store}${path}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        return { status: res.status, text: await res.text() };
+    }
+
+    async write(user: string, relation: string, object: string): Promise<void> {
+        const r = await this.post('/write', {
+            writes: { tuple_keys: [{ user, relation, object }] },
+            authorization_model_id: this.model,
+        });
+        if (r.status >= 400 && !/already exists|duplicate/i.test(r.text)) {
+            throw new Error(`FGA write ${r.status}: ${r.text}`);
+        }
+    }
+
+    async delete(user: string, relation: string, object: string): Promise<void> {
+        const r = await this.post('/write', {
+            deletes: { tuple_keys: [{ user, relation, object }] },
+            authorization_model_id: this.model,
+        });
+        if (r.status >= 400 && !/not found|cannot delete/i.test(r.text)) {
+            throw new Error(`FGA delete ${r.status}: ${r.text}`);
+        }
+    }
+
+    async check(user: string, relation: string, object: string): Promise<boolean> {
+        const r = await this.post('/check', {
+            tuple_key: { user, relation, object },
+            authorization_model_id: this.model,
+        });
+        if (r.status >= 400) throw new Error(`FGA check ${r.status}: ${r.text}`);
+        return JSON.parse(r.text).allowed === true;
+    }
+}

--- a/e2e/rbac/support/grant.test.ts
+++ b/e2e/rbac/support/grant.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { grantScope, revokeScope } from './grant';
+import { seedUser } from './seed';
+import { Fga } from './fga';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+test('grantScope writes the user\'s defined tuple; revokeScope removes it', async () => {
+    const f = new Fga();
+    const z = new ZitadelAdmin();
+    // cei-editor is seeded WITHOUT its tuple (Task 1). grantScope adds it as a precondition.
+    const id = await seedUser('cei-editor');
+    const u = USERS['cei-editor'].fga!;
+    try {
+        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(false);
+        await grantScope('cei-editor');
+        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+        await grantScope('cei-editor'); // idempotent — must not throw
+        await revokeScope('cei-editor');
+        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(false);
+    } finally {
+        await z.deleteUser(id).catch(() => {});
+        await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`).catch(() => {});
+    }
+});

--- a/e2e/rbac/support/grant.ts
+++ b/e2e/rbac/support/grant.ts
@@ -1,0 +1,34 @@
+import { Fga } from './fga';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+/**
+ * Per-spec precondition seeding. Editors are not granted at setup (see seed.ts), so a
+ * scenario that needs a user to already hold their scope seeds it here. Idempotent.
+ */
+export async function grantScope(userKey: string, opts: { role?: boolean } = {}): Promise<void> {
+    const u = USERS[userKey];
+    if (!u?.fga) throw new Error(`grantScope: ${userKey} has no fga scope`);
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+    const zid = await z.findUserIdByEmail(u.email);
+    if (!zid) throw new Error(`grantScope: ${userKey} (${u.email}) is not seeded in Zitadel`);
+    if (opts.role !== false) await z.grantProjectRole(zid, u.role).catch(() => {}); // tolerate already-granted
+    await f.write(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`); // write tolerates dup
+}
+
+export async function revokeScope(userKey: string): Promise<void> {
+    const u = USERS[userKey];
+    if (!u?.fga) return;
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+    const zid = await z.findUserIdByEmail(u.email);
+    if (!zid) return;
+    await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`).catch(() => {});
+}
+
+export async function grantTuple(
+    zitadelUserId: string, relation: string, objectType: string, objectId: string,
+): Promise<void> {
+    await new Fga().write(`user:${zitadelUserId}`, relation, `${objectType}:${objectId}`);
+}

--- a/e2e/rbac/support/mailpit.test.ts
+++ b/e2e/rbac/support/mailpit.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { waitForVerificationLink } from './mailpit';
+
+test('waitForVerificationLink extracts the verification URL from the newest message', async () => {
+    const verifyUrl = 'http://localhost:8080/ui/v2/login/verify?code=ABC&userID=42';
+    const fetchImpl = (async (url: string) => {
+        if (url.includes('/api/v1/messages')) {
+            return new Response(
+                JSON.stringify({ messages: [{ ID: 'm1', To: [{ Address: 'cei-admin+e2e@litcal.test' }] }] }),
+                { status: 200 },
+            );
+        }
+        if (url.includes('/api/v1/message/m1')) {
+            return new Response(JSON.stringify({ HTML: `<a href="${verifyUrl}">Verify</a>`, Text: '' }), { status: 200 });
+        }
+        return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const link = await waitForVerificationLink('cei-admin+e2e@litcal.test', { fetchImpl, timeoutMs: 1000 });
+    expect(link).toBe(verifyUrl);
+});
+
+test('waitForVerificationLink times out when no message arrives', async () => {
+    const fetchImpl = (async (url: string) => {
+        if (url.includes('/api/v1/messages')) {
+            return new Response(JSON.stringify({ messages: [] }), { status: 200 });
+        }
+        return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+        waitForVerificationLink('nobody+e2e@litcal.test', { fetchImpl, timeoutMs: 600 }),
+    ).rejects.toThrow(/timed out/i);
+});

--- a/e2e/rbac/support/mailpit.ts
+++ b/e2e/rbac/support/mailpit.ts
@@ -71,5 +71,8 @@ function extractVerificationUrl(body: string): string | null {
 }
 
 function decodeHtmlEntities(s: string): string {
-    return s.replace(/&amp;/g, '&').replace(/&#38;/g, '&');
+    // Single-pass replace of the two HTML encodings of '&'. Chained .replace() calls can
+    // double-unescape (e.g. "&amp;#38;" -> "&#38;" -> "&"); one alternation pass over the
+    // original string decodes each occurrence exactly once.
+    return s.replace(/&(amp|#38);/g, '&');
 }

--- a/e2e/rbac/support/mailpit.ts
+++ b/e2e/rbac/support/mailpit.ts
@@ -1,0 +1,75 @@
+/**
+ * Mailpit verification-email retrieval for the registration scenarios (01/04).
+ *
+ * Mailpit (axllent/mailpit) exposes a REST API on MAILPIT_API_URL (host http://localhost:8025
+ * in the local stack; service `mailpit`, SMTP at mailpit:1025 where Zitadel delivers). We query
+ * `GET /api/v1/messages` (newest-first) for the latest message to an address, then
+ * `GET /api/v1/message/{ID}` for its body, and extract the Zitadel verification link.
+ *
+ * `fetchImpl` is injectable so the unit test runs without a live Mailpit.
+ */
+const MAILPIT_API_URL = (process.env.MAILPIT_API_URL || 'http://localhost:8025').replace(/\/$/, '');
+
+type FetchLike = typeof fetch;
+
+interface MailpitListItem {
+    ID: string;
+    To?: Array<{ Address?: string }>;
+}
+
+export async function latestMessageTo(
+    toEmail: string,
+    fetchImpl: FetchLike = fetch,
+): Promise<{ id: string; html: string; text: string } | null> {
+    const listRes = await fetchImpl(`${MAILPIT_API_URL}/api/v1/messages`);
+    if (!listRes.ok) return null;
+    const list = (await listRes.json()) as { messages?: MailpitListItem[] };
+    const target = toEmail.toLowerCase();
+    const msg = (list.messages || []).find(
+        (m) => (m.To || []).some((t) => (t.Address || '').toLowerCase() === target),
+    );
+    if (!msg) return null;
+
+    const msgRes = await fetchImpl(`${MAILPIT_API_URL}/api/v1/message/${encodeURIComponent(msg.ID)}`);
+    if (!msgRes.ok) return null;
+    const body = (await msgRes.json()) as { HTML?: string; Text?: string };
+    return { id: msg.ID, html: body.HTML || '', text: body.Text || '' };
+}
+
+export async function waitForVerificationLink(
+    toEmail: string,
+    opts: { timeoutMs?: number; fetchImpl?: FetchLike } = {},
+): Promise<string> {
+    const timeoutMs = opts.timeoutMs ?? 30000;
+    const fetchImpl = opts.fetchImpl ?? fetch;
+    // Date.now() is available in e2e TS (only restricted in workflow scripts).
+    const deadline = Date.now() + timeoutMs;
+    let lastErr = 'no message for address';
+
+    while (Date.now() < deadline) {
+        const msg = await latestMessageTo(toEmail, fetchImpl);
+        if (msg) {
+            const link = extractVerificationUrl(msg.html) || extractVerificationUrl(msg.text);
+            if (link) return link;
+            lastErr = 'message found but no verification link';
+        }
+        await new Promise<void>((r) => setTimeout(r, 500));
+    }
+    throw new Error(`waitForVerificationLink: timed out for ${toEmail} (${lastErr})`);
+}
+
+/**
+ * Extract the verification URL from an email body. Prefers an href whose URL mentions
+ * verification (verif/verify/code=); falls back to the first http(s) URL in the body.
+ */
+function extractVerificationUrl(body: string): string | null {
+    if (!body) return null;
+    const hrefMatch = body.match(/href=["']([^"']*(?:verif|verify|code=)[^"']*)["']/i);
+    if (hrefMatch) return decodeHtmlEntities(hrefMatch[1]);
+    const urlMatch = body.match(/https?:\/\/[^\s"'<>]+/i);
+    return urlMatch ? decodeHtmlEntities(urlMatch[0]) : null;
+}
+
+function decodeHtmlEntities(s: string): string {
+    return s.replace(/&amp;/g, '&').replace(/&#38;/g, '&');
+}

--- a/e2e/rbac/support/requestAccess.ts
+++ b/e2e/rbac/support/requestAccess.ts
@@ -15,6 +15,16 @@ import { expect, type Page } from '@playwright/test';
  *   - Justification: `#justification` (optional). Submit: `#submitBtn`.
  *   - Success: `#formAlerts .alert-success`; the new pending request also appears in
  *     `#existingRequestsBody` as `tr[id^="request-"]`.
+ *
+ * Resubmit flow (for a rejected request):
+ *   - The existing-requests table renders a `.resubmit-btn[data-request-id]` button
+ *     only when status === 'rejected'.
+ *   - Clicking it calls openResubmitForm() which pre-fills the form and switches
+ *     #submitBtn to Resubmit mode.
+ *   - Clicking #submitBtn then POSTs to /auth/access-requests/{id}/resubmit, which
+ *     returns the SAME request to pending (does NOT add a new row).
+ *   - Durable success signal: `.resubmit-btn` count drops to 0 (pending rows have no
+ *     resubmit button).
  */
 export interface AccessRequestOptions {
     requestedRole: string; // e.g. 'calendar_editor'
@@ -64,4 +74,34 @@ export async function submitAccessRequest(page: Page, opts: AccessRequestOptions
     const rowsBefore = await requestRows.count();
     await page.click('#submitBtn');
     await expect(requestRows).toHaveCount(rowsBefore + 1);
+}
+
+/**
+ * Resubmit the user's single rejected access request via the real UI flow on
+ * permission-requests.php. Navigates fresh, clicks the `.resubmit-btn`, then
+ * clicks `#submitBtn` (now in Resubmit mode). Waits for the row's status to
+ * return to pending (durable: `.resubmit-btn` disappears because only rejected
+ * rows carry it).
+ *
+ * Precondition: exactly one rejected request exists for this user (no pending
+ * requests). If the user has no rejected request the helper will throw with a
+ * meaningful Playwright assertion error.
+ */
+export async function resubmitAccessRequest(page: Page): Promise<void> {
+    await page.goto('/permission-requests.php');
+
+    // Wait for the existing-requests list to finish loading.
+    await expect(page.locator('#existingRequestsBody .fa-spinner')).toHaveCount(0);
+
+    // Click the resubmit button on the rejected row.
+    const resubmitBtn = page.locator('#existingRequestsBody .resubmit-btn').first();
+    await expect(resubmitBtn).toBeVisible();
+    await resubmitBtn.click();
+
+    // The form is now in resubmit mode; #submitBtn label changed to "Resubmit".
+    // Click it to POST /auth/access-requests/{id}/resubmit.
+    await page.click('#submitBtn');
+
+    // Durable success: the resubmit button disappears (the row is now pending, not rejected).
+    await expect(page.locator('#existingRequestsBody .resubmit-btn')).toHaveCount(0);
 }

--- a/e2e/rbac/support/requestAccess.ts
+++ b/e2e/rbac/support/requestAccess.ts
@@ -51,6 +51,12 @@ export async function submitAccessRequest(page: Page, opts: AccessRequestOptions
         await page.fill('#justification', opts.justification);
     }
 
+    // Wait for the initial request-list load to settle (the body shows a spinner until
+    // loadExistingRequests() renders the table or the empty state) so the count below
+    // reflects the rendered list, not the pre-fetch state — otherwise a user with an
+    // existing request could read a stale rowsBefore and flake the post-submit assertion.
+    await expect(page.locator('#existingRequestsBody .fa-spinner')).toHaveCount(0);
+
     // Capture the current request count, then submit and wait for the new pending request to
     // appear in the user's list. Success is durable here; the green toast is animated and is
     // cleared by the form reset that runs on success, so it's an unreliable signal.

--- a/e2e/rbac/support/requestAccess.ts
+++ b/e2e/rbac/support/requestAccess.ts
@@ -1,0 +1,61 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Submit a pending access request by driving the real permission-requests.php UI
+ * (the design's "real UI flow"). Pinned against assets/js/permission-requests.js
+ * (verified 2026-06-22):
+ *
+ *   - Page: `/permission-requests.php`, form `#accessRequestForm`.
+ *   - Role: radios `input[name="requested_role"]`; checking one reveals
+ *     `#permissionsSection` and auto-adds one permission row when none exist.
+ *   - Permission row: `#permissionRows .card`, with `.perm-object-type` (select),
+ *     `.perm-object-id` (text input — but swapped to a <select> when object-type is
+ *     `general_roman_calendar`), and `.perm-relation` (select). Set object-type FIRST
+ *     so the object-id control is in its final form before we fill it.
+ *   - Justification: `#justification` (optional). Submit: `#submitBtn`.
+ *   - Success: `#formAlerts .alert-success`; the new pending request also appears in
+ *     `#existingRequestsBody` as `tr[id^="request-"]`.
+ */
+export interface AccessRequestOptions {
+    requestedRole: string; // e.g. 'calendar_editor'
+    permission: {
+        objectType: 'national_calendar' | 'diocesan_calendar' | 'wider_region' | 'general_roman_calendar';
+        objectId: string;
+        relation: 'admin' | 'editor' | 'viewer' | 'deleter';
+    };
+    justification?: string;
+}
+
+export async function submitAccessRequest(page: Page, opts: AccessRequestOptions): Promise<void> {
+    await page.goto('/permission-requests.php');
+
+    // Select the role; this reveals the permissions section and auto-adds the first row.
+    await page.check(`input[name="requested_role"][value="${opts.requestedRole}"]`);
+
+    const row = page.locator('#permissionRows .card').first();
+    await expect(row).toBeVisible();
+
+    // Object-type first — for GRC this swaps .perm-object-id from <input> to <select>.
+    await row.locator('.perm-object-type').selectOption(opts.permission.objectType);
+
+    const idField = row.locator('.perm-object-id');
+    if (opts.permission.objectType === 'general_roman_calendar') {
+        await idField.selectOption(opts.permission.objectId);
+    } else {
+        await idField.fill(opts.permission.objectId);
+    }
+
+    await row.locator('.perm-relation').selectOption(opts.permission.relation);
+
+    if (opts.justification) {
+        await page.fill('#justification', opts.justification);
+    }
+
+    // Capture the current request count, then submit and wait for the new pending request to
+    // appear in the user's list. Success is durable here; the green toast is animated and is
+    // cleared by the form reset that runs on success, so it's an unreliable signal.
+    const requestRows = page.locator('#existingRequestsBody tr[id^="request-"]');
+    const rowsBefore = await requestRows.count();
+    await page.click('#submitBtn');
+    await expect(requestRows).toHaveCount(rowsBefore + 1);
+}

--- a/e2e/rbac/support/review.ts
+++ b/e2e/rbac/support/review.ts
@@ -55,33 +55,28 @@ function statusBodySelector(status: string): string {
 
 /**
  * Navigate to the admin access-requests page, activate the given status tab,
- * and wait for the list to finish loading.
+ * and wait for the list XHR to complete — not just the spinner, which Bootstrap's
+ * shown.bs.tab can clear before the fetch resolves.
  *
- * Uses DOM-only synchronisation (network-idle + spinner-gone) rather than
- * waitForResponse: the XHR to /admin/access-requests consistently fires and
- * delivers data, but Playwright's waitForResponse does not intercept it in the
- * Docker test stack (likely due to the internal Docker bridge URL rewrite).
- * networkidle waits for all in-flight XHRs to settle; the spinner check then
- * confirms that loadAccessRequests() finished rendering.
- *
- * Note: loadAccessRequests() issues a SINGLE fetch for all statuses at once;
- * tab clicks only toggle visibility and do not trigger additional requests.
+ * loadAccessRequests() issues a SINGLE GET /admin/access-requests for all statuses
+ * on page init, so register the listener BEFORE goto to avoid missing it. Match on
+ * the GET method (not status 200) so even a non-200 resolves the wait rather than
+ * hanging. (A resource-admin only reaches this page — and fires this XHR — when
+ * AuthHelper resolves isResourceAdmin() true; that server-side admin-scopes call
+ * needs API_INTERNAL_URL in Docker, else the page redirects and no XHR fires.)
  */
 async function gotoAndWaitList(page: Page, status: string): Promise<void> {
-    await page.goto(PAGE_PATH, { waitUntil: 'domcontentloaded' });
+    const responseReady = page.waitForResponse(
+        r => r.url().includes('/admin/access-requests') && r.request().method() === 'GET',
+    );
+    await page.goto(PAGE_PATH);
     // For non-pending tabs, activate the correct tab so its body is visible
     // before we start reading the DOM (tab click is purely cosmetic, no fetch).
     if (status !== 'pending') {
         await page.click(statusTabSelector(status));
     }
-    // Wait for all XHRs fired during page init to settle, then confirm the
-    // target-status spinner is gone. Use an explicit 30 s timeout: the API can
-    // be slow under the test Docker stack.
-    await page.waitForLoadState('networkidle', { timeout: 30000 });
-    await expect(page.locator(`${statusBodySelector(status)} .fa-spinner`)).toHaveCount(
-        0,
-        { timeout: 30000 },
-    );
+    await responseReady;
+    await expect(page.locator(`${statusBodySelector(status)} .fa-spinner`)).toHaveCount(0);
 }
 
 /**

--- a/e2e/rbac/support/review.ts
+++ b/e2e/rbac/support/review.ts
@@ -1,0 +1,151 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/*
+ * Selector reference (pinned against admin-permissions.php + assets/js/admin-permissions.js,
+ * verified 2026-06-22):
+ *
+ * URL: /admin-permissions.php
+ *
+ * ── Access Requests list ─────────────────────────────────────────────────────
+ * Status tabs:     #permRequestStatusTabs  →  buttons #permReq-{status}-tab
+ *                  (admin-permissions.php line 157, 164, 169, 175)
+ * List containers: #permReq{Status}Body   e.g. #permReqPendingBody
+ *                  (admin-permissions.php lines 187, 194, 201, 208)
+ *   Loading spinner present while fetching: .fa-spinner inside the container
+ *                  (admin-permissions.js loadAccessRequests(), line 596-603)
+ * Per-row:         tr  (inside table rendered by renderAccessReqList, line 722)
+ *   Email cell:    td > small.text-muted   (renderAccessReqUserCell, line 677)
+ *   Review button: .permReq-review-btn     (renderAccessReqRow, line 710)
+ *                  data-permreq-id  = request DB id
+ *                  data-permreq-status = current status (pending | approved | …)
+ *
+ * ── Review modal ─────────────────────────────────────────────────────────────
+ * Modal element:   #permReqReviewModal     (admin-permissions.php line 218)
+ * Details content: #permReqDetails         (admin-permissions.php line 228)
+ * Notes section:   #permReqNotesSection    (admin-permissions.php line 232; hidden for
+ *                                           rejected/revoked by configureReviewModalButtons,
+ *                                           admin-permissions.js line 856)
+ * Notes textarea:  #permReqReviewNotes     (admin-permissions.php line 241)
+ * Alerts div:      #permReqModalAlerts     (admin-permissions.php line 244)
+ * Approve button:  #permReqApproveBtn      (admin-permissions.php line 247; d-none unless
+ *                                           status === pending, line 847)
+ * Reject button:   #permReqRejectBtn       (admin-permissions.php line 250; d-none unless
+ *                                           status === pending, line 848)
+ * Revoke button:   #permReqRevokeBtn       (admin-permissions.php line 253; d-none unless
+ *                                           status === approved, line 851)
+ *
+ * ── Post-action flow (processAccessReq, admin-permissions.js line 885) ───────
+ * On success: success alert shown in #permReqModalAlerts → 1500 ms delay →
+ *   modal.hide() → loadAccessRequests() refreshes all tab bodies.
+ * Durable assertion: modal is hidden + spinner gone in the source-status body.
+ * (Alert in #permReqModalAlerts is transient and cleared after 1500 ms.)
+ */
+
+const PAGE_PATH = '/admin-permissions.php';
+
+function statusTabSelector(status: string): string {
+    return `#permReq-${status}-tab`;
+}
+
+function statusBodySelector(status: string): string {
+    // 'pending' → '#permReqPendingBody', 'approved' → '#permReqApprovedBody', etc.
+    const cap = status.charAt(0).toUpperCase() + status.slice(1);
+    return `#permReq${cap}Body`;
+}
+
+/**
+ * Navigate to the admin access-requests page, activate the given status tab,
+ * and wait for the list to finish loading (spinner disappears).
+ */
+async function gotoAndWaitList(page: Page, status: string): Promise<void> {
+    // Always navigate fresh so we read the current DB state.
+    await page.goto(PAGE_PATH);
+
+    // The default active tab is 'pending'. For any other status, click its tab.
+    if (status !== 'pending') {
+        await page.click(statusTabSelector(status));
+    }
+
+    // Wait for the spinner inside the target body to disappear.
+    await expect(page.locator(`${statusBodySelector(status)} .fa-spinner`)).toHaveCount(0);
+}
+
+/**
+ * Navigate/reload the review list (optionally with a status filter) and return
+ * whether a row for `requesterEmail` is present.
+ */
+export async function requestVisible(
+    page: Page,
+    q: { requesterEmail: string; status?: string },
+): Promise<boolean> {
+    const status = q.status ?? 'pending';
+    await gotoAndWaitList(page, status);
+    const count = await page
+        .locator(`${statusBodySelector(status)} tr`)
+        .filter({ has: page.locator(`td small.text-muted:text-is("${q.requesterEmail}")`) })
+        .count();
+    return count > 0;
+}
+
+/**
+ * Return the table-row Locator for a specific requester in the pending list.
+ * Assumes the page is already on admin-permissions.php with the pending list
+ * loaded; call `requestVisible` or `gotoAndWaitList` first.
+ */
+export async function findRequestRow(
+    page: Page,
+    q: { requesterEmail: string },
+): Promise<Locator> {
+    return page
+        .locator(`${statusBodySelector('pending')} tr`)
+        .filter({ has: page.locator(`td small.text-muted:text-is("${q.requesterEmail}")`) });
+}
+
+/**
+ * Open the review modal for the given requester's request, optionally fill
+ * review notes, click the action button, and wait for the modal to close and
+ * the list to refresh.
+ *
+ * - approve / reject → expects the request to be in the `pending` tab.
+ * - revoke           → expects the request to be in the `approved` tab.
+ */
+export async function actOnRequest(
+    page: Page,
+    q: { requesterEmail: string; action: 'approve' | 'reject' | 'revoke'; notes?: string },
+): Promise<void> {
+    // The source tab depends on the action.
+    const fromStatus = q.action === 'revoke' ? 'approved' : 'pending';
+    await gotoAndWaitList(page, fromStatus);
+
+    // Find the row and click its review button.
+    const row = page
+        .locator(`${statusBodySelector(fromStatus)} tr`)
+        .filter({ has: page.locator(`td small.text-muted:text-is("${q.requesterEmail}")`) });
+    await expect(row).toBeVisible();
+    await row.locator('.permReq-review-btn').click();
+
+    // Wait for the review modal to open.
+    const modal = page.locator('#permReqReviewModal');
+    await expect(modal).toBeVisible();
+
+    // Fill notes if provided (the notes section is present for pending + approved).
+    if (q.notes) {
+        await page.fill('#permReqReviewNotes', q.notes);
+    }
+
+    // Click the action button.
+    const actionBtnSelector: Record<string, string> = {
+        approve: '#permReqApproveBtn',
+        reject: '#permReqRejectBtn',
+        revoke: '#permReqRevokeBtn',
+    };
+    await page.click(actionBtnSelector[q.action]);
+
+    // Wait for the modal to close (JS hides it after the 1500 ms success delay).
+    await expect(modal).toBeHidden({ timeout: 10000 });
+
+    // Wait for the list to reload in the source-status body (spinner gone).
+    await expect(
+        page.locator(`${statusBodySelector(fromStatus)} .fa-spinner`),
+    ).toHaveCount(0);
+}

--- a/e2e/rbac/support/review.ts
+++ b/e2e/rbac/support/review.ts
@@ -55,18 +55,28 @@ function statusBodySelector(status: string): string {
 
 /**
  * Navigate to the admin access-requests page, activate the given status tab,
- * and wait for the list to finish loading (spinner disappears).
+ * and wait for the list to finish loading — anchored to the network response
+ * AND the spinner disappearing (belt-and-suspenders against the race where
+ * Bootstrap's shown.bs.tab can clear the spinner before the XHR resolves).
+ *
+ * Note: loadAccessRequests() issues a SINGLE fetch for all statuses at once;
+ * tab clicks only toggle visibility and do not trigger additional requests.
+ * We therefore always register the listener BEFORE page.goto to avoid missing
+ * the one fetch that fires during page initialisation.
  */
 async function gotoAndWaitList(page: Page, status: string): Promise<void> {
-    // Always navigate fresh so we read the current DB state.
+    // Register before navigation so we never miss the single all-statuses fetch.
+    const responseReady = page.waitForResponse(
+        r => r.url().includes('/admin/access-requests') && r.status() === 200,
+    );
     await page.goto(PAGE_PATH);
-
-    // The default active tab is 'pending'. For any other status, click its tab.
+    // For non-pending tabs, activate the correct tab so its body is visible
+    // before we start reading the DOM (tab click is purely cosmetic, no fetch).
     if (status !== 'pending') {
         await page.click(statusTabSelector(status));
     }
-
-    // Wait for the spinner inside the target body to disappear.
+    await responseReady;
+    // Belt-and-suspenders: confirm the target tab's spinner is also gone.
     await expect(page.locator(`${statusBodySelector(status)} .fa-spinner`)).toHaveCount(0);
 }
 
@@ -82,23 +92,24 @@ export async function requestVisible(
     await gotoAndWaitList(page, status);
     const count = await page
         .locator(`${statusBodySelector(status)} tr`)
-        .filter({ has: page.locator(`td small.text-muted:text-is("${q.requesterEmail}")`) })
+        .filter({ has: page.locator(`td:first-child small.text-muted:text-is("${q.requesterEmail}")`) })
         .count();
     return count > 0;
 }
 
 /**
- * Return the table-row Locator for a specific requester in the pending list.
- * Assumes the page is already on admin-permissions.php with the pending list
- * loaded; call `requestVisible` or `gotoAndWaitList` first.
+ * Return the table-row Locator for a specific requester in the given status list
+ * (defaults to 'pending'). Assumes the page is already on admin-permissions.php
+ * with the appropriate tab loaded; call `requestVisible` or `gotoAndWaitList` first.
  */
 export async function findRequestRow(
     page: Page,
-    q: { requesterEmail: string },
+    q: { requesterEmail: string; status?: string },
 ): Promise<Locator> {
+    const status = q.status ?? 'pending';
     return page
-        .locator(`${statusBodySelector('pending')} tr`)
-        .filter({ has: page.locator(`td small.text-muted:text-is("${q.requesterEmail}")`) });
+        .locator(`${statusBodySelector(status)} tr`)
+        .filter({ has: page.locator(`td:first-child small.text-muted:text-is("${q.requesterEmail}")`) });
 }
 
 /**
@@ -118,9 +129,10 @@ export async function actOnRequest(
     await gotoAndWaitList(page, fromStatus);
 
     // Find the row and click its review button.
+    // Scope to the first cell so the justification cell's small.text-muted doesn't match.
     const row = page
         .locator(`${statusBodySelector(fromStatus)} tr`)
-        .filter({ has: page.locator(`td small.text-muted:text-is("${q.requesterEmail}")`) });
+        .filter({ has: page.locator(`td:first-child small.text-muted:text-is("${q.requesterEmail}")`) });
     await expect(row).toBeVisible();
     await row.locator('.permReq-review-btn').click();
 
@@ -133,12 +145,14 @@ export async function actOnRequest(
         await page.fill('#permReqReviewNotes', q.notes);
     }
 
-    // Click the action button.
+    // Click the action button — assert it is visible first so an action that is
+    // invalid for the row's current status fails with a meaningful message.
     const actionBtnSelector: Record<string, string> = {
         approve: '#permReqApproveBtn',
         reject: '#permReqRejectBtn',
         revoke: '#permReqRevokeBtn',
     };
+    await expect(page.locator(actionBtnSelector[q.action])).toBeVisible();
     await page.click(actionBtnSelector[q.action]);
 
     // Wait for the modal to close (JS hides it after the 1500 ms success delay).

--- a/e2e/rbac/support/review.ts
+++ b/e2e/rbac/support/review.ts
@@ -55,29 +55,33 @@ function statusBodySelector(status: string): string {
 
 /**
  * Navigate to the admin access-requests page, activate the given status tab,
- * and wait for the list to finish loading — anchored to the network response
- * AND the spinner disappearing (belt-and-suspenders against the race where
- * Bootstrap's shown.bs.tab can clear the spinner before the XHR resolves).
+ * and wait for the list to finish loading.
+ *
+ * Uses DOM-only synchronisation (network-idle + spinner-gone) rather than
+ * waitForResponse: the XHR to /admin/access-requests consistently fires and
+ * delivers data, but Playwright's waitForResponse does not intercept it in the
+ * Docker test stack (likely due to the internal Docker bridge URL rewrite).
+ * networkidle waits for all in-flight XHRs to settle; the spinner check then
+ * confirms that loadAccessRequests() finished rendering.
  *
  * Note: loadAccessRequests() issues a SINGLE fetch for all statuses at once;
  * tab clicks only toggle visibility and do not trigger additional requests.
- * We therefore always register the listener BEFORE page.goto to avoid missing
- * the one fetch that fires during page initialisation.
  */
 async function gotoAndWaitList(page: Page, status: string): Promise<void> {
-    // Register before navigation so we never miss the single all-statuses fetch.
-    const responseReady = page.waitForResponse(
-        r => r.url().includes('/admin/access-requests') && r.status() === 200,
-    );
-    await page.goto(PAGE_PATH);
+    await page.goto(PAGE_PATH, { waitUntil: 'domcontentloaded' });
     // For non-pending tabs, activate the correct tab so its body is visible
     // before we start reading the DOM (tab click is purely cosmetic, no fetch).
     if (status !== 'pending') {
         await page.click(statusTabSelector(status));
     }
-    await responseReady;
-    // Belt-and-suspenders: confirm the target tab's spinner is also gone.
-    await expect(page.locator(`${statusBodySelector(status)} .fa-spinner`)).toHaveCount(0);
+    // Wait for all XHRs fired during page init to settle, then confirm the
+    // target-status spinner is gone. Use an explicit 30 s timeout: the API can
+    // be slow under the test Docker stack.
+    await page.waitForLoadState('networkidle', { timeout: 30000 });
+    await expect(page.locator(`${statusBodySelector(status)} .fa-spinner`)).toHaveCount(
+        0,
+        { timeout: 30000 },
+    );
 }
 
 /**

--- a/e2e/rbac/support/seed.test.ts
+++ b/e2e/rbac/support/seed.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { seedUser } from './seed';
+import { Fga } from './fga';
+import { ZitadelAdmin } from './zitadel';
+import { USERS } from './users';
+
+test('seedUser creates user, grants role, writes scoped tuple', async () => {
+    const id = await seedUser('cei-editor');
+    expect(id).toMatch(/^\d+$/);
+    const f = new Fga();
+    const u = USERS['cei-editor'].fga!;
+    expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+    // cleanup
+    await new ZitadelAdmin().deleteUser(id);
+    await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`);
+});

--- a/e2e/rbac/support/seed.test.ts
+++ b/e2e/rbac/support/seed.test.ts
@@ -4,17 +4,27 @@ import { Fga } from './fga';
 import { ZitadelAdmin } from './zitadel';
 import { USERS } from './users';
 
-test('seedUser creates user, grants role, writes scoped tuple', async () => {
-    const id = await seedUser('cei-editor');
+test('seedUser grants role for all; writes FGA tuple only for admins', async () => {
     const f = new Fga();
-    const u = USERS['cei-editor'].fga!;
+    const z = new ZitadelAdmin();
+
+    // editor: account + role, but NO FGA tuple (it is requested via UI in scenarios)
+    const editorId = await seedUser('cei-editor');
+    const e = USERS['cei-editor'].fga!;
     try {
-        expect(id).toMatch(/^\d+$/);
-        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+        expect(editorId).toMatch(/^\d+$/);
+        expect(await f.check(`user:${editorId}`, e.relation, `${e.objectType}:${e.objectId}`)).toBe(false);
     } finally {
-        // Always clean up, even if an assertion above fails, so a failed run
-        // doesn't leave an orphaned user + tuple that poisons later runs.
-        await new ZitadelAdmin().deleteUser(id).catch(() => {});
-        await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`).catch(() => {});
+        await z.deleteUser(editorId).catch(() => {});
+    }
+
+    // admin: account + role + FGA admin tuple
+    const adminId = await seedUser('usccb-admin');
+    const a = USERS['usccb-admin'].fga!;
+    try {
+        expect(await f.check(`user:${adminId}`, a.relation, `${a.objectType}:${a.objectId}`)).toBe(true);
+    } finally {
+        await z.deleteUser(adminId).catch(() => {});
+        await f.delete(`user:${adminId}`, a.relation, `${a.objectType}:${a.objectId}`).catch(() => {});
     }
 });

--- a/e2e/rbac/support/seed.test.ts
+++ b/e2e/rbac/support/seed.test.ts
@@ -6,11 +6,15 @@ import { USERS } from './users';
 
 test('seedUser creates user, grants role, writes scoped tuple', async () => {
     const id = await seedUser('cei-editor');
-    expect(id).toMatch(/^\d+$/);
     const f = new Fga();
     const u = USERS['cei-editor'].fga!;
-    expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
-    // cleanup
-    await new ZitadelAdmin().deleteUser(id);
-    await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`);
+    try {
+        expect(id).toMatch(/^\d+$/);
+        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+    } finally {
+        // Always clean up, even if an assertion above fails, so a failed run
+        // doesn't leave an orphaned user + tuple that poisons later runs.
+        await new ZitadelAdmin().deleteUser(id).catch(() => {});
+        await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`).catch(() => {});
+    }
 });

--- a/e2e/rbac/support/seed.ts
+++ b/e2e/rbac/support/seed.ts
@@ -37,11 +37,17 @@ export async function seedUser(id: string): Promise<string> {
 }
 
 /**
- * Obtain a Zitadel OIDC access token (JWT) for a user via the headless session→PKCE flow.
+ * Obtain Zitadel OIDC tokens for a user via the headless session→PKCE flow.
  * `loginClientToken` is a session-capable PAT (minted for the `login-client` user in setup).
- * Returns the access_token to be set as the `litcal_access_token` cookie.
+ * Returns both the access_token and id_token; production's auth/callback.php sets BOTH as
+ * cookies, and AuthHelper's OIDC mode reads user claims (email_verified, name, …) from the
+ * id_token in preference to the access token — so the harness must carry the id_token too.
  */
-export async function oidcLogin(email: string, password: string, loginClientToken: string): Promise<string> {
+export async function oidcLogin(
+    email: string,
+    password: string,
+    loginClientToken: string,
+): Promise<{ accessToken: string; idToken: string | null }> {
     const Hl = { Authorization: `Bearer ${loginClientToken}`, 'Content-Type': 'application/json', Host: HOST };
     const json = async (r: Response) => { const t = await r.text(); if (!r.ok) throw new Error(`${r.url} -> ${r.status}: ${t}`); return JSON.parse(t); };
 
@@ -79,7 +85,7 @@ export async function oidcLogin(email: string, password: string, loginClientToke
         method: 'POST', headers: { Host: HOST, 'Content-Type': 'application/x-www-form-urlencoded' }, body: form,
     }));
     if (!tok.access_token) throw new Error(`token exchange returned no access_token: ${JSON.stringify(tok)}`);
-    return tok.access_token as string;
+    return { accessToken: tok.access_token as string, idToken: (tok.id_token ?? null) as string | null };
 }
 
 // state param need only be opaque/unique-ish; avoid Math.random for determinism-friendliness.
@@ -87,17 +93,23 @@ function id_state(): string { return b64url(crypto.randomBytes(8)); }
 
 /**
  * Log a user in headlessly and write a Playwright storageState file containing the
- * `litcal_access_token` cookie. Cookie domain is `localhost` (port-agnostic) so it is sent to
- * both the frontend (:3000) and the API (:8000). The real cookie is HttpOnly.
+ * `litcal_access_token` AND `litcal_id_token` cookies — mirroring production's
+ * auth/callback.php, which sets both. AuthHelper's OIDC mode prefers the id_token for
+ * user claims (email_verified, name, …), so omitting it leaves seeded users looking
+ * email-unverified (blocked from email-verified-gated pages like permission-requests.php).
+ * Cookie domain is `localhost` (port-agnostic) so cookies reach both the frontend (:3000)
+ * and the API (:8000). The real cookies are HttpOnly.
  */
 export async function loginAndSaveState(id: string, loginClientToken: string): Promise<void> {
     const u = USERS[id];
-    const accessToken = await oidcLogin(u.email, u.password, loginClientToken);
+    const { accessToken, idToken } = await oidcLogin(u.email, u.password, loginClientToken);
+    const cookieBase = {
+        domain: 'localhost', path: '/', expires: -1, httpOnly: true, secure: false, sameSite: 'Lax' as const,
+    };
+    const cookies = [{ name: 'litcal_access_token', value: accessToken, ...cookieBase }];
+    if (idToken) cookies.push({ name: 'litcal_id_token', value: idToken, ...cookieBase });
     const storageState = {
-        cookies: [{
-            name: 'litcal_access_token', value: accessToken, domain: 'localhost', path: '/',
-            expires: -1, httpOnly: true, secure: false, sameSite: 'Lax' as const,
-        }],
+        cookies,
         origins: [],
     };
     const authPath = path.join(__dirname, '..', '..', '.auth', `${id}.json`);

--- a/e2e/rbac/support/seed.ts
+++ b/e2e/rbac/support/seed.ts
@@ -135,6 +135,10 @@ export async function seedAndLogin(userKey: string): Promise<string> {
         await loginAndSaveState(userKey, pat.token);
         return userId;
     } finally {
-        await z.deletePat(loginClientUserId, pat.tokenId).catch(() => {});
+        // Surface (don't swallow) a PAT-revocation failure so a leaked ephemeral token is
+        // visible, while still not masking a real error from the seeding above.
+        await z.deletePat(loginClientUserId, pat.tokenId).catch((e) =>
+            console.warn('seedAndLogin: failed to delete ephemeral PAT (token may persist):', String(e)),
+        );
     }
 }

--- a/e2e/rbac/support/seed.ts
+++ b/e2e/rbac/support/seed.ts
@@ -1,0 +1,101 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+import { USERS } from './users';
+import { ZitadelAdmin } from './zitadel';
+import { Fga } from './fga';
+
+const ISSUER = (process.env.ZITADEL_ISSUER || 'http://localhost:8080').replace(/\/$/, '');
+// Reuse the existing Zitadel OIDC client (authorization_code + PKCE, public/no-secret) for the
+// headless login flow. We drive it server-side via the session API rather than a browser redirect.
+const CLIENT_ID = process.env.ZITADEL_CLIENT_ID!;
+const REDIRECT_URI = `${process.env.FRONTEND_URL || 'http://localhost:3000'}/auth/callback.php`;
+// Zitadel matches requests by its configured external domain; send Host = the issuer hostname
+// (port-stripped) rather than hardcoding 'localhost', so a non-localhost ZITADEL_ISSUER still works.
+const HOST = new URL(ISSUER).hostname;
+const b64url = (b: Buffer) => b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+export async function seedUser(id: string): Promise<string> {
+    const u = USERS[id];
+    const z = new ZitadelAdmin();
+    const f = new Fga();
+
+    const existing = await z.findUserIdByEmail(u.email);
+    if (existing) {
+        if (u.fga) await f.delete(`user:${existing}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+        await z.deleteUser(existing);
+    }
+    const userId = await z.createVerifiedUser({ email: u.email, password: u.password, firstName: u.id, lastName: 'E2E' });
+    await z.grantProjectRole(userId, u.role);
+    if (u.fga) await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+    return userId;
+}
+
+/**
+ * Obtain a Zitadel OIDC access token (JWT) for a user via the headless session→PKCE flow.
+ * `loginClientToken` is a session-capable PAT (minted for the `login-client` user in setup).
+ * Returns the access_token to be set as the `litcal_access_token` cookie.
+ */
+export async function oidcLogin(email: string, password: string, loginClientToken: string): Promise<string> {
+    const Hl = { Authorization: `Bearer ${loginClientToken}`, 'Content-Type': 'application/json', Host: HOST };
+    const json = async (r: Response) => { const t = await r.text(); if (!r.ok) throw new Error(`${r.url} -> ${r.status}: ${t}`); return JSON.parse(t); };
+
+    // 1. Create a password-checked session (login-client token).
+    const s = await json(await fetch(`${ISSUER}/v2/sessions`, {
+        method: 'POST', headers: Hl,
+        body: JSON.stringify({ checks: { user: { loginName: email }, password: { password } } }),
+    }));
+
+    // 2. Start an OIDC auth request (Frontend client, PKCE S256) → 302 to login-v2 with ?authRequest=...
+    const verifier = b64url(crypto.randomBytes(32));
+    const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+    const qs = new URLSearchParams({
+        response_type: 'code', client_id: CLIENT_ID, redirect_uri: REDIRECT_URI,
+        scope: 'openid profile email', code_challenge: challenge, code_challenge_method: 'S256', state: id_state(),
+    });
+    const authResp = await fetch(`${ISSUER}/oauth/v2/authorize?${qs}`, { headers: { Host: HOST }, redirect: 'manual' });
+    const loc = authResp.headers.get('location') || '';
+    const arMatch = loc.match(/authRequest(?:Id)?=([^&]+)/);
+    if (!arMatch) throw new Error(`authorize did not return an authRequest id: ${authResp.status} ${loc}`);
+    const authRequestId = decodeURIComponent(arMatch[1]);
+
+    // 3. Finalize the auth request with the session (login-client token) → callbackUrl with ?code=
+    const fin = await json(await fetch(`${ISSUER}/v2/oidc/auth_requests/${authRequestId}`, {
+        method: 'POST', headers: Hl,
+        body: JSON.stringify({ session: { sessionId: s.sessionId, sessionToken: s.sessionToken } }),
+    }));
+    const codeMatch = String(fin.callbackUrl || '').match(/[?&]code=([^&]+)/);
+    if (!codeMatch) throw new Error(`finalize returned no code: ${JSON.stringify(fin)}`);
+    const code = decodeURIComponent(codeMatch[1]);
+
+    // 4. Exchange the code for tokens (public client, PKCE — no client secret).
+    const form = new URLSearchParams({ grant_type: 'authorization_code', code, redirect_uri: REDIRECT_URI, client_id: CLIENT_ID, code_verifier: verifier });
+    const tok = await json(await fetch(`${ISSUER}/oauth/v2/token`, {
+        method: 'POST', headers: { Host: HOST, 'Content-Type': 'application/x-www-form-urlencoded' }, body: form,
+    }));
+    if (!tok.access_token) throw new Error(`token exchange returned no access_token: ${JSON.stringify(tok)}`);
+    return tok.access_token as string;
+}
+
+// state param need only be opaque/unique-ish; avoid Math.random for determinism-friendliness.
+function id_state(): string { return b64url(crypto.randomBytes(8)); }
+
+/**
+ * Log a user in headlessly and write a Playwright storageState file containing the
+ * `litcal_access_token` cookie. Cookie domain is `localhost` (port-agnostic) so it is sent to
+ * both the frontend (:3000) and the API (:8000). The real cookie is HttpOnly.
+ */
+export async function loginAndSaveState(id: string, loginClientToken: string): Promise<void> {
+    const u = USERS[id];
+    const accessToken = await oidcLogin(u.email, u.password, loginClientToken);
+    const storageState = {
+        cookies: [{
+            name: 'litcal_access_token', value: accessToken, domain: 'localhost', path: '/',
+            expires: -1, httpOnly: true, secure: false, sameSite: 'Lax' as const,
+        }],
+        origins: [],
+    };
+    const authPath = path.join(__dirname, '..', '..', '.auth', `${id}.json`);
+    fs.mkdirSync(path.dirname(authPath), { recursive: true });
+    fs.writeFileSync(authPath, JSON.stringify(storageState, null, 2));
+}

--- a/e2e/rbac/support/seed.ts
+++ b/e2e/rbac/support/seed.ts
@@ -116,3 +116,25 @@ export async function loginAndSaveState(id: string, loginClientToken: string): P
     fs.mkdirSync(path.dirname(authPath), { recursive: true });
     fs.writeFileSync(authPath, JSON.stringify(storageState, null, 2));
 }
+
+/**
+ * Provision a user on demand within a spec's precondition: create the Zitadel account + role
+ * (+ admin FGA tuple, for admin-relation users) AND write its login storageState so
+ * `actingAs(browser, userKey)` works. Factors the per-user logic of rbac.setup.ts, minting and
+ * deleting its own ephemeral login-client PAT. Use this for scenarios that need a
+ * REGISTRATION_USER (e.g. cei-admin) to already exist as a precondition — those users are not
+ * seeded by rbac.setup.ts. Idempotent on the user (seedUser deletes-existing-first).
+ */
+export async function seedAndLogin(userKey: string): Promise<string> {
+    const z = new ZitadelAdmin();
+    const loginClientUserId = await z.findUserIdByUsername('login-client');
+    if (!loginClientUserId) throw new Error('seedAndLogin: login-client machine user not found in Zitadel');
+    const pat = await z.mintPat(loginClientUserId);
+    try {
+        const userId = await seedUser(userKey);
+        await loginAndSaveState(userKey, pat.token);
+        return userId;
+    } finally {
+        await z.deletePat(loginClientUserId, pat.tokenId).catch(() => {});
+    }
+}

--- a/e2e/rbac/support/seed.ts
+++ b/e2e/rbac/support/seed.ts
@@ -27,7 +27,12 @@ export async function seedUser(id: string): Promise<string> {
     }
     const userId = await z.createVerifiedUser({ email: u.email, password: u.password, firstName: u.id, lastName: 'E2E' });
     await z.grantProjectRole(userId, u.role);
-    if (u.fga) await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+    // Seed the FGA tuple only for resource-admins. Editor grants are earned via the
+    // request-access UI in scenarios (the approval outcome), seeded per-spec where a
+    // scenario needs the grant as a precondition (see support/grant.ts).
+    if (u.fga?.relation === 'admin') {
+        await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+    }
     return userId;
 }
 

--- a/e2e/rbac/support/users.test.ts
+++ b/e2e/rbac/support/users.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { USERS, SEEDED_USER_IDS, REGISTRATION_USER_IDS } from './users';
+
+test('matrix has 11 users with unique emails', () => {
+    const ids = Object.keys(USERS);
+    expect(ids).toHaveLength(11);
+    const emails = ids.map((i) => USERS[i].email);
+    expect(new Set(emails).size).toBe(11);
+});
+
+test('only super-admin holds the global admin role; others are calendar_editor', () => {
+    expect(USERS['super-admin'].role).toBe('admin');
+    expect(USERS['super-admin'].fga).toBeNull();
+    for (const id of Object.keys(USERS).filter((i) => i !== 'super-admin')) {
+        expect(USERS[id].role).toBe('calendar_editor');
+        expect(USERS[id].fga).not.toBeNull();
+    }
+});
+
+test('registration users are a subset not included in seeded ids', () => {
+    expect(REGISTRATION_USER_IDS).toEqual(['cei-admin', 'usccb-editor']);
+    for (const id of REGISTRATION_USER_IDS) expect(SEEDED_USER_IDS).not.toContain(id);
+});

--- a/e2e/rbac/support/users.ts
+++ b/e2e/rbac/support/users.ts
@@ -1,0 +1,32 @@
+export type RbacRelation = 'admin' | 'editor';
+
+export interface RbacUser {
+    id: string;
+    email: string;
+    password: string;
+    role: 'admin' | 'calendar_editor';
+    fga: { relation: RbacRelation; objectType: string; objectId: string } | null;
+}
+
+const pw = 'E2e-Test-Passw0rd!'; // shared test password; users live only in the test org
+
+function mk(id: string, role: RbacUser['role'], fga: RbacUser['fga']): RbacUser {
+    return { id, email: `${id}+e2e@litcal.test`, password: pw, role, fga };
+}
+
+export const USERS: Record<string, RbacUser> = {
+    'super-admin': mk('super-admin', 'admin', null),
+    'cei-admin': mk('cei-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'IT' }),
+    'cei-editor': mk('cei-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'IT' }),
+    'usccb-admin': mk('usccb-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'US' }),
+    'usccb-editor': mk('usccb-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'US' }),
+    'rome-admin': mk('rome-admin', 'calendar_editor', { relation: 'admin', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
+    'rome-editor': mk('rome-editor', 'calendar_editor', { relation: 'editor', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
+    'grc-admin': mk('grc-admin', 'calendar_editor', { relation: 'admin', objectType: 'general_roman_calendar', objectId: 'temporale' }),
+    'grc-editor': mk('grc-editor', 'calendar_editor', { relation: 'editor', objectType: 'general_roman_calendar', objectId: 'temporale' }),
+    'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: 'Europe' }),
+    'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: 'Europe' }),
+};
+
+export const REGISTRATION_USER_IDS = ['cei-admin', 'usccb-editor'];
+export const SEEDED_USER_IDS = Object.keys(USERS).filter((id) => !REGISTRATION_USER_IDS.includes(id));

--- a/e2e/rbac/support/zitadel.test.ts
+++ b/e2e/rbac/support/zitadel.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { ZitadelAdmin } from './zitadel';
+
+test('create, find, grant role, delete a verified user', async () => {
+    const z = new ZitadelAdmin();
+    const email = `zit-probe+e2e@litcal.test`;
+    // clean slate
+    const existing = await z.findUserIdByEmail(email);
+    if (existing) await z.deleteUser(existing);
+
+    const id = await z.createVerifiedUser({ email, password: 'E2e-Test-Passw0rd!', firstName: 'Zit', lastName: 'Probe' });
+    expect(id).toMatch(/^\d+$/);
+    expect(await z.findUserIdByEmail(email)).toBe(id);
+
+    await z.grantProjectRole(id, 'calendar_editor'); // must not throw
+    await z.deleteUser(id);
+    expect(await z.findUserIdByEmail(email)).toBeNull();
+});

--- a/e2e/rbac/support/zitadel.test.ts
+++ b/e2e/rbac/support/zitadel.test.ts
@@ -9,10 +9,15 @@ test('create, find, grant role, delete a verified user', async () => {
     if (existing) await z.deleteUser(existing);
 
     const id = await z.createVerifiedUser({ email, password: 'E2e-Test-Passw0rd!', firstName: 'Zit', lastName: 'Probe' });
-    expect(id).toMatch(/^\d+$/);
-    expect(await z.findUserIdByEmail(email)).toBe(id);
-
-    await z.grantProjectRole(id, 'calendar_editor'); // must not throw
-    await z.deleteUser(id);
+    try {
+        expect(id).toMatch(/^\d+$/);
+        expect(await z.findUserIdByEmail(email)).toBe(id);
+        await z.grantProjectRole(id, 'calendar_editor'); // must not throw
+    } finally {
+        // Always remove the probe user, even if an assertion above fails, so it
+        // doesn't contaminate later runs.
+        await z.deleteUser(id).catch(() => {});
+    }
+    // Deletion above is also the behavior under test: confirm it took effect.
     expect(await z.findUserIdByEmail(email)).toBeNull();
 });

--- a/e2e/rbac/support/zitadel.ts
+++ b/e2e/rbac/support/zitadel.ts
@@ -39,9 +39,14 @@ export class ZitadelAdmin {
             email: { email: u.email, isVerified: true },
             password: { password: u.password, changeRequired: false },
         });
-        // Zitadel's search projection is eventually consistent; wait until the new
-        // user is visible to findUserIdByEmail before returning.
-        await new Promise<void>(r => setTimeout(r, 200));
+        // Zitadel's search projection is eventually consistent; poll until the new
+        // user is visible to findUserIdByEmail before returning (max ~2.25 s).
+        const maxAttempts = 15;
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            const found = await this.findUserIdByEmail(u.email);
+            if (found !== null) break;
+            await new Promise<void>(r => setTimeout(r, 150));
+        }
         return data.userId as string;
     }
 

--- a/e2e/rbac/support/zitadel.ts
+++ b/e2e/rbac/support/zitadel.ts
@@ -41,11 +41,18 @@ export class ZitadelAdmin {
         });
         // Zitadel's search projection is eventually consistent; poll until the new
         // user is visible to findUserIdByEmail before returning (max ~2.25 s).
+        // Fail fast if it never appears: a user invisible to search after the full
+        // window would otherwise be silently skipped by findUserIdByEmail-based
+        // cleanup, orphaning it.
         const maxAttempts = 15;
+        let found: string | null = null;
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            const found = await this.findUserIdByEmail(u.email);
+            found = await this.findUserIdByEmail(u.email);
             if (found !== null) break;
             await new Promise<void>(r => setTimeout(r, 150));
+        }
+        if (found === null) {
+            throw new Error(`createVerifiedUser: projection timed out — ${u.email} not visible to search after ${maxAttempts} attempts`);
         }
         return data.userId as string;
     }
@@ -76,8 +83,12 @@ export class ZitadelAdmin {
     }
 
     async mintPat(userId: string): Promise<{ tokenId: string; token: string }> {
+        // Short-lived PAT (6h) for the ephemeral setup flow: minimizes the blast
+        // radius if cleanup (deletePat) fails to remove it. The setup→test→cleanup
+        // cycle is minutes, so 6h is ample margin.
+        const expirationDate = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString();
         const data = await this.req('POST', `/management/v1/users/${userId}/pats`, {
-            expirationDate: '2030-01-01T00:00:00Z',
+            expirationDate,
         });
         return { tokenId: data.tokenId as string, token: data.token as string };
     }

--- a/e2e/rbac/support/zitadel.ts
+++ b/e2e/rbac/support/zitadel.ts
@@ -11,7 +11,9 @@ export class ZitadelAdmin {
                 Authorization: `Bearer ${this.token}`,
                 'Content-Type': 'application/json',
                 'x-zitadel-orgid': this.orgId,
-                Host: 'localhost',
+                // Send Host = the issuer hostname (port-stripped) so a non-localhost
+                // ZITADEL_ISSUER still matches Zitadel's configured external domain.
+                Host: new URL(this.issuer).hostname,
             },
             body: body === undefined ? undefined : JSON.stringify(body),
         });

--- a/e2e/rbac/support/zitadel.ts
+++ b/e2e/rbac/support/zitadel.ts
@@ -1,0 +1,81 @@
+export class ZitadelAdmin {
+    private issuer = process.env.ZITADEL_ISSUER!.replace(/\/$/, '');
+    private token = process.env.ZITADEL_MACHINE_TOKEN!;
+    private orgId = process.env.ZITADEL_ORG_ID!;
+    private projectId = process.env.ZITADEL_PROJECT_ID!;
+
+    private async req(method: string, path: string, body?: unknown): Promise<any> {
+        const res = await fetch(`${this.issuer}${path}`, {
+            method,
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+                'Content-Type': 'application/json',
+                'x-zitadel-orgid': this.orgId,
+                Host: 'localhost',
+            },
+            body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        const text = await res.text();
+        if (!res.ok) throw new Error(`Zitadel ${method} ${path} -> ${res.status}: ${text}`);
+        return text ? JSON.parse(text) : {};
+    }
+
+    async findUserIdByEmail(email: string): Promise<string | null> {
+        const data = await this.req('POST', '/v2/users', {
+            queries: [
+                { emailQuery: { emailAddress: email } },
+                { stateQuery: { state: 'USER_STATE_ACTIVE' } },
+            ],
+        });
+        const u = (data.result ?? [])[0];
+        return u?.userId ?? null;
+    }
+
+    async createVerifiedUser(u: { email: string; password: string; firstName: string; lastName: string }): Promise<string> {
+        const data = await this.req('POST', '/v2/users/human', {
+            profile: { givenName: u.firstName, familyName: u.lastName },
+            email: { email: u.email, isVerified: true },
+            password: { password: u.password, changeRequired: false },
+        });
+        // Zitadel's search projection is eventually consistent; wait until the new
+        // user is visible to findUserIdByEmail before returning.
+        await new Promise<void>(r => setTimeout(r, 200));
+        return data.userId as string;
+    }
+
+    async grantProjectRole(userId: string, role: string): Promise<void> {
+        await this.req('POST', `/management/v1/users/${userId}/grants`, {
+            projectId: this.projectId,
+            roleKeys: [role],
+        });
+    }
+
+    async deleteUser(userId: string): Promise<void> {
+        await this.req('DELETE', `/v2/users/${userId}`);
+        // Zitadel's search projection is eventually consistent; a brief pause ensures
+        // callers can immediately call findUserIdByEmail and get a consistent result.
+        await new Promise<void>(r => setTimeout(r, 200));
+    }
+
+    async findUserIdByUsername(userName: string): Promise<string | null> {
+        const data = await this.req('POST', '/v2/users', {
+            queries: [
+                { userNameQuery: { userName } },
+                { stateQuery: { state: 'USER_STATE_ACTIVE' } },
+            ],
+        });
+        const u = (data.result ?? [])[0];
+        return u?.userId ?? null;
+    }
+
+    async mintPat(userId: string): Promise<{ tokenId: string; token: string }> {
+        const data = await this.req('POST', `/management/v1/users/${userId}/pats`, {
+            expirationDate: '2030-01-01T00:00:00Z',
+        });
+        return { tokenId: data.tokenId as string, token: data.token as string };
+    }
+
+    async deletePat(userId: string, tokenId: string): Promise<void> {
+        await this.req('DELETE', `/management/v1/users/${userId}/pats/${tokenId}`);
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="frontend">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,6 +71,22 @@ export default defineConfig({
             },
             dependencies: ['setup'],
         },
+        {
+            // Unit/integration tests for the support modules (users/zitadel/fga/seed/cleanup).
+            // They run against the live stack but do NOT need the full seed, so no dependency.
+            name: 'rbac-support',
+            testMatch: /rbac\/support\/.*\.test\.ts/,
+        },
+        {
+            name: 'rbac-setup',
+            testMatch: /rbac\/rbac\.setup\.ts/,
+        },
+        {
+            name: 'rbac',
+            testMatch: /rbac\/.*\.spec\.ts/,
+            use: { ...devices['Desktop Chrome'] },
+            dependencies: ['rbac-setup'],
+        },
     ],
 
     /* Run servers before starting the tests */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
         // Setup project to authenticate
         {
             name: 'setup',
-            testMatch: /.*\.setup\.ts/,
+            testMatch: /auth\.setup\.ts/,
         },
         {
             name: 'chromium',
@@ -54,6 +54,7 @@ export default defineConfig({
                 storageState: 'e2e/.auth/user.json',
             },
             dependencies: ['setup'],
+            testIgnore: /rbac\//,
         },
         {
             name: 'firefox',
@@ -62,6 +63,7 @@ export default defineConfig({
                 storageState: 'e2e/.auth/user.json',
             },
             dependencies: ['setup'],
+            testIgnore: /rbac\//,
         },
         {
             name: 'webkit',
@@ -70,6 +72,7 @@ export default defineConfig({
                 storageState: 'e2e/.auth/user.json',
             },
             dependencies: ['setup'],
+            testIgnore: /rbac\//,
         },
         {
             // Unit/integration tests for the support modules (users/zitadel/fga/seed/cleanup).

--- a/src/AuthHelper.php
+++ b/src/AuthHelper.php
@@ -45,6 +45,14 @@ class AuthHelper
     public readonly ?array $permissions;
 
     /**
+     * Memoized admin-scopes result for this request.
+     * Shape: array{is_resource_admin: bool, admin_scopes: list<array{object_type: string, object_id: string}>}
+     *
+     * @var array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}|null
+     */
+    private ?array $adminScopesResult = null;
+
+    /**
      * Private constructor - use getInstance() to get the singleton
      *
      * @param object|null $payload Validated JWT payload, or null if not authenticated
@@ -299,6 +307,119 @@ class AuthHelper
             return false;
         }
         return in_array($permission, $this->permissions, true);
+    }
+
+    /**
+     * Whether the caller holds an OpenFGA `admin` tuple on at least one resource.
+     *
+     * Resolved once per request from GET /auth/admin-scopes (server-side, using
+     * the caller's session cookies). Fails closed: an unauthenticated caller or
+     * any API/parse error yields false.
+     */
+    public function isResourceAdmin(): bool
+    {
+        return $this->loadAdminScopes()['is_resource_admin'];
+    }
+
+    /**
+     * The caller's OpenFGA `admin` scopes.
+     *
+     * @return array<int, array{object_type: string, object_id: string}>
+     */
+    public function adminScopes(): array
+    {
+        return $this->loadAdminScopes()['admin_scopes'];
+    }
+
+    /**
+     * Resolve (and memoize) the admin-scopes result for this request.
+     *
+     * @return array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}
+     */
+    private function loadAdminScopes(): array
+    {
+        if ($this->adminScopesResult !== null) {
+            return $this->adminScopesResult;
+        }
+
+        // Fail closed for unauthenticated callers — never hit the API.
+        if (!$this->isAuthenticated) {
+            return $this->adminScopesResult = ['is_resource_admin' => false, 'admin_scopes' => []];
+        }
+
+        $apiBaseUrl   = ApiConfig::getInstance()->apiBaseUrl;
+        $cookieHeader = self::buildCookieHeader();
+
+        return $this->adminScopesResult = self::fetchAdminScopes($apiBaseUrl, $cookieHeader);
+    }
+
+    /**
+     * Build a Cookie header from the session token cookies, to forward the
+     * caller's identity to the API on the server-to-server call.
+     */
+    private static function buildCookieHeader(): ?string
+    {
+        $parts = [];
+        foreach ([self::ACCESS_TOKEN_COOKIE, self::ID_TOKEN_COOKIE] as $name) {
+            $value = $_COOKIE[$name] ?? null;
+            if (is_string($value) && $value !== '') {
+                $parts[] = "{$name}={$value}";
+            }
+        }
+        return $parts === [] ? null : implode('; ', $parts);
+    }
+
+    /**
+     * Fetch and parse GET /auth/admin-scopes. Fails closed on any error.
+     *
+     * @param string $apiBaseUrl Base API URL (no trailing slash)
+     * @param string|null $cookieHeader Cookie header forwarding the caller's session
+     * @param \GuzzleHttp\Client|null $client Injectable client (tests)
+     * @return array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}
+     */
+    public static function fetchAdminScopes(
+        string $apiBaseUrl,
+        ?string $cookieHeader,
+        ?\GuzzleHttp\Client $client = null
+    ): array {
+        $failClosed = ['is_resource_admin' => false, 'admin_scopes' => []];
+
+        $client ??= new \GuzzleHttp\Client(['timeout' => 5, 'connect_timeout' => 2, 'http_errors' => true]);
+
+        $headers = ['Accept' => 'application/json'];
+        if ($cookieHeader !== null) {
+            $headers['Cookie'] = $cookieHeader;
+        }
+
+        try {
+            $response = $client->get("{$apiBaseUrl}/auth/admin-scopes", ['headers' => $headers]);
+            $data     = json_decode((string) $response->getBody(), true);
+        } catch (\Throwable) {
+            return $failClosed;
+        }
+
+        if (!is_array($data)) {
+            return $failClosed;
+        }
+
+        $scopes = [];
+        if (isset($data['admin_scopes']) && is_array($data['admin_scopes'])) {
+            foreach ($data['admin_scopes'] as $scope) {
+                if (
+                    is_array($scope)
+                    && isset($scope['object_type'], $scope['object_id'])
+                    && is_string($scope['object_type'])
+                    && is_string($scope['object_id'])
+                ) {
+                    $scopes[] = ['object_type' => $scope['object_type'], 'object_id' => $scope['object_id']];
+                }
+            }
+        }
+
+        return [
+            'is_resource_admin' => (bool) ( $data['is_resource_admin'] ?? false ),
+            'admin_scopes'      => $scopes,
+        ];
     }
 
     /**

--- a/src/AuthHelper.php
+++ b/src/AuthHelper.php
@@ -416,8 +416,11 @@ class AuthHelper
             }
         }
 
+        // Strict, fail-closed: only an explicit JSON `true` counts as resource-admin.
+        // A non-boolean value (e.g. the string "false") or a missing key yields false,
+        // mirroring the per-scope type validation above.
         return [
-            'is_resource_admin' => (bool) ( $data['is_resource_admin'] ?? false ),
+            'is_resource_admin' => ( $data['is_resource_admin'] ?? false ) === true,
             'admin_scopes'      => $scopes,
         ];
     }

--- a/src/AuthHelper.php
+++ b/src/AuthHelper.php
@@ -347,7 +347,13 @@ class AuthHelper
             return $this->adminScopesResult = ['is_resource_admin' => false, 'admin_scopes' => []];
         }
 
-        $apiBaseUrl   = ApiConfig::getInstance()->apiBaseUrl;
+        // Prefer API_INTERNAL_URL for server-side Guzzle calls so that in Docker
+        // environments the request routes through the internal network (e.g. to
+        // 'litcal-api') rather than to the container's own loopback. This mirrors the
+        // ZITADEL_INTERNAL_URL pattern used by OidcClient. Falls back to the public
+        // apiBaseUrl when no internal override is configured.
+        $internalUrl  = $_ENV['API_INTERNAL_URL'] ?? getenv('API_INTERNAL_URL') ?: null;
+        $apiBaseUrl   = $internalUrl ? rtrim($internalUrl, '/') : ApiConfig::getInstance()->apiBaseUrl;
         $cookieHeader = self::buildCookieHeader();
 
         return $this->adminScopesResult = self::fetchAdminScopes($apiBaseUrl, $cookieHeader);

--- a/tests/AuthHelperAdminScopesTest.php
+++ b/tests/AuthHelperAdminScopesTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Frontend\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Frontend\AuthHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AuthHelper::class)]
+final class AuthHelperAdminScopesTest extends TestCase
+{
+    private function clientWith(Response ...$responses): Client
+    {
+        return new Client(['handler' => HandlerStack::create(new MockHandler($responses))]);
+    }
+
+    public function testFetchAdminScopesParsesResourceAdminResponse(): void
+    {
+        $client = $this->clientWith(new Response(200, [], json_encode([
+            'is_global_admin'   => false,
+            'is_resource_admin' => true,
+            'admin_scopes'      => [
+                ['object_type' => 'national_calendar', 'object_id' => 'IT'],
+            ],
+        ])));
+
+        $result = AuthHelper::fetchAdminScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertTrue($result['is_resource_admin']);
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $result['admin_scopes']
+        );
+    }
+
+    public function testFetchAdminScopesFailsClosedOnHttpError(): void
+    {
+        $client = $this->clientWith(new Response(401, [], 'Unauthorized'));
+
+        $result = AuthHelper::fetchAdminScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_resource_admin']);
+        self::assertSame([], $result['admin_scopes']);
+    }
+
+    public function testFetchAdminScopesFailsClosedOnMalformedJson(): void
+    {
+        $client = $this->clientWith(new Response(200, [], 'not json'));
+
+        $result = AuthHelper::fetchAdminScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_resource_admin']);
+        self::assertSame([], $result['admin_scopes']);
+    }
+}

--- a/tests/AuthHelperAdminScopesTest.php
+++ b/tests/AuthHelperAdminScopesTest.php
@@ -20,6 +20,97 @@ final class AuthHelperAdminScopesTest extends TestCase
         return new Client(['handler' => HandlerStack::create(new MockHandler($responses))]);
     }
 
+    /**
+     * Clear a set of env vars from both $_ENV and the process environment,
+     * returning the previous values so they can be restored.
+     *
+     * @param list<string> $keys
+     * @return array<string, array{env: string|null, proc: string|false}>
+     */
+    private function stashAndClearEnv(array $keys): array
+    {
+        $saved = [];
+        foreach ($keys as $k) {
+            $saved[$k] = ['env' => $_ENV[$k] ?? null, 'proc' => getenv($k)];
+            unset($_ENV[$k]);
+            putenv($k); // no '=value' → removes the variable from the process environment
+        }
+        return $saved;
+    }
+
+    /**
+     * @param array<string, array{env: string|null, proc: string|false}> $saved
+     */
+    private function restoreEnv(array $saved): void
+    {
+        foreach ($saved as $k => $v) {
+            if ($v['env'] !== null) {
+                $_ENV[$k] = $v['env'];
+            }
+            if ($v['proc'] !== false) {
+                putenv("{$k}={$v['proc']}");
+            }
+        }
+    }
+
+    /**
+     * Unauthenticated short-circuit: loadAdminScopes() must return the fail-closed
+     * default WITHOUT ever calling the API when !$this->isAuthenticated, and the
+     * result must be memoized (a second call must not refetch).
+     *
+     * NOTE: We cannot assert programmatically that *no* HTTP call was made —
+     * fetchAdminScopes() catches all Throwables and fails closed, so even if the
+     * short-circuit were accidentally removed and a Guzzle request were attempted,
+     * the assertion values would still be the same. The structural guarantee is in
+     * the code: loadAdminScopes() returns before reaching fetchAdminScopes() when
+     * isAuthenticated is false (lines 346-347 of AuthHelper.php).
+     */
+    public function testUnauthenticatedShortCircuitFailsClosed(): void
+    {
+        // Start from a clean singleton state.
+        AuthHelper::reset();
+
+        // Stash and clear any env vars that could trigger OIDC or legacy auth.
+        // Without ZITADEL_ISSUER/CLIENT_ID, getInstance() skips tryValidateOidcToken().
+        // Without JWT_SECRET (≥32 chars), tryValidateFromCookie() returns null immediately.
+        $envSaved = $this->stashAndClearEnv(['ZITADEL_ISSUER', 'ZITADEL_CLIENT_ID', 'JWT_SECRET']);
+
+        // Stash and clear any auth cookies (belt-and-suspenders: with JWT_SECRET absent
+        // tryValidateFromCookie() already short-circuits before reading $_COOKIE, but we
+        // clear cookies anyway to make the test self-contained).
+        $cookieSaved = [];
+        foreach (['litcal_access_token', 'litcal_id_token'] as $name) {
+            $cookieSaved[$name] = $_COOKIE[$name] ?? null;
+            unset($_COOKIE[$name]);
+        }
+
+        try {
+            $auth = AuthHelper::getInstance();
+
+            // Precondition: the instance must be unauthenticated.
+            self::assertFalse($auth->isAuthenticated, 'Precondition: instance must be unauthenticated');
+
+            // The unauthenticated short-circuit must fail closed.
+            self::assertFalse($auth->isResourceAdmin());
+            self::assertSame([], $auth->adminScopes());
+
+            // Memoization: a second call must return the cached result.
+            self::assertFalse($auth->isResourceAdmin(), 'Memoized second call must still return false');
+            self::assertSame([], $auth->adminScopes(), 'Memoized second call must still return []');
+        } finally {
+            $this->restoreEnv($envSaved);
+
+            foreach ($cookieSaved as $name => $val) {
+                if ($val !== null) {
+                    $_COOKIE[$name] = $val;
+                }
+            }
+
+            // Always reset the singleton so subsequent tests start clean.
+            AuthHelper::reset();
+        }
+    }
+
     public function testFetchAdminScopesParsesResourceAdminResponse(): void
     {
         $client = $this->clientWith(new Response(200, [], json_encode([


### PR DESCRIPTION
## What this delivers

This branch outgrew its original "Phase 1 harness" scope. It now bundles two related deliverables:

### 1. Frontend feature — scoped admin-review for resource-admins

Lets an OpenFGA resource-admin (an `admin` tuple on a resource, without the global Zitadel `admin` role) review the access-requests scoped to the resources they administer, through the existing admin UI, with a scoped notification badge. The API remains the sole authorization boundary; the frontend only widens who the UI admits.

- `src/AuthHelper.php` — `isResourceAdmin()` / `adminScopes()` (+ PHPUnit scaffolding), calling `GET /auth/admin-scopes`
- `assets/js/auth.js` — `Auth.isResourceAdmin()`
- `admin-permissions.php` — gate admits resource-admins; the raw FGA-tuple section stays global-admin-only
- `admin-dashboard.php` — "Access Requests to Review" card; `assets/js/notifications.js` — review-queue bell

The **API half is merged separately** (PR #656 → `development`): `ResourceAdminService`, `GET /auth/admin-scopes`, widened `GET /admin/notifications`.

### 2. RBAC access-request E2E suite (Playwright)

- **Phase 1 harness** (complete): scoped Zitadel users + OpenFGA tuples, headless OIDC login → per-user `storageState`, `actingAs` fixture, dashboard-scoping smoke spec. New projects `rbac-support`/`rbac-setup`/`rbac`, isolated from the default suite.
- **Phase 2** (in progress): foundation helpers — `grant.ts`, `requestAccess.ts`, `mailpit.ts`, `seedAndLogin`, cleanup extensions, and the `review.ts` admin-review driver — plus scenario `02` (full submit → scoped-visibility → reject → resubmit → approve lifecycle). Remaining 10 scenarios tracked in `docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-scenarios.md`.

## Notable: a production bug the E2E caught

`AuthHelper::isResourceAdmin()` makes a **server-side** frontend→API call. In Docker/containerized deploys `API_HOST=localhost` is the frontend container's own loopback, so the call failed and the feature silently fell closed. Fixed with an `API_INTERNAL_URL` fallback (mirrors `ZITADEL_INTERNAL_URL`), wired into `docker-compose.yml` + `.env.example`. **Containerized prod deploys must set `API_INTERNAL_URL`.**

## Harness design notes (reviewers)

- Scoped users authenticate via **Zitadel session API → OIDC PKCE → token exchange** (no ROPC); both access + id tokens are set as cookies (the id token carries `email_verified`, required by email-gated pages). Verification via the frontend `/auth/me.php`.
- Run against the **frontend** docker stack on the host; loads `.env.development` (`ZITADEL_ORG_ID`, `ZITADEL_MACHINE_TOKEN`, `MAILPIT_API_URL` — gitignored/local).
- Object_ids (matrix is source of truth): `national_calendar:IT`/`US`, `diocesan_calendar:romamo_it`, `wider_region:Europe`, `general_roman_calendar:temporale`.

## Status

Large PR (feature + test suite). Phase 2 scenarios 01, 03–11 remain (follow-up on this branch). API companion #656 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resource admins can now review access requests scoped to their administered resources.
  * Added "Access Requests to Review" dashboard section for resource admin users.

* **Tests**
  * Added comprehensive PHPUnit unit tests for admin-scope authentication functionality.
  * Added extensive Playwright E2E test harness and smoke tests for RBAC workflows.

* **Documentation**
  * Added detailed RBAC E2E test plan and design specifications.
  * Added scoped admin-review execution plan and design documentation.

* **Chores**
  * Updated .gitignore, composer.json, docker-compose, and .env.example configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->