### PR TITLE
fix(ci): reference correct PAT secret name WORKFLOW_AUTOMERGE_PAT

### DIFF
--- a/.github/pat-expiry.txt
+++ b/.github/pat-expiry.txt
@@ -1,5 +1,7 @@
-# Expiration date (YYYY-MM-DD) of the WORKFLOW_AUTO_MERGE_PAT org-level
-# secret. The .github/workflows/pat-expiry-reminder.yml workflow reads
+# Expiration date (YYYY-MM-DD) of the WORKFLOW_AUTO_MERGE_PAT fine-grained
+# PAT (stored as the org-level Actions secret WORKFLOW_AUTOMERGE_PAT — the
+# secret name workflows resolve differs from the PAT's display name).
+# The .github/workflows/pat-expiry-reminder.yml workflow reads
 # this date weekly and opens an issue when <30 days remain.
 #
 # When you rotate the PAT, update this date in the same PR / commit so

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,11 +23,12 @@ jobs:
       # that bump action versions, auto-merge therefore fails with
       # "Tried to create or update workflow without `workflows` permission".
       # Fall back through a fine-grained PAT (repo-scoped, Workflows: write)
-      # stored as WORKFLOW_AUTO_MERGE_PAT. When the secret is absent the
-      # workflow still works for non-workflow PRs.
+      # stored as the org Actions secret WORKFLOW_AUTOMERGE_PAT (the PAT itself
+      # is named WORKFLOW_AUTO_MERGE_PAT — Actions resolves the secret name).
+      # When the secret is absent the workflow still works for non-workflow PRs.
       - name: Auto-merge minor and patch updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,20 +29,22 @@ jobs:
       # status checks). Open a PR instead and let auto-merge land it once
       # CodeQL + Analyze (javascript) go green on the .pot-only diff.
       #
-      # The PR MUST be created with a PAT (WORKFLOW_AUTO_MERGE_PAT), not the
+      # The PR MUST be created with a PAT (the WORKFLOW_AUTO_MERGE_PAT token,
+      # stored as the org Actions secret WORKFLOW_AUTOMERGE_PAT), not the
       # default GITHUB_TOKEN: GitHub deliberately does not trigger `pull_request`
       # workflow runs for PRs opened by GITHUB_TOKEN (recursion guard), so the
       # required status checks would never start and auto-merge would wait
       # forever. A PAT-authored PR triggers the checks normally. Falls back to
       # GITHUB_TOKEN when the secret is absent (same pattern as
-      # dependabot-auto-merge.yml). NOTE: WORKFLOW_AUTO_MERGE_PAT is rotated
-      # periodically (see the rotation-reminder workflow).
+      # dependabot-auto-merge.yml). NOTE: the PAT is rotated periodically (see
+      # the rotation-reminder workflow); `secrets.WORKFLOW_AUTOMERGE_PAT` is the
+      # secret name Actions resolves — it differs from the PAT's display name.
       - name: Open PR with regenerated POT
         if: ${{ steps.update_pot.outputs.POT_LINES_CHANGED > 0 }}
         id: create_pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
           branch: chore/regenerate-pot
           delete-branch: true
           add-paths: i18n/litcal.pot
@@ -58,6 +60,6 @@ jobs:
       - name: Enable auto-merge
         if: steps.create_pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
         run: gh pr merge "$PR_NUMBER" --auto --merge

--- a/.github/workflows/pat-expiry-reminder.yml
+++ b/.github/workflows/pat-expiry-reminder.yml
@@ -83,7 +83,7 @@ jobs:
           # EXPIRY and DAYS_LEFT values are interpolated, both already
           # date-validated above.
           BODY=$(cat <<EOF
-          The fine-grained PAT \`WORKFLOW_AUTO_MERGE_PAT\` (org-level secret) expires on **$EXPIRY** — $DAYS_LEFT day(s) from now.
+          The fine-grained PAT \`WORKFLOW_AUTO_MERGE_PAT\` (stored as the org-level Actions secret \`WORKFLOW_AUTOMERGE_PAT\`) expires on **$EXPIRY** — $DAYS_LEFT day(s) from now.
 
           Without this PAT the Dependabot auto-merge workflow will silently fail to merge any PR that touches \`.github/workflows/*\` (e.g. action-version bumps), since GITHUB_TOKEN cannot modify workflow files.
 
@@ -97,7 +97,7 @@ jobs:
                - **Pull requests**: Read and write
                - **Workflows**: Read and write
              - Pick a new expiry (max 1 year)
-          2. Replace the secret value at <https://github.com/organizations/Liturgical-Calendar/settings/secrets/actions/WORKFLOW_AUTO_MERGE_PAT>
+          2. Replace the secret value at <https://github.com/organizations/Liturgical-Calendar/settings/secrets/actions/WORKFLOW_AUTOMERGE_PAT>
           3. Update \`.github/pat-expiry.txt\` with the new expiration date and commit
           4. This issue will auto-close on the next workflow run after step 3 lands
 


### PR DESCRIPTION
## Problem

POT-regen auto-merge PRs (e.g. #346) get stuck `BLOCKED` forever. The "Update POTs"
workflow opens its PR with a PAT specifically so the required CodeQL check triggers
(`GITHUB_TOKEN`-authored PRs don't fire `pull_request` runs — recursion guard), but the
token reference was wrong:

- Workflows reference `secrets.WORKFLOW_AUTO_MERGE_PAT`
- The org Actions **secret** is actually named `WORKFLOW_AUTOMERGE_PAT` (the underscored
  `WORKFLOW_AUTO_MERGE_PAT` is the **PAT's display name**, not the secret)

The mismatch resolved to empty, so the `|| secrets.GITHUB_TOKEN` fallback silently took
over → the PR was opened by `GITHUB_TOKEN` → CodeQL stayed `action_required` → the required
`CodeQL` context never posted → auto-merge blocked indefinitely. The same latent typo also
affected `dependabot-auto-merge.yml` (workflow-file bumps) and made the rotation-reminder
settings URL a 404.

## Fix

Point every `secrets.*` reference and the rotation settings URL at the real secret
`WORKFLOW_AUTOMERGE_PAT`, and clarify PAT-vs-secret naming in the surrounding comments and
`pat-expiry.txt`:

- `.github/workflows/main.yml` — both token references + comment
- `.github/workflows/dependabot-auto-merge.yml` — token reference + comment
- `.github/workflows/pat-expiry-reminder.yml` — issue body + settings URL
- `.github/pat-expiry.txt` — header comment

No functional/logic change beyond resolving the correct secret. Once merged, the next POT
regeneration opens its PR under the real PAT, CodeQL triggers, and auto-merge lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)