### PR TITLE
chore(i18n): regenerate i18n/litcal.pot

### DIFF
--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-21 11:05+0000\n"
+"POT-Creation-Date: 2026-06-21 15:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1253,43 +1253,31 @@ msgstr ""
 msgid "Just now"
 msgstr ""
 
-#: layout/footer.php:96
-msgid "min ago"
-msgstr ""
-
-#: layout/footer.php:97
-msgid "hours ago"
-msgstr ""
-
-#: layout/footer.php:98
-msgid "days ago"
-msgstr ""
-
-#: layout/footer.php:99 admin-permissions.php:415 admin-role-requests.php:252
+#: layout/footer.php:96 admin-permissions.php:415 admin-role-requests.php:252
 msgid "Requested"
 msgstr ""
 
-#: layout/footer.php:100
+#: layout/footer.php:97
 msgid "Requested access"
 msgstr ""
 
-#: layout/footer.php:101
+#: layout/footer.php:98
 msgid "Your request was approved"
 msgstr ""
 
-#: layout/footer.php:102
+#: layout/footer.php:99
 msgid "Your request was rejected"
 msgstr ""
 
-#: layout/footer.php:103
+#: layout/footer.php:100
 msgid "Your access was revoked"
 msgstr ""
 
-#: layout/footer.php:104
+#: layout/footer.php:101
 msgid "Request access to start using the system"
 msgstr ""
 
-#: layout/footer.php:105
+#: layout/footer.php:102
 msgid "Get started"
 msgstr ""
 


### PR DESCRIPTION
Automated regeneration of `i18n/litcal.pot` from the project source files.

Generated by the [Update POTs workflow](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/actions/runs/27909241280).