### PR TITLE
feat(rbac): calendar-scoped test types in the permission-request UI

### DIFF
--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -74,13 +74,13 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                     <label for="filterObjectType" class="form-label"><?php echo htmlspecialchars($objectTypeLabel, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
                     <select class="form-select form-select-sm" id="filterObjectType">
                         <option value=""><?php echo htmlspecialchars(_('All'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="general_roman_calendar_test"><?php echo htmlspecialchars(_('General Roman Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="national_calendar"><?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="diocesan_calendar"><?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="wider_region"><?php echo htmlspecialchars(_('Wider Region'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="national_calendar_test"><?php echo htmlspecialchars(_('National Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="diocesan_calendar_test"><?php echo htmlspecialchars(_('Diocesan Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                        <option value="general_roman_calendar_test"><?php echo htmlspecialchars(_('General Roman Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                        <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                     </select>
                 </div>
                 <div class="col-md-3">
@@ -94,7 +94,7 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                     <label for="filterRelation" class="form-label"><?php echo htmlspecialchars($relationLabel, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
                     <select class="form-select form-select-sm" id="filterRelation">
                         <option value=""><?php echo htmlspecialchars(_('All'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                        <option value="admin"><?php echo htmlspecialchars(_('Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="admin"><?php echo htmlspecialchars(pgettext('permission relation', 'Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="viewer"><?php echo htmlspecialchars(_('Viewer'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="editor"><?php echo htmlspecialchars(_('Editor'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="deleter"><?php echo htmlspecialchars(_('Deleter'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
@@ -290,7 +290,7 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                         <label for="grantRelation" class="form-label"><?php echo htmlspecialchars(_('Relation'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
                         <select class="form-select" id="grantRelation" required>
                             <option value=""><?php echo htmlspecialchars(_('Select relation...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="admin"><?php echo htmlspecialchars(_('Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="admin"><?php echo htmlspecialchars(pgettext('permission relation', 'Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="viewer"><?php echo htmlspecialchars(_('Viewer'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="editor"><?php echo htmlspecialchars(_('Editor'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="deleter"><?php echo htmlspecialchars(_('Deleter'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
@@ -300,13 +300,13 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                         <label for="grantObjectType" class="form-label"><?php echo htmlspecialchars(_('Calendar scope'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
                         <select class="form-select" id="grantObjectType" required>
                             <option value=""><?php echo htmlspecialchars(_('Select calendar scope...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="general_roman_calendar_test"><?php echo htmlspecialchars(_('General Roman Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="national_calendar"><?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="diocesan_calendar"><?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="wider_region"><?php echo htmlspecialchars(_('Wider Region'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="national_calendar_test"><?php echo htmlspecialchars(_('National Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="diocesan_calendar_test"><?php echo htmlspecialchars(_('Diocesan Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="general_roman_calendar_test"><?php echo htmlspecialchars(_('General Roman Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         </select>
                     </div>
                     <div class="mb-3">
@@ -401,7 +401,7 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                 testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests')); ?>,
                 testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests')); ?>,
                 // Relation display names
-                admin: <?php echo json_encode(_('Admin')); ?>,
+                admin: <?php echo json_encode(pgettext('permission relation', 'Admin')); ?>,
                 viewer: <?php echo json_encode(_('Viewer')); ?>,
                 editor: <?php echo json_encode(_('Editor')); ?>,
                 deleter: <?php echo json_encode(_('Deleter')); ?>,

--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -77,7 +77,9 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                         <option value="national_calendar"><?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="diocesan_calendar"><?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="wider_region"><?php echo htmlspecialchars(_('Wider Region'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                        <option value="test_definition"><?php echo htmlspecialchars(_('Test Definition'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="national_calendar_test"><?php echo htmlspecialchars(_('National Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="diocesan_calendar_test"><?php echo htmlspecialchars(_('Diocesan Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="general_roman_calendar_test"><?php echo htmlspecialchars(_('General Roman Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                     </select>
                 </div>
@@ -285,22 +287,6 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                             placeholder="<?php echo htmlspecialchars(_('Enter user ID...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
                     </div>
                     <div class="mb-3">
-                        <label for="grantObjectType" class="form-label"><?php echo htmlspecialchars(_('Object Type'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
-                        <select class="form-select" id="grantObjectType" required>
-                            <option value=""><?php echo htmlspecialchars(_('Select object type...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="national_calendar"><?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="diocesan_calendar"><?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="wider_region"><?php echo htmlspecialchars(_('Wider Region'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="test_definition"><?php echo htmlspecialchars(_('Test Definition'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label for="grantObjectId" class="form-label"><?php echo htmlspecialchars(_('Object ID'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
-                        <input type="text" class="form-control" id="grantObjectId" required
-                            placeholder="<?php echo htmlspecialchars(_('Enter object ID...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
-                    </div>
-                    <div class="mb-3">
                         <label for="grantRelation" class="form-label"><?php echo htmlspecialchars(_('Relation'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
                         <select class="form-select" id="grantRelation" required>
                             <option value=""><?php echo htmlspecialchars(_('Select relation...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
@@ -309,6 +295,27 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                             <option value="editor"><?php echo htmlspecialchars(_('Editor'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="deleter"><?php echo htmlspecialchars(_('Deleter'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="grantObjectType" class="form-label"><?php echo htmlspecialchars(_('Calendar scope'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
+                        <select class="form-select" id="grantObjectType" required>
+                            <option value=""><?php echo htmlspecialchars(_('Select calendar scope...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="national_calendar"><?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="diocesan_calendar"><?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="wider_region"><?php echo htmlspecialchars(_('Wider Region'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="national_calendar_test"><?php echo htmlspecialchars(_('National Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="diocesan_calendar_test"><?php echo htmlspecialchars(_('Diocesan Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="general_roman_calendar_test"><?php echo htmlspecialchars(_('General Roman Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="grantObjectId" class="form-label"><?php echo htmlspecialchars(_('Calendar ID'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
+                        <div id="grantObjectIdMount">
+                            <select class="form-select" id="grantObjectId" required>
+                                <option value="" disabled selected><?php echo htmlspecialchars(_('Select calendar ID...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            </select>
+                        </div>
                     </div>
                     <div id="grantModalAlerts"></div>
                 </div>
@@ -387,6 +394,12 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                 grcDecrees: <?php echo json_encode(_('Decrees of the Dicastery for Divine Worship')); ?>,
                 enterObjectId: <?php echo json_encode(_('Enter object ID...')); ?>,
                 selectObjectId: <?php echo json_encode(_('Select object ID...')); ?>,
+                calendarScope: <?php echo json_encode(_('Calendar scope')); ?>,
+                calendarId: <?php echo json_encode(_('Calendar ID')); ?>,
+                selectCalendarId: <?php echo json_encode(_('Select calendar ID...')); ?>,
+                testsNational: <?php echo json_encode(_('National Calendar Tests')); ?>,
+                testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests')); ?>,
+                testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests')); ?>,
                 // Relation display names
                 admin: <?php echo json_encode(_('Admin')); ?>,
                 viewer: <?php echo json_encode(_('Viewer')); ?>,
@@ -411,6 +424,12 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                     permissions: <?php echo json_encode(_('Permissions')); ?>,
                     objectType: <?php echo json_encode(_('Object Type')); ?>,
                     objectId: <?php echo json_encode(_('Object ID')); ?>,
+                    calendarScope: <?php echo json_encode(_('Calendar scope')); ?>,
+                    calendarId: <?php echo json_encode(_('Calendar ID')); ?>,
+                    selectCalendarId: <?php echo json_encode(_('Select calendar ID...')); ?>,
+                    testsNational: <?php echo json_encode(_('National Calendar Tests')); ?>,
+                    testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests')); ?>,
+                    testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests')); ?>,
                     relation: <?php echo json_encode(_('Relation')); ?>,
                     justification: <?php echo json_encode(_('Justification')); ?>,
                     credentials: <?php echo json_encode(_('Credentials')); ?>,

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -5,6 +5,20 @@
  * Provides functionality for listing, granting, and revoking permissions.
  */
 
+import {
+    ApiClient,
+    CalendarSelect,
+    CalendarSelectFilter,
+} from '@liturgical-calendar/components-js';
+
+// Initialize the API client once; CalendarSelect requires this to have resolved.
+const apiClientReady = ApiClient.init(BaseUrl)
+    .then(function(client) { return client instanceof ApiClient ? client : false; })
+    .catch(function(err) {
+        console.error('Failed to initialize ApiClient for permission fields:', err);
+        return false;
+    });
+
 document.addEventListener('DOMContentLoaded', function() {
     const config = window.AdminPermissionsConfig;
     if (!config) {
@@ -50,40 +64,81 @@ document.addEventListener('DOMContentLoaded', function() {
         { id: 'decrees',            label: config.i18n.grcDecrees }
     ];
 
-    // Swap the free-text Object ID input for a <select> when GRC is selected, and back otherwise.
-    function syncObjectIdField(objectType) {
-        const current = document.getElementById('grantObjectId');
-        if (objectType === 'general_roman_calendar') {
-            if (current.tagName === 'SELECT') {
-                return;
-            }
-            const select = document.createElement('select');
-            select.className = 'form-select';
-            select.id = 'grantObjectId';
-            select.required = true;
-            // Empty placeholder forces an explicit choice instead of silently defaulting to the
-            // first id (temporale); consistent with the object-type and relation selects.
-            const placeholder = document.createElement('option');
-            placeholder.value = '';
-            placeholder.textContent = config.i18n.selectObjectId || 'Select object ID...';
-            placeholder.disabled = true;
-            placeholder.selected = true;
-            select.appendChild(placeholder);
-            for (const opt of GRC_OBJECT_IDS) {
-                const o = document.createElement('option');
-                o.value = opt.id;
-                o.textContent = opt.label;
-                select.appendChild(o);
-            }
-            current.replaceWith(select);
-        } else if (current.tagName === 'SELECT') {
-            const input = document.createElement('input');
-            input.type = 'text';
-            input.className = 'form-control';
-            input.id = 'grantObjectId';
-            input.required = true;
-            input.placeholder = config.i18n.enterObjectId || '';
-            current.replaceWith(input);
+    // The five wider-region names (object_id for the wider_region scope).
+    // Keep in sync with the API; these are not localized (proper nouns).
+    const WIDER_REGIONS = ['Americas', 'Europe', 'Asia', 'Africa', 'Oceania'];
+
+    const NATIONAL_FILTER_TYPES = ['national_calendar', 'national_calendar_test'];
+    const DIOCESAN_FILTER_TYPES = ['diocesan_calendar', 'diocesan_calendar_test'];
+
+    /**
+     * Build a native <select class="form-select" id="grantObjectId"> for the three
+     * non-calendar scopes (wider_region / GRC / GRC test).
+     * @param {string} objectType - The currently selected object type
+     * @returns {HTMLSelectElement} The built select element
+     */
+    function buildStaticGrantObjectId(objectType) {
+        const select = document.createElement('select');
+        select.className = 'form-select';
+        select.id = 'grantObjectId';
+        select.required = true;
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        select.appendChild(placeholder);
+
+        let entries = [];
+        if (objectType === 'wider_region') {
+            entries = WIDER_REGIONS.map(function(name) { return { value: name, label: name }; });
+        } else if (objectType === 'general_roman_calendar') {
+            entries = GRC_OBJECT_IDS.map(function(o) { return { value: o.id, label: o.label }; });
+        } else if (objectType === 'general_roman_calendar_test') {
+            entries = [
+                { value: 'general_roman_calendar', label: config.i18n.testsGeneralRoman }
+            ];
+        }
+        for (const e of entries) {
+            const o = document.createElement('option');
+            o.value = e.value;
+            o.textContent = e.label;
+            select.appendChild(o);
+        }
+        // Auto-select the single fixed GRC-test id.
+        if (objectType === 'general_roman_calendar_test') {
+            select.value = 'general_roman_calendar';
+        }
+        return select;
+    }
+
+    /**
+     * Swap the contents of #grantObjectIdMount.
+     * Calendar-backed scopes mount a CalendarSelect; the rest use a native select.
+     * @param {string} objectType - The currently selected object type
+     */
+    async function syncObjectIdField(objectType) {
+        const mount = document.getElementById('grantObjectIdMount');
+        if (!mount) return;
+        mount.innerHTML = '';
+        if (
+            NATIONAL_FILTER_TYPES.includes(objectType) ||
+            DIOCESAN_FILTER_TYPES.includes(objectType)
+        ) {
+            const client = await apiClientReady;
+            if (!client) return;
+            if (grantObjectType.value !== objectType) return; // scope changed again meanwhile
+            const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+                ? CalendarSelectFilter.NATIONAL_CALENDARS
+                : CalendarSelectFilter.DIOCESAN_CALENDARS;
+            const calSelect = new CalendarSelect(LITCAL_LOCALE)
+                .filter(filter)
+                .allowNull(true)
+                .class('form-select')
+                .id('grantObjectId');
+            calSelect.appendTo(mount);
+        } else {
+            mount.appendChild(buildStaticGrantObjectId(objectType));
         }
     }
 
@@ -107,8 +162,10 @@ document.addEventListener('DOMContentLoaded', function() {
         'national_calendar': config.i18n.nationalCalendar,
         'diocesan_calendar': config.i18n.diocesanCalendar,
         'wider_region': config.i18n.widerRegion,
-        'test_definition': config.i18n.testDefinition,
-        'general_roman_calendar': config.i18n.generalRomanCalendar
+        'general_roman_calendar': config.i18n.generalRomanCalendar,
+        'national_calendar_test': config.i18n.testsNational,
+        'diocesan_calendar_test': config.i18n.testsDiocesan,
+        'general_roman_calendar_test': config.i18n.testsGeneralRoman
     };
 
     // Relation display names and badge classes

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -380,7 +380,8 @@ document.addEventListener('DOMContentLoaded', function() {
     async function handleGrant() {
         const user = grantUser.value.trim();
         const objectType = grantObjectType.value;
-        const objectId = document.getElementById('grantObjectId').value.trim();
+        const objectIdEl = document.getElementById('grantObjectId');
+        const objectId = objectIdEl ? objectIdEl.value.trim() : '';
         const relation = grantRelation.value;
 
         if (!user || !objectType || !objectId || !relation) {

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -137,6 +137,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 .class('form-select')
                 .id('grantObjectId');
             calSelect.appendTo(mount);
+            // CalendarSelect's allowNull adds an empty option that semantically
+            // means "no nation/diocese" = General Roman Calendar, which is not a
+            // valid national/diocesan object_id. Turn it into a disabled
+            // placeholder so the user must pick a concrete calendar.
+            const calNullOpt = mount.querySelector('#grantObjectId option[value=""]');
+            if (calNullOpt) {
+                calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+                calNullOpt.disabled = true;
+                calNullOpt.selected = true;
+            }
         } else {
             mount.appendChild(buildStaticGrantObjectId(objectType));
         }

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -111,26 +111,29 @@ document.addEventListener('DOMContentLoaded', async function() {
     const WIDER_REGIONS = ['Americas', 'Europe', 'Asia', 'Africa', 'Oceania'];
 
     // Object types allowed per role (mirror AccessRequestRepository::ROLE_OBJECT_TYPES)
+    // Membership mirrors AccessRequestRepository::ROLE_OBJECT_TYPES (the API
+    // validates the SET, not the order). Display order is deliberate: the
+    // General Roman Calendar scope(s) come first.
     const roleObjectTypes = {
         'calendar_editor': [
+            'general_roman_calendar',
             'national_calendar',
             'diocesan_calendar',
-            'wider_region',
-            'general_roman_calendar'
+            'wider_region'
         ],
         'test_editor': [
+            'general_roman_calendar_test',
             'national_calendar_test',
-            'diocesan_calendar_test',
-            'general_roman_calendar_test'
+            'diocesan_calendar_test'
         ],
         'developer': [
+            'general_roman_calendar',
+            'general_roman_calendar_test',
             'national_calendar',
             'diocesan_calendar',
             'wider_region',
             'national_calendar_test',
-            'diocesan_calendar_test',
-            'general_roman_calendar_test',
-            'general_roman_calendar'
+            'diocesan_calendar_test'
         ]
     };
 
@@ -222,6 +225,17 @@ document.addEventListener('DOMContentLoaded', async function() {
                 .allowNull(true)
                 .class('form-select form-select-sm perm-object-id');
             calSelect.appendTo(mount);
+            // CalendarSelect's allowNull adds an empty option that semantically
+            // means "no nation/diocese" = General Roman Calendar, which is not a
+            // valid national/diocesan object_id. Turn it into a disabled
+            // placeholder so the user must pick a concrete calendar (Vatican
+            // included — it has its own national-style calendar).
+            const calNullOpt = mount.querySelector('.perm-object-id option[value=""]');
+            if (calNullOpt) {
+                calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+                calNullOpt.disabled = true;
+                calNullOpt.selected = true;
+            }
         } else {
             mount.appendChild(buildStaticObjectIdSelect(objectType));
         }

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -317,7 +317,11 @@ document.addEventListener('DOMContentLoaded', async function() {
                     </div>
                     <div class="col-md-3">
                         <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.calendarId)}</label>
-                        <div class="perm-objid-mount"></div>
+                        <div class="perm-objid-mount">
+                            <select class="form-select form-select-sm perm-object-id" required>
+                                <option value="" disabled selected>${escapeHtml(config.i18n.selectCalendarId)}</option>
+                            </select>
+                        </div>
                     </div>
                     <div class="col-md-2">
                         <button type="button" class="btn btn-outline-danger btn-sm w-100 remove-perm-btn"

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -588,7 +588,7 @@ document.addEventListener('DOMContentLoaded', async function() {
      * with a single warning if the stored array exceeds the cap.
      * @param {Array|undefined} stored - Stored permissions from the request
      */
-    function populateRowsFromStoredPermissions(stored) {
+    async function populateRowsFromStoredPermissions(stored) {
         if (!Array.isArray(stored)) return;
         if (stored.length > MAX_PERMISSIONS) {
             const tmpl = config.i18n.permissionsTruncated
@@ -606,9 +606,9 @@ document.addEventListener('DOMContentLoaded', async function() {
             const typeSelect = row.querySelector('.perm-object-type');
             const relSelect = row.querySelector('.perm-relation');
             if (typeSelect) typeSelect.value = perm.object_type || '';
-            // Sync the object-id control BEFORE setting its value; for GRC the
-            // input is replaced with a <select>, so re-query after the swap.
-            syncRowObjectIdField(row, perm.object_type || '');
+            // Sync the object-id control (mounts a CalendarSelect for calendar
+            // scopes; await so the <select> exists before we set its value).
+            await syncRowObjectIdField(row, perm.object_type || '');
             const idField = row.querySelector('.perm-object-id');
             if (idField) idField.value = perm.object_id || '';
             if (relSelect) relSelect.value = perm.relation || '';
@@ -620,7 +620,7 @@ document.addEventListener('DOMContentLoaded', async function() {
      * @param {string} requestId - The request ID to resubmit
      * @param {Array} requests - All requests (to find the one to resubmit)
      */
-    function openResubmitForm(requestId, requests) {
+    async function openResubmitForm(requestId, requests) {
         const request = requests.find(function(r) { return String(r.id) === String(requestId); });
         if (!request) return;
 
@@ -632,7 +632,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         updatePermissionsSection();
         permissionRows.innerHTML = '';
         permissionRowCounter = 0;
-        populateRowsFromStoredPermissions(request.permissions);
+        await populateRowsFromStoredPermissions(request.permissions);
 
         // Pre-fill justification
         const justificationEl = document.getElementById('justification');

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -5,6 +5,20 @@
  * via the unified /auth/access-requests endpoint, and viewing existing request status.
  */
 
+import {
+    ApiClient,
+    CalendarSelect,
+    CalendarSelectFilter,
+} from '@liturgical-calendar/components-js';
+
+// Initialize the API client once; CalendarSelect requires this to have resolved.
+const apiClientReady = ApiClient.init(BaseUrl)
+    .then(function(client) { return client instanceof ApiClient ? client : false; })
+    .catch(function(err) {
+        console.error('Failed to initialize ApiClient for permission fields:', err);
+        return false;
+    });
+
 document.addEventListener('DOMContentLoaded', async function() {
     const config = window.AccessRequestsConfig;
     if (!config) {
@@ -45,13 +59,15 @@ document.addEventListener('DOMContentLoaded', async function() {
         'developer': config.i18n.developer
     };
 
-    // Object type display names
+    // Object type ("Calendar scope") display names
     const objectTypeNames = {
         'national_calendar': config.i18n.nationalCalendar,
         'diocesan_calendar': config.i18n.diocesanCalendar,
         'wider_region': config.i18n.widerRegion,
-        'test_definition': config.i18n.testDefinition,
-        'general_roman_calendar': config.i18n.generalRomanCalendar
+        'general_roman_calendar': config.i18n.generalRomanCalendar,
+        'national_calendar_test': config.i18n.testsNational,
+        'diocesan_calendar_test': config.i18n.testsDiocesan,
+        'general_roman_calendar_test': config.i18n.testsGeneralRoman
     };
 
     // Relation display names
@@ -90,11 +106,32 @@ document.addEventListener('DOMContentLoaded', async function() {
         { id: 'decrees',            label: config.i18n.grcDecrees }
     ];
 
-    // Object types allowed per role
+    // The five wider-region names (object_id for the wider_region scope).
+    // Keep in sync with the API; these are not localized (proper nouns).
+    const WIDER_REGIONS = ['Americas', 'Europe', 'Asia', 'Africa', 'Oceania'];
+
+    // Object types allowed per role (mirror AccessRequestRepository::ROLE_OBJECT_TYPES)
     const roleObjectTypes = {
-        'calendar_editor': ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'],
-        'test_editor': ['test_definition'],
-        'developer': ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition', 'general_roman_calendar']
+        'calendar_editor': [
+            'national_calendar',
+            'diocesan_calendar',
+            'wider_region',
+            'general_roman_calendar'
+        ],
+        'test_editor': [
+            'national_calendar_test',
+            'diocesan_calendar_test',
+            'general_roman_calendar_test'
+        ],
+        'developer': [
+            'national_calendar',
+            'diocesan_calendar',
+            'wider_region',
+            'national_calendar_test',
+            'diocesan_calendar_test',
+            'general_roman_calendar_test',
+            'general_roman_calendar'
+        ]
     };
 
     let permissionRowCounter = 0;
@@ -111,46 +148,82 @@ document.addEventListener('DOMContentLoaded', async function() {
         return div.innerHTML;
     }
 
+    const NATIONAL_FILTER_TYPES = ['national_calendar', 'national_calendar_test'];
+    const DIOCESAN_FILTER_TYPES = ['diocesan_calendar', 'diocesan_calendar_test'];
+
     /**
-     * Swap the free-text Object ID input for a <select> when GRC is selected,
-     * and restore the free-text input for any other object type.
-     * The element is looked up live from the row so that repeated calls
-     * after a previous swap work correctly (no stale cached reference).
+     * Build a native <select class="form-select form-select-sm perm-object-id">
+     * for the three non-calendar scopes (wider_region / GRC / GRC test).
+     * @param {string} objectType - The currently selected object type
+     * @returns {HTMLSelectElement} The built select element
+     */
+    function buildStaticObjectIdSelect(objectType) {
+        const select = document.createElement('select');
+        select.className = 'form-select form-select-sm perm-object-id';
+        select.required = true;
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        select.appendChild(placeholder);
+
+        let entries = [];
+        if (objectType === 'wider_region') {
+            entries = WIDER_REGIONS.map(function(name) { return { value: name, label: name }; });
+        } else if (objectType === 'general_roman_calendar') {
+            entries = GRC_OBJECT_IDS.map(function(o) { return { value: o.id, label: o.label }; });
+        } else if (objectType === 'general_roman_calendar_test') {
+            entries = [
+                { value: 'general_roman_calendar', label: config.i18n.testsGeneralRoman }
+            ];
+        }
+        for (const e of entries) {
+            const o = document.createElement('option');
+            o.value = e.value;
+            o.textContent = e.label;
+            select.appendChild(o);
+        }
+        // Auto-select the single fixed GRC-test id.
+        if (objectType === 'general_roman_calendar_test') {
+            select.value = 'general_roman_calendar';
+        }
+        return select;
+    }
+
+    /**
+     * Rebuild the Calendar ID control for a row based on the chosen scope.
+     * Calendar-backed scopes mount a CalendarSelect; the rest use a native select.
      * @param {HTMLElement} row - The permission row (.card element)
      * @param {string} objectType - The currently selected object type
      */
-    function syncRowObjectIdField(row, objectType) {
-        const current = row.querySelector('.perm-object-id');
-        if (!current) return;
-        if (objectType === 'general_roman_calendar') {
-            if (current.tagName === 'SELECT') {
-                return;
-            }
-            const select = document.createElement('select');
-            select.className = 'form-select form-select-sm perm-object-id';
-            select.required = true;
-            // Empty placeholder forces an explicit choice instead of silently defaulting to the
-            // first id (temporale); consistent with the object-type and relation selects.
-            const placeholder = document.createElement('option');
-            placeholder.value = '';
-            placeholder.textContent = config.i18n.selectObjectId || 'Select object ID...';
-            placeholder.disabled = true;
-            placeholder.selected = true;
-            select.appendChild(placeholder);
-            for (const opt of GRC_OBJECT_IDS) {
-                const o = document.createElement('option');
-                o.value = opt.id;
-                o.textContent = opt.label;
-                select.appendChild(o);
-            }
-            current.replaceWith(select);
-        } else if (current.tagName === 'SELECT') {
-            const input = document.createElement('input');
-            input.type = 'text';
-            input.className = 'form-control form-control-sm perm-object-id';
-            input.required = true;
-            input.placeholder = config.i18n.objectIdPlaceholder || '';
-            current.replaceWith(input);
+    async function syncRowObjectIdField(row, objectType) {
+        const mount = row.querySelector('.perm-objid-mount');
+        if (!mount) return;
+        mount.innerHTML = '';
+
+        if (
+            NATIONAL_FILTER_TYPES.includes(objectType) ||
+            DIOCESAN_FILTER_TYPES.includes(objectType)
+        ) {
+            const client = await apiClientReady;
+            if (!client) return; // init failed; leave empty (validation will block submit)
+            // Guard against a rapid scope change that already replaced the mount.
+            if (
+                !row.isConnected ||
+                row.querySelector('.perm-object-type').value !== objectType
+            ) return;
+            const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+                ? CalendarSelectFilter.NATIONAL_CALENDARS
+                : CalendarSelectFilter.DIOCESAN_CALENDARS;
+            const calSelect = new CalendarSelect(LITCAL_LOCALE)
+                .filter(filter)
+                .allowNull(true)
+                .class('form-select form-select-sm perm-object-id');
+            calSelect.appendTo(mount);
+        } else {
+            mount.appendChild(buildStaticObjectIdSelect(objectType));
         }
     }
 
@@ -194,7 +267,7 @@ document.addEventListener('DOMContentLoaded', async function() {
      */
     function buildObjectTypeOptions() {
         const allowed = getAllowedObjectTypes();
-        let html = '<option value="">' + escapeHtml(config.i18n.selectObjectType) + '</option>';
+        let html = '<option value="">' + escapeHtml(config.i18n.selectCalendarScope) + '</option>';
         for (const type of allowed) {
             html += '<option value="' + escapeHtml(type) + '">' + escapeHtml(objectTypeNames[type] || type) + '</option>';
         }
@@ -226,17 +299,6 @@ document.addEventListener('DOMContentLoaded', async function() {
         row.innerHTML = `
             <div class="card-body py-2 px-3">
                 <div class="row g-2 align-items-end">
-                    <div class="col-md-4">
-                        <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.objectType)}</label>
-                        <select class="form-select form-select-sm perm-object-type" required>
-                            ${buildObjectTypeOptions()}
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.objectId)}</label>
-                        <input type="text" class="form-control form-control-sm perm-object-id" required
-                            placeholder="${escapeHtml(config.i18n.objectIdPlaceholder)}">
-                    </div>
                     <div class="col-md-3">
                         <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.relation)}</label>
                         <select class="form-select form-select-sm perm-relation" required>
@@ -246,6 +308,16 @@ document.addEventListener('DOMContentLoaded', async function() {
                             <option value="editor">${escapeHtml(config.i18n.editor)}</option>
                             <option value="deleter">${escapeHtml(config.i18n.deleter)}</option>
                         </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.calendarScope)}</label>
+                        <select class="form-select form-select-sm perm-object-type" required>
+                            ${buildObjectTypeOptions()}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.calendarId)}</label>
+                        <div class="perm-objid-mount"></div>
                     </div>
                     <div class="col-md-2">
                         <button type="button" class="btn btn-outline-danger btn-sm w-100 remove-perm-btn"
@@ -322,7 +394,8 @@ document.addEventListener('DOMContentLoaded', async function() {
 
         for (const row of rows) {
             const objectType = row.querySelector('.perm-object-type').value;
-            const objectId = row.querySelector('.perm-object-id').value.trim();
+            const objectIdEl = row.querySelector('.perm-object-id');
+            const objectId = objectIdEl ? objectIdEl.value.trim() : '';
             const relation = row.querySelector('.perm-relation').value;
 
             if (!objectType || !objectId || !relation) {

--- a/docs/superpowers/plans/2026-06-25-permission-request-ui-calendar-scoped.md
+++ b/docs/superpowers/plans/2026-06-25-permission-request-ui-calendar-scoped.md
@@ -1,0 +1,764 @@
+# Permission-Request UI — Calendar-Scoped Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the fine-grained permission UI (`permission-requests.php` and
+`admin-permissions.php`) so each permission row is Relation-first with a
+"Calendar ID" control that is a real picker, and so it offers the three new
+calendar-scoped test object types (`national_calendar_test`,
+`diocesan_calendar_test`, `general_roman_calendar_test`) instead of the removed
+flat `test_definition`.
+
+**Architecture:** Hybrid Calendar ID control. For calendar-backed scopes
+(`national_calendar`, `diocesan_calendar`, and their `_test` twins) the UI
+mounts a `CalendarSelect` instance from the already-loaded
+`@liturgical-calendar/components-js` package (cached, localized country/diocese
+names, diocese grouping handled for us). For the three non-calendar scopes
+(`wider_region`, `general_roman_calendar`, `general_roman_calendar_test`) the UI
+builds a small native `<select>` from static lists. Both kinds of control render
+a `<select class="… perm-object-id">` (or `#grantObjectId`), so existing
+value-reading and e2e selectors keep working. The package is initialized once
+per page via `ApiClient.init(BaseUrl)`.
+
+**Tech Stack:** Vanilla ES modules (page scripts already load as
+`type="module"`; importmap already emitted),
+`@liturgical-calendar/components-js` (`ApiClient`, `CalendarSelect`,
+`CalendarSelectFilter`), Bootstrap 5 markup, PHP gettext (`_()`) strings
+pre-rendered into per-page `window.*Config.i18n` JSON, Playwright e2e + manual
+Chrome for verification, ESLint + `tsc` (e2e) + `composer lint`/`parallel-lint`
+gates.
+
+## Global Constraints
+
+- **No build step / no bundler.** Page scripts load as `type="module"`
+  (`layout/footer.php:166-173`); the importmap mapping
+  `@liturgical-calendar/components-js` is already emitted for every page except
+  `examples` (`layout/footer.php:134`). No `footer.php` change is required.
+- **Package init:** `CalendarSelect` throws unless `ApiClient.init(BaseUrl)` has
+  resolved first (`ApiClient._metadata` must be populated). Initialize once at
+  module load and gate Calendar ID construction on that promise. `BaseUrl` and
+  `LITCAL_LOCALE` / `currentLocale` are existing globals.
+- **Object-type sets must mirror the API verbatim**
+  (`AccessRequestRepository::ROLE_OBJECT_TYPES`, post-merge of API PR #666):
+  - `calendar_editor`: `national_calendar`, `diocesan_calendar`, `wider_region`,
+    `general_roman_calendar`
+  - `test_editor`: `national_calendar_test`, `diocesan_calendar_test`,
+    `general_roman_calendar_test`
+  - `developer`: `national_calendar`, `diocesan_calendar`, `wider_region`,
+    `national_calendar_test`, `diocesan_calendar_test`,
+    `general_roman_calendar_test`, `general_roman_calendar`
+- **Scope → Calendar ID source:**
+  - `national_calendar`, `national_calendar_test` →
+    `CalendarSelect().filter(CalendarSelectFilter.NATIONAL_CALENDARS)` (option
+    value = nation code, e.g. `IT`)
+  - `diocesan_calendar`, `diocesan_calendar_test` →
+    `CalendarSelect().filter(CalendarSelectFilter.DIOCESAN_CALENDARS)` (option
+    value = diocese calendar_id, grouped by nation)
+  - `wider_region` → static `['Americas','Europe','Asia','Africa','Oceania']`
+    (value = label = name)
+  - `general_roman_calendar` → static `GRC_OBJECT_IDS` (`temporale`,
+    `EDITIO_TYPICA_1970`, `EDITIO_TYPICA_2002`, `EDITIO_TYPICA_2008`, `decrees`)
+  - `general_roman_calendar_test` → single fixed option value
+    `general_roman_calendar` (auto-selected)
+- **`GRC_OBJECT_IDS` keys** must stay in sync with API
+  `AccessRequestRepository::GRC_OBJECT_IDS`. They remain duplicated in
+  `permission-requests.js` and `admin-permissions.js` (existing convention, with
+  a sync comment). `WIDER_REGIONS` is likewise a small inline constant in both.
+- **Every Calendar ID control renders an element with class `perm-object-id`**
+  (request rows) or **id `grantObjectId`** (admin grant modal) so
+  `collectPermissions()` / grant submit read `.value` unchanged.
+- **Import specifier:** `@liturgical-calendar/components-js` (exports include
+  `ApiClient`, `CalendarSelect`, `CalendarSelectFilter` — confirmed in
+  `dist/index.js`).
+- **Field order:** Relation → Calendar scope → Calendar ID. **Labels:** "Object
+  Type" → **"Calendar scope"**, "Object ID" → **"Calendar ID"** (gettext source
+  strings).
+- **Translations are owned by Weblate**, not hand-edited `.po` files. Add `_()`
+  source strings + regenerate `i18n/litcal.pot`; untranslated msgids fall back
+  to English at runtime.
+- **Pre-commit hooks must pass** (never `--no-verify`). Do not push until the
+  user asks.
+
+---
+
+### Task 1: `permission-requests.php` — relabel + new i18n keys
+
+**Files:**
+
+- Modify: `permission-requests.php` (inline `window.AccessRequestsConfig.i18n`
+  block, ~lines 226-256)
+
+**Interfaces:**
+
+- Produces i18n keys consumed by Task 2: `calendarScope`, `calendarId`,
+  `selectCalendarScope`, `selectCalendarId`, `testsNational`, `testsDiocesan`,
+  `testsGeneralRoman`.
+
+- [ ] **Step 1: Add the relabeled + new i18n strings**
+
+In `permission-requests.php`, inside the `i18n: { ... }` object, add these keys
+(keep the existing `objectType`/`objectId`/`selectObjectId` keys — the
+existing-requests table renderer still uses `objectType`/`objectId` until Task 2
+migrates the row labels; `selectObjectId` is superseded by `selectCalendarId`):
+
+```php
+        calendarScope: <?php echo json_encode(_('Calendar scope'), $jsonFlags); ?>,
+        calendarId: <?php echo json_encode(_('Calendar ID'), $jsonFlags); ?>,
+        selectCalendarScope: <?php echo json_encode(_('Select calendar scope...'), $jsonFlags); ?>,
+        selectCalendarId: <?php echo json_encode(_('Select calendar ID...'), $jsonFlags); ?>,
+        testsNational: <?php echo json_encode(_('National Calendar Tests'), $jsonFlags); ?>,
+        testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests'), $jsonFlags); ?>,
+        testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests'), $jsonFlags); ?>,
+```
+
+- [ ] **Step 2: PHP syntax + lint**
+
+Run: `composer parallel-lint && composer lint` Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add permission-requests.php
+git commit -m "feat(permissions): add Calendar scope/ID + scoped-test i18n strings"
+```
+
+---
+
+### Task 2: `permission-requests.js` — package import, scoped types, hybrid Calendar ID, reorder
+
+**Files:**
+
+- Modify: `assets/js/permission-requests.js` (top-of-file import; const maps
+  ~lines 49-98; `syncRowObjectIdField` ~lines 114-155; `addPermissionRow` ~lines
+  212-275; `collectPermissions` ~lines 316-340; existing-requests renderer
+  `objectTypeNames` ~line 353)
+
+**Interfaces:**
+
+- Consumes from package: `ApiClient`, `CalendarSelect`, `CalendarSelectFilter`.
+- Consumes from Task 1: the new `config.i18n` keys.
+
+- [ ] **Step 1: Add the package import and ApiClient init gate**
+
+At the very top of the file (module top-level, before the existing IIFE), add:
+
+```js
+import {
+  ApiClient,
+  CalendarSelect,
+  CalendarSelectFilter,
+} from "@liturgical-calendar/components-js";
+
+// Initialize the API client once; CalendarSelect requires this to have resolved.
+const apiClientReady = ApiClient.init(BaseUrl)
+  .then((client) => (client instanceof ApiClient ? client : false))
+  .catch((err) => {
+    console.error("Failed to initialize ApiClient for permission fields:", err);
+    return false;
+  });
+```
+
+- [ ] **Step 2: Replace `objectTypeNames` and `roleObjectTypes` with the scoped
+      types; add `WIDER_REGIONS`**
+
+Replace the `objectTypeNames` block (lines 49-55) with:
+
+```js
+// Object type ("Calendar scope") display names
+const objectTypeNames = {
+  national_calendar: config.i18n.nationalCalendar,
+  diocesan_calendar: config.i18n.diocesanCalendar,
+  wider_region: config.i18n.widerRegion,
+  general_roman_calendar: config.i18n.generalRomanCalendar,
+  national_calendar_test: config.i18n.testsNational,
+  diocesan_calendar_test: config.i18n.testsDiocesan,
+  general_roman_calendar_test: config.i18n.testsGeneralRoman,
+};
+```
+
+Replace `roleObjectTypes` (lines 94-98) with the API-mirrored sets:
+
+```js
+// Object types allowed per role (mirror AccessRequestRepository::ROLE_OBJECT_TYPES)
+const roleObjectTypes = {
+  calendar_editor: [
+    "national_calendar",
+    "diocesan_calendar",
+    "wider_region",
+    "general_roman_calendar",
+  ],
+  test_editor: [
+    "national_calendar_test",
+    "diocesan_calendar_test",
+    "general_roman_calendar_test",
+  ],
+  developer: [
+    "national_calendar",
+    "diocesan_calendar",
+    "wider_region",
+    "national_calendar_test",
+    "diocesan_calendar_test",
+    "general_roman_calendar_test",
+    "general_roman_calendar",
+  ],
+};
+```
+
+Immediately after the existing `GRC_OBJECT_IDS` array (lines 85-91, keep it),
+add the wider-region constant:
+
+```js
+// The five wider-region names (object_id for the wider_region scope).
+// Keep in sync with the API; these are not localized (proper nouns).
+const WIDER_REGIONS = ["Americas", "Europe", "Asia", "Africa", "Oceania"];
+```
+
+- [ ] **Step 3: Replace `syncRowObjectIdField` with the hybrid builder**
+
+Replace the whole `syncRowObjectIdField(row, objectType)` function (lines
+~122-155) with the version below. Calendar scopes mount a `CalendarSelect`; the
+three static scopes build a native `<select>`. Both end with an element carrying
+class `perm-object-id` inside the row's `.perm-objid-mount` cell.
+
+```js
+const NATIONAL_FILTER_TYPES = ["national_calendar", "national_calendar_test"];
+const DIOCESAN_FILTER_TYPES = ["diocesan_calendar", "diocesan_calendar_test"];
+
+/**
+ * Build a native <select class="form-select form-select-sm perm-object-id">
+ * for the three non-calendar scopes (wider_region / GRC / GRC test).
+ */
+function buildStaticObjectIdSelect(objectType) {
+  const select = document.createElement("select");
+  select.className = "form-select form-select-sm perm-object-id";
+  select.required = true;
+
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.textContent =
+    config.i18n.selectCalendarId || "Select calendar ID...";
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  select.appendChild(placeholder);
+
+  let entries = [];
+  if (objectType === "wider_region") {
+    entries = WIDER_REGIONS.map((name) => ({ value: name, label: name }));
+  } else if (objectType === "general_roman_calendar") {
+    entries = GRC_OBJECT_IDS.map((o) => ({ value: o.id, label: o.label }));
+  } else if (objectType === "general_roman_calendar_test") {
+    entries = [
+      { value: "general_roman_calendar", label: config.i18n.testsGeneralRoman },
+    ];
+  }
+  for (const e of entries) {
+    const o = document.createElement("option");
+    o.value = e.value;
+    o.textContent = e.label;
+    select.appendChild(o);
+  }
+  // Auto-select the single fixed GRC-test id.
+  if (objectType === "general_roman_calendar_test") {
+    select.value = "general_roman_calendar";
+  }
+  return select;
+}
+
+/**
+ * Rebuild the Calendar ID control for a row based on the chosen scope.
+ * Calendar-backed scopes mount a CalendarSelect; the rest use a native select.
+ */
+async function syncRowObjectIdField(row, objectType) {
+  const mount = row.querySelector(".perm-objid-mount");
+  if (!mount) return;
+  mount.innerHTML = "";
+
+  if (
+    NATIONAL_FILTER_TYPES.includes(objectType) ||
+    DIOCESAN_FILTER_TYPES.includes(objectType)
+  ) {
+    const client = await apiClientReady;
+    if (!client) return; // init failed; leave empty (validation will block submit)
+    // Guard against a rapid scope change that already replaced the mount.
+    if (
+      !row.isConnected ||
+      row.querySelector(".perm-object-type").value !== objectType
+    )
+      return;
+    const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+      ? CalendarSelectFilter.NATIONAL_CALENDARS
+      : CalendarSelectFilter.DIOCESAN_CALENDARS;
+    const calSelect = new CalendarSelect(LITCAL_LOCALE)
+      .filter(filter)
+      .allowNull(true)
+      .class("form-select form-select-sm perm-object-id");
+    calSelect.appendTo(mount);
+  } else {
+    mount.appendChild(buildStaticObjectIdSelect(objectType));
+  }
+}
+```
+
+- [ ] **Step 4: Reorder the row to Relation → Calendar scope → Calendar ID;
+      relabel; add the mount cell**
+
+In `addPermissionRow()` (`row.innerHTML = ...`, lines ~226-259), replace the
+template so the order/labels are correct and the Calendar ID cell is an empty
+`.perm-objid-mount` (populated by `syncRowObjectIdField`):
+
+```js
+row.innerHTML = `
+        <div class="card-body py-2 px-3">
+            <div class="row g-2 align-items-end">
+                <div class="col-md-3">
+                    <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.relation)}</label>
+                    <select class="form-select form-select-sm perm-relation" required>
+                        <option value="">${escapeHtml(config.i18n.selectRelation)}</option>
+                        <option value="admin">${escapeHtml(config.i18n.admin)}</option>
+                        <option value="viewer">${escapeHtml(config.i18n.viewer)}</option>
+                        <option value="editor">${escapeHtml(config.i18n.editor)}</option>
+                        <option value="deleter">${escapeHtml(config.i18n.deleter)}</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.calendarScope)}</label>
+                    <select class="form-select form-select-sm perm-object-type" required>
+                        ${buildObjectTypeOptions()}
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.calendarId)}</label>
+                    <div class="perm-objid-mount"></div>
+                </div>
+                <div class="col-md-2">
+                    <button type="button" class="btn btn-outline-danger btn-sm w-100 remove-perm-btn"
+                            title="${escapeHtml(config.i18n.remove)}"
+                            aria-label="${escapeHtml(config.i18n.remove)}">
+                        <i class="fas fa-trash-alt" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+    `;
+```
+
+The existing `.perm-object-type` `change` handler (~line 270) already calls
+`syncRowObjectIdField(row, e.target.value)`; it now returns a promise — calling
+it fire-and-forget is fine (no `await` needed at the call site). Leave that
+wiring.
+
+- [ ] **Step 5: Update the scope-select placeholder text**
+
+In `buildObjectTypeOptions()` (lines ~195-202), change the placeholder string to
+the new key:
+
+```js
+let html =
+  '<option value="">' +
+  escapeHtml(config.i18n.selectCalendarScope) +
+  "</option>";
+```
+
+- [ ] **Step 6: Guard `collectPermissions` against an unpopulated Calendar ID**
+
+In `collectPermissions()` (lines ~316-340), replace the object-id read so a row
+with no chosen Calendar ID is treated as invalid rather than throwing:
+
+```js
+const objectIdEl = row.querySelector(".perm-object-id");
+const objectId = objectIdEl ? objectIdEl.value.trim() : "";
+```
+
+(Leave the subsequent
+`if (!objectType || !objectId || !relation) { return null; }` check intact.)
+
+- [ ] **Step 7: Syntax + lint**
+
+Run: `node --check assets/js/permission-requests.js && yarn lint` Expected: no
+errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add assets/js/permission-requests.js
+git commit -m "feat(permissions): relation-first rows + hybrid CalendarSelect/static Calendar ID + scoped test types"
+```
+
+---
+
+### Task 3: `admin-permissions.php` — scoped types in filter + grant modal, relabel, reorder
+
+**Files:**
+
+- Modify: `admin-permissions.php` (filter object-type `<select>` ~lines 76-81;
+  grant-modal object-type `<select>` ~lines 289-295; grant-modal labels ~lines
+  288, 299; reorder grant-modal controls; `window.AdminPermissionsConfig.i18n`
+  blocks ~lines 372, 412)
+
+**Interfaces:**
+
+- Produces i18n keys consumed by Task 4: `calendarScope`, `calendarId`,
+  `selectCalendarId`, `testsNational`, `testsDiocesan`, `testsGeneralRoman`.
+
+- [ ] **Step 1: Replace `test_definition` with the three scoped types in both
+      selects**
+
+In the **filter** object-type select (line 80) and the **grant-modal**
+object-type select (line 294), replace the single `test_definition` `<option>`
+with:
+
+```php
+                        <option value="national_calendar_test"><?php echo htmlspecialchars(_('National Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="diocesan_calendar_test"><?php echo htmlspecialchars(_('Diocesan Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="general_roman_calendar_test"><?php echo htmlspecialchars(_('General Roman Calendar Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+```
+
+- [ ] **Step 2: Relabel + reorder the grant modal to Relation → Calendar scope →
+      Calendar ID**
+
+Reorder the three grant-modal control blocks (object-type ~288-295, object-id
+~299-300, relation ~305-310) so Relation precedes Calendar scope precedes
+Calendar ID. Change the object-type `<label>` (line 288) to
+`_('Calendar scope')`, its placeholder option (line 290) to
+`_('Select calendar scope...')`, and the object-id `<label>` (line 299) to
+`_('Calendar ID')`. Wrap the object-id input in a mount so JS can swap controls;
+replace the `<input id="grantObjectId">` (lines 299-300) markup with:
+
+```php
+                        <label for="grantObjectId" class="form-label"><?php echo htmlspecialchars(_('Calendar ID'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
+                        <div id="grantObjectIdMount">
+                            <select class="form-select" id="grantObjectId" required>
+                                <option value="" disabled selected><?php echo htmlspecialchars(_('Select calendar ID...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            </select>
+                        </div>
+```
+
+(Keep element ids `grantObjectType`, `grantObjectId`, `grantRelation` so
+existing JS reads keep working.)
+
+- [ ] **Step 3: Add new i18n keys to both `AdminPermissionsConfig.i18n` blocks**
+
+In each `i18n: { ... }` block (~line 372 and ~line 412), add:
+
+```php
+                calendarScope: <?php echo json_encode(_('Calendar scope')); ?>,
+                calendarId: <?php echo json_encode(_('Calendar ID')); ?>,
+                selectCalendarId: <?php echo json_encode(_('Select calendar ID...')); ?>,
+                testsNational: <?php echo json_encode(_('National Calendar Tests')); ?>,
+                testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests')); ?>,
+                testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests')); ?>,
+```
+
+- [ ] **Step 4: PHP syntax + lint**
+
+Run: `composer parallel-lint && composer lint` Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-permissions.php
+git commit -m "feat(admin-permissions): scoped test types + Calendar scope/ID labels"
+```
+
+---
+
+### Task 4: `admin-permissions.js` — package import, scoped names, hybrid grant Calendar ID
+
+**Files:**
+
+- Modify: `assets/js/admin-permissions.js` (top-of-file import; `GRC_OBJECT_IDS`
+  ~lines 45-51; `syncObjectIdField` ~lines 54-88; `objectTypeNames` ~lines
+  106-111; init/listener wiring ~line 510)
+
+**Interfaces:**
+
+- Consumes from package: `ApiClient`, `CalendarSelect`, `CalendarSelectFilter`.
+- Consumes from Task 3: new `config.i18n` keys.
+
+- [ ] **Step 1: Add the package import + ApiClient init gate**
+
+At the top of the file (module top-level), add the same import +
+`apiClientReady` promise as Task 2 Step 1.
+
+- [ ] **Step 2: Update `objectTypeNames`; add `WIDER_REGIONS` (keep
+      `GRC_OBJECT_IDS`)**
+
+Replace `objectTypeNames` (lines 106-111) with the same scoped map as Task 2
+Step 2 (national/diocesan/wider_region/general_roman_calendar + the three
+`_test` types → `config.i18n.testsNational/testsDiocesan/testsGeneralRoman`;
+remove `test_definition`). After `GRC_OBJECT_IDS` (lines 45-51, keep it) add the
+same `WIDER_REGIONS` constant as Task 2 Step 2.
+
+- [ ] **Step 3: Replace `syncObjectIdField` with the hybrid builder (single
+      grant control)**
+
+Replace `syncObjectIdField(objectType)` (lines 54-88) with a version that swaps
+the contents of `#grantObjectIdMount`. Calendar scopes mount a `CalendarSelect`
+with `.class('form-select').id('grantObjectId')`; static scopes build a native
+`<select id="grantObjectId" class="form-select">`:
+
+```js
+const NATIONAL_FILTER_TYPES = ["national_calendar", "national_calendar_test"];
+const DIOCESAN_FILTER_TYPES = ["diocesan_calendar", "diocesan_calendar_test"];
+
+function buildStaticGrantObjectId(objectType) {
+  const select = document.createElement("select");
+  select.className = "form-select";
+  select.id = "grantObjectId";
+  select.required = true;
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.textContent =
+    config.i18n.selectCalendarId || "Select calendar ID...";
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  select.appendChild(placeholder);
+
+  let entries = [];
+  if (objectType === "wider_region") {
+    entries = WIDER_REGIONS.map((name) => ({ value: name, label: name }));
+  } else if (objectType === "general_roman_calendar") {
+    entries = GRC_OBJECT_IDS.map((o) => ({ value: o.id, label: o.label }));
+  } else if (objectType === "general_roman_calendar_test") {
+    entries = [
+      { value: "general_roman_calendar", label: config.i18n.testsGeneralRoman },
+    ];
+  }
+  for (const e of entries) {
+    const o = document.createElement("option");
+    o.value = e.value;
+    o.textContent = e.label;
+    select.appendChild(o);
+  }
+  if (objectType === "general_roman_calendar_test") {
+    select.value = "general_roman_calendar";
+  }
+  return select;
+}
+
+async function syncObjectIdField(objectType) {
+  const mount = document.getElementById("grantObjectIdMount");
+  if (!mount) return;
+  mount.innerHTML = "";
+  if (
+    NATIONAL_FILTER_TYPES.includes(objectType) ||
+    DIOCESAN_FILTER_TYPES.includes(objectType)
+  ) {
+    const client = await apiClientReady;
+    if (!client) return;
+    if (grantObjectType.value !== objectType) return; // scope changed again meanwhile
+    const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+      ? CalendarSelectFilter.NATIONAL_CALENDARS
+      : CalendarSelectFilter.DIOCESAN_CALENDARS;
+    new CalendarSelect(LITCAL_LOCALE)
+      .filter(filter)
+      .allowNull(true)
+      .class("form-select")
+      .id("grantObjectId")
+      .appendTo(mount);
+  } else {
+    mount.appendChild(buildStaticGrantObjectId(objectType));
+  }
+}
+```
+
+(The grant submit handler reads `document.getElementById('grantObjectId').value`
+— unchanged. The `grantObjectType` change listener at ~line 510 already calls
+`syncObjectIdField(e.target.value)`; the now-async function is fine called
+fire-and-forget. The reset path that does
+`document.getElementById('grantObjectId').value = ''` still works on the
+rendered select.)
+
+- [ ] **Step 4: Syntax + lint**
+
+Run: `node --check assets/js/admin-permissions.js && yarn lint` Expected: no
+errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/js/admin-permissions.js
+git commit -m "feat(admin-permissions): hybrid CalendarSelect/static grant Calendar ID + scoped types"
+```
+
+---
+
+### Task 5: E2E support + i18n template
+
+**Files:**
+
+- Modify: `e2e/rbac/support/requestAccess.ts` (`objectType` union ~lines 31-33;
+  object-id interaction)
+- Modify: `i18n/litcal.pot` (regenerated)
+
+**Interfaces:**
+
+- Widens a TypeScript union and switches the object-id interaction to
+  `selectOption` (the control is now always a `<select>`).
+
+- [ ] **Step 1: Widen the objectType union**
+
+In `e2e/rbac/support/requestAccess.ts`, extend the union:
+
+```ts
+objectType: "national_calendar" |
+  "diocesan_calendar" |
+  "wider_region" |
+  "general_roman_calendar" |
+  "national_calendar_test" |
+  "diocesan_calendar_test" |
+  "general_roman_calendar_test";
+```
+
+- [ ] **Step 2: Ensure the object-id interaction uses `selectOption`**
+
+In `submitAccessRequest` (lines ~39-77), the Calendar ID control is now always a
+`<select>` (CalendarSelect-rendered or static). If the helper currently
+`.fill()`s `.perm-object-id`, change it to wait for the option then select it:
+
+```ts
+const objectIdControl = row.locator(".perm-object-id");
+await objectIdControl.waitFor({ state: "visible" });
+await objectIdControl.selectOption(opts.permission.objectId);
+```
+
+(Selecting by value works because option values are the nation code / diocese id
+/ region / GRC id as appropriate.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `yarn typecheck` Expected: no errors.
+
+- [ ] **Step 4: Regenerate the gettext template**
+
+Regenerate `i18n/litcal.pot` so the new msgids are present ("Calendar scope",
+"Calendar ID", "Select calendar scope...", "Select calendar ID...", "National
+Calendar Tests", "Diocesan Calendar Tests", "General Roman Calendar Tests"). Use
+the project's existing extraction tooling if present; otherwise:
+
+```bash
+find . -name '*.php' -not -path './vendor/*' -not -path './.yarn/*' \
+  | xargs xgettext --from-code=UTF-8 --keyword=_ --language=PHP \
+      --omit-header --sort-output -o i18n/litcal.pot.new
+```
+
+Confirm `i18n/litcal.pot.new` contains the new msgids, reconcile into
+`i18n/litcal.pot` (preserve existing header/structure), then remove the `.new`
+file. Do **not** edit per-language `.po` files — Weblate owns those.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/rbac/support/requestAccess.ts i18n/litcal.pot
+git commit -m "test(e2e): scoped test object types + select-based Calendar ID; refresh i18n template"
+```
+
+---
+
+### Task 6: Integration verification (local stack) + e2e scope coverage
+
+**Files:**
+
+- Modify: `e2e/rbac/` — extend or add one spec asserting a `test_editor` request
+  against a scoped test type (reuse `submitAccessRequest`).
+
+- [ ] **Step 1: Bring up the local stack and confirm scoped types**
+
+Ensure the docker stack (Postgres, Zitadel, OpenFGA, API on merged
+`development`, frontend) is healthy:
+
+```bash
+curl -s http://localhost:8000/calendars | jq '.litcal_metadata | keys'
+```
+
+Expected: includes `national_calendars`, `diocesan_calendars`, `wider_regions`.
+
+- [ ] **Step 2: Manual Chrome smoke**
+
+On `permission-requests.php`, for each role verify field order Relation →
+Calendar scope → Calendar ID and that:
+
+- **test_editor** scope offers exactly National/Diocesan/General Roman Calendar
+  Tests; National Calendar Tests mounts a CalendarSelect of nations (localized
+  names); Diocesan Calendar Tests mounts a grouped diocese CalendarSelect;
+  General Roman Calendar Tests shows the single fixed id.
+- **calendar_editor** offers the four calendar scopes; `wider_region` shows the
+  five regions; `general_roman_calendar` shows the five GRC ids.
+- **developer** offers all seven scopes. Then verify the same behavior in the
+  `admin-permissions.php` grant modal.
+
+- [ ] **Step 3: Add an e2e assertion for a scoped test request**
+
+Add/extend an rbac spec driving
+`submitAccessRequest(page, { requestedRole: 'test_editor', permission: { objectType: 'national_calendar_test', objectId: 'IT', relation: 'editor' } })`
+and asserting the request row appears. Confirm the CalendarSelect-rendered
+option for `IT` is present before `selectOption`.
+
+- [ ] **Step 4: Run the e2e suite (chromium)**
+
+Run: `yarn test:ci:chromium` Expected: PASS (or the targeted rbac specs pass).
+
+- [ ] **Step 5: Final gates + commit**
+
+Run:
+`composer parallel-lint && composer lint && yarn lint && yarn typecheck && composer lint:md:fix`
+Expected: all green.
+
+```bash
+git add -A
+git commit -m "test(e2e): cover scoped test-type permission request"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (design §"Part 4 — Frontend changes"):**
+
+1. Field order Relation → Calendar scope → Calendar ID → Task 2 Step 4, Task 3
+   Step 2. ✓
+2. Object ID as a real picker for every type → Task 2 Step 3 (CalendarSelect for
+   national/diocesan + `_test`; static select for wider_region/GRC/GRC-test) and
+   Task 4 Step 3. ✓
+3. Labels "Calendar scope"/"Calendar ID"; scope lists the three test types per
+   role → Tasks 1-4. ✓
+4. GRC ids in sync across files + API; wider regions inline constant → Task 2/4
+   (`GRC_OBJECT_IDS` kept with sync comment, `WIDER_REGIONS` added). ✓
+
+- `general_roman_calendar_test` single fixed id, auto-selected → Task 2/4
+  builders. ✓
+- Object-type sets mirror API `ROLE_OBJECT_TYPES` → Task 2 Step 2 (verbatim from
+  merged API). ✓
+- Package already cached/consistent; no `/calendars` fetch in our code
+  (CalendarSelect owns it); no footer/importmap change (already emitted). ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to" — each code step
+shows complete code. The xgettext command in Task 5 is concrete with a reconcile
+step.
+
+**Type/identifier consistency:** `apiClientReady` promise defined identically in
+Tasks 2 & 4; `NATIONAL_FILTER_TYPES`/`DIOCESAN_FILTER_TYPES`, `WIDER_REGIONS`,
+`GRC_OBJECT_IDS` referenced consistently; every Calendar ID control carries
+class `perm-object-id` (rows) or id `grantObjectId` (grant modal); i18n keys
+(`calendarScope`, `calendarId`, `selectCalendarScope`, `selectCalendarId`,
+`testsNational`, `testsDiocesan`, `testsGeneralRoman`) defined in Tasks 1/3 and
+consumed in Tasks 2/4.
+
+**Risk notes:**
+
+- **Per-row CalendarSelect lifecycle:** `syncRowObjectIdField` is async (awaits
+  `apiClientReady`); a stale-scope guard
+  (`row.querySelector('.perm-object-type').value !== objectType`) prevents a
+  late async build from overwriting a newer selection. `apiClientReady` resolves
+  at page load, so the await is effectively instant by the time the user
+  interacts.
+- **No JS unit framework** in the frontend; the dynamic logic (CalendarSelect)
+  is already covered by the package's own tests, and the new static-list
+  builders are verified by Playwright e2e + manual Chrome — consistent with the
+  project's e2e-only test strategy.
+- **`CalendarSelect.appendTo(mount)`** appends the rendered `<select>` into the
+  mount; reading `.perm-object-id`/`#grantObjectId` `.value` is unchanged for
+  submission.

--- a/e2e/rbac/12-test-editor-scoped-test-request.spec.ts
+++ b/e2e/rbac/12-test-editor-scoped-test-request.spec.ts
@@ -1,0 +1,47 @@
+import { test } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+import { submitAccessRequest } from './support/requestAccess';
+import { truncateAppTables, settleCleanup } from './support/cleanup';
+
+/**
+ * Scenario 12 — test_editor scoped to national_calendar_test:IT
+ *
+ * Proves the new calendar-scoped TEST object types are accepted end-to-end through the real UI:
+ *   - Selecting the test_editor role reveals the permissions section.
+ *   - Choosing "national_calendar_test" as the object type mounts a CalendarSelect.
+ *   - Selecting "IT" from that select and submitting results in a new pending request row.
+ *
+ * Requester: grc-editor (editor@general_roman_calendar:temporale).
+ * Seeded by rbac-setup; .auth/grc-editor.json exists.
+ * No approval step — submit + visible in #existingRequestsBody is sufficient.
+ *
+ * Preconditions (seeded by rbac-setup):
+ *   - grc-editor: Zitadel calendar_editor role, FGA editor@general_roman_calendar:temporale
+ */
+
+test('12 — test_editor request scoped to national_calendar_test:IT is accepted and visible', async ({ browser }) => {
+    // grc-editor submits a test_editor request for national_calendar_test:IT.
+    // submitAccessRequest asserts the new pending row appears in #existingRequestsBody.
+    const grced = await actingAs(browser, 'grc-editor');
+    try {
+        await submitAccessRequest(grced.page, {
+            requestedRole: 'test_editor',
+            permission: {
+                objectType: 'national_calendar_test',
+                objectId: 'IT',
+                relation: 'editor',
+            },
+            justification: 'Testing national calendar test data for IT locale',
+        });
+    } finally {
+        await grced.context.close();
+    }
+});
+
+test.afterEach(async () => {
+    // Remove the pending request row so the spec is re-runnable from a clean slate.
+    // No FGA tuples to revoke (no approval step in this scenario).
+    await settleCleanup('scenario 12 afterEach', [
+        truncateAppTables(),
+    ]);
+});

--- a/e2e/rbac/support/requestAccess.ts
+++ b/e2e/rbac/support/requestAccess.ts
@@ -9,9 +9,8 @@ import { expect, type Page } from '@playwright/test';
  *   - Role: radios `input[name="requested_role"]`; checking one reveals
  *     `#permissionsSection` and auto-adds one permission row when none exist.
  *   - Permission row: `#permissionRows .card`, with `.perm-object-type` (select),
- *     `.perm-object-id` (text input — but swapped to a <select> when object-type is
- *     `general_roman_calendar`), and `.perm-relation` (select). Set object-type FIRST
- *     so the object-id control is in its final form before we fill it.
+ *     `.perm-object-id` (always a <select>), and `.perm-relation` (select). Set
+ *     object-type FIRST so the object-id control is populated before we select from it.
  *   - Justification: `#justification` (optional). Submit: `#submitBtn`.
  *   - Success: `#formAlerts .alert-success`; the new pending request also appears in
  *     `#existingRequestsBody` as `tr[id^="request-"]`.
@@ -29,7 +28,7 @@ import { expect, type Page } from '@playwright/test';
 export interface AccessRequestOptions {
     requestedRole: string; // e.g. 'calendar_editor'
     permission: {
-        objectType: 'national_calendar' | 'diocesan_calendar' | 'wider_region' | 'general_roman_calendar';
+        objectType: 'national_calendar' | 'diocesan_calendar' | 'wider_region' | 'general_roman_calendar' | 'national_calendar_test' | 'diocesan_calendar_test' | 'general_roman_calendar_test';
         objectId: string;
         relation: 'admin' | 'editor' | 'viewer' | 'deleter';
     };
@@ -45,15 +44,12 @@ export async function submitAccessRequest(page: Page, opts: AccessRequestOptions
     const row = page.locator('#permissionRows .card').first();
     await expect(row).toBeVisible();
 
-    // Object-type first — for GRC this swaps .perm-object-id from <input> to <select>.
+    // Object-type first — populates the object-id <select> options for this type.
     await row.locator('.perm-object-type').selectOption(opts.permission.objectType);
 
-    const idField = row.locator('.perm-object-id');
-    if (opts.permission.objectType === 'general_roman_calendar') {
-        await idField.selectOption(opts.permission.objectId);
-    } else {
-        await idField.fill(opts.permission.objectId);
-    }
+    const objectIdControl = row.locator('.perm-object-id');
+    await objectIdControl.waitFor({ state: 'visible' });
+    await objectIdControl.selectOption(opts.permission.objectId);
 
     await row.locator('.perm-relation').selectOption(opts.permission.relation);
 

--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -2454,7 +2454,8 @@ msgstr ""
 
 #: permission-requests.php:214
 msgid ""
-"Each permission row must have object type, object ID, and relation filled in."
+"Each permission row must have a calendar scope, calendar ID, and relation "
+"filled in."
 msgstr ""
 
 #: permission-requests.php:215

--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -3310,3 +3310,31 @@ msgstr ""
 #: user-profile.php:407
 msgid "Session expired"
 msgstr ""
+
+#: admin-permissions.php:300 admin-permissions.php:397 admin-permissions.php:427 permission-requests.php:234
+msgid "Calendar scope"
+msgstr ""
+
+#: admin-permissions.php:313 admin-permissions.php:398 admin-permissions.php:428 permission-requests.php:235
+msgid "Calendar ID"
+msgstr ""
+
+#: admin-permissions.php:302 permission-requests.php:236
+msgid "Select calendar scope..."
+msgstr ""
+
+#: admin-permissions.php:316 admin-permissions.php:399 admin-permissions.php:429 permission-requests.php:237
+msgid "Select calendar ID..."
+msgstr ""
+
+#: admin-permissions.php:80 admin-permissions.php:306 admin-permissions.php:400 admin-permissions.php:430 permission-requests.php:243
+msgid "National Calendar Tests"
+msgstr ""
+
+#: admin-permissions.php:81 admin-permissions.php:307 admin-permissions.php:401 admin-permissions.php:431 permission-requests.php:244
+msgid "Diocesan Calendar Tests"
+msgstr ""
+
+#: admin-permissions.php:82 admin-permissions.php:308 admin-permissions.php:402 admin-permissions.php:432 permission-requests.php:245
+msgid "General Roman Calendar Tests"
+msgstr ""

--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -1180,8 +1180,13 @@ msgstr ""
 msgid "Developer"
 msgstr ""
 
-#: layout/header.php:200 admin-permissions.php:95 admin-permissions.php:307
-#: admin-permissions.php:391 permission-requests.php:256
+#: layout/header.php:200
+msgid "Admin"
+msgstr ""
+
+#: admin-permissions.php:97 admin-permissions.php:293 admin-permissions.php:404
+#: permission-requests.php:259
+msgctxt "permission relation"
 msgid "Admin"
 msgstr ""
 

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -224,11 +224,7 @@ if (!$authHelper->emailVerified) {
                 submitted: <?php echo json_encode(_('Submitted'), $jsonFlags); ?>,
                 reviewed: <?php echo json_encode(_('Reviewed'), $jsonFlags); ?>,
                 // Permission form labels
-                objectType: <?php echo json_encode(_('Object Type'), $jsonFlags); ?>,
-                objectId: <?php echo json_encode(_('Object ID'), $jsonFlags); ?>,
                 relation: <?php echo json_encode(_('Relation'), $jsonFlags); ?>,
-                selectObjectType: <?php echo json_encode(_('Select object type...'), $jsonFlags); ?>,
-                selectObjectId: <?php echo json_encode(_('Select object ID...'), $jsonFlags); ?>,
                 selectRelation: <?php echo json_encode(_('Select relation...'), $jsonFlags); ?>,
                 remove: <?php echo json_encode(_('Remove'), $jsonFlags); ?>,
                 calendarScope: <?php echo json_encode(_('Calendar scope'), $jsonFlags); ?>,
@@ -266,9 +262,7 @@ if (!$authHelper->emailVerified) {
                 statusPending: <?php echo json_encode(_('Pending'), $jsonFlags); ?>,
                 statusApproved: <?php echo json_encode(_('Approved'), $jsonFlags); ?>,
                 statusRejected: <?php echo json_encode(_('Rejected'), $jsonFlags); ?>,
-                statusRevoked: <?php echo json_encode(_('Revoked'), $jsonFlags); ?>,
-                // Object ID placeholders
-                objectIdPlaceholder: <?php echo json_encode(_('e.g. IT, USA, BOSTON, Americas...'), $jsonFlags); ?>
+                statusRevoked: <?php echo json_encode(_('Revoked'), $jsonFlags); ?>
             }
         };
     </script>

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -256,7 +256,7 @@ if (!$authHelper->emailVerified) {
                 // Relation display names
                 viewer: <?php echo json_encode(_('Viewer'), $jsonFlags); ?>,
                 editor: <?php echo json_encode(_('Editor'), $jsonFlags); ?>,
-                admin: <?php echo json_encode(_('Admin'), $jsonFlags); ?>,
+                admin: <?php echo json_encode(pgettext('permission relation', 'Admin'), $jsonFlags); ?>,
                 deleter: <?php echo json_encode(_('Deleter'), $jsonFlags); ?>,
                 // Status labels
                 statusPending: <?php echo json_encode(_('Pending'), $jsonFlags); ?>,

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -231,11 +231,18 @@ if (!$authHelper->emailVerified) {
                 selectObjectId: <?php echo json_encode(_('Select object ID...'), $jsonFlags); ?>,
                 selectRelation: <?php echo json_encode(_('Select relation...'), $jsonFlags); ?>,
                 remove: <?php echo json_encode(_('Remove'), $jsonFlags); ?>,
+                calendarScope: <?php echo json_encode(_('Calendar scope'), $jsonFlags); ?>,
+                calendarId: <?php echo json_encode(_('Calendar ID'), $jsonFlags); ?>,
+                selectCalendarScope: <?php echo json_encode(_('Select calendar scope...'), $jsonFlags); ?>,
+                selectCalendarId: <?php echo json_encode(_('Select calendar ID...'), $jsonFlags); ?>,
                 // Object type display names
                 nationalCalendar: <?php echo json_encode(_('National Calendar'), $jsonFlags); ?>,
                 diocesanCalendar: <?php echo json_encode(_('Diocesan Calendar'), $jsonFlags); ?>,
                 widerRegion: <?php echo json_encode(_('Wider Region'), $jsonFlags); ?>,
                 testDefinition: <?php echo json_encode(_('Test Definition'), $jsonFlags); ?>,
+                testsNational: <?php echo json_encode(_('National Calendar Tests'), $jsonFlags); ?>,
+                testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests'), $jsonFlags); ?>,
+                testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests'), $jsonFlags); ?>,
                 generalRomanCalendar: <?php echo json_encode(_('General Roman Calendar'), $jsonFlags); ?>,
                 grcTemporale: <?php echo json_encode(_('Temporale'), $jsonFlags); ?>,
                 // phpcs:ignore Generic.Files.LineLength

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -211,7 +211,7 @@ if (!$authHelper->emailVerified) {
                 resubmit: <?php echo json_encode(_('Resubmit'), $jsonFlags); ?>,
                 rejectionReason: <?php echo json_encode(_('Rejection reason'), $jsonFlags); ?>,
                 roleRequired: <?php echo json_encode(_('Please select a role.'), $jsonFlags); ?>,
-                permissionIncomplete: <?php echo json_encode(_('Each permission row must have object type, object ID, and relation filled in.'), $jsonFlags); ?>,
+                permissionIncomplete: <?php echo json_encode(_('Each permission row must have a calendar scope, calendar ID, and relation filled in.'), $jsonFlags); ?>,
                 maxPermissionsReached: <?php echo json_encode(_('You have reached the maximum of %1$d permissions per request.'), $jsonFlags); ?>,
                 permissionsTruncated: <?php echo json_encode(_('This request had more than %1$d permissions; only the first %2$d are shown.'), $jsonFlags); ?>,
                 unknownError: <?php echo json_encode(_('Unknown error'), $jsonFlags); ?>,


### PR DESCRIPTION
## Summary

Reworks the fine-grained permission UI (`permission-requests.php` + `admin-permissions.php`) to match the API's calendar-scoped test types (API PR #666, merged to `development`). Each permission row / admin grant form is now **Relation-first** with a real **"Calendar ID"** picker, and the scope dropdown offers the three new scoped test types — `national_calendar_test`, `diocesan_calendar_test`, `general_roman_calendar_test` — instead of the removed flat `test_definition`.

### Hybrid "Calendar ID" control
- **Calendar-backed scopes** (`national_calendar`, `diocesan_calendar`, + their `_test` twins) mount a `CalendarSelect` from `@liturgical-calendar/components-js` — already cached/used elsewhere, with localized country/diocese names and diocese grouping for free.
- **Non-calendar scopes** (`wider_region`, `general_roman_calendar`, `general_roman_calendar_test`) use a small native `<select>` from static lists (`WIDER_REGIONS`, `GRC_OBJECT_IDS`, single fixed GRC-test id).
- Every control renders a `<select class="perm-object-id">` (rows) / `#grantObjectId` (admin) so value-reads and e2e selectors are unchanged. `ApiClient.init(BaseUrl)` gates construction; importmap + `type="module"` are already emitted on these pages (no `footer.php` change).

### Changes
- `permission-requests.php` / `admin-permissions.php`: "Calendar scope"/"Calendar ID" labels, scoped-test i18n strings, three scoped options in the filter + grant selects, grant-modal reorder + `#grantObjectIdMount`.
- `assets/js/permission-requests.js` / `assets/js/admin-permissions.js`: package import, scoped `roleObjectTypes`/`objectTypeNames` (verbatim from API `ROLE_OBJECT_TYPES`), hybrid Calendar ID builder, Relation-first rows, resubmit-await + null-guards.
- `e2e/rbac/support/requestAccess.ts`: widened `objectType` union; `.perm-object-id` now always a `<select>` (`selectOption`).
- `e2e/rbac/12-test-editor-scoped-test-request.spec.ts`: new spec — `test_editor` submits `national_calendar_test:IT`.
- `i18n/litcal.pot`: 7 new msgids appended (untranslated — Weblate owns translations; `.po` untouched).

## Approach decision
Originally planned as vanilla native selects; switched to the **hybrid CalendarSelect** approach for consistency with the rest of the site + a warm cache (CalendarSelect only covers national/diocesan, so the 3 non-calendar scopes stay native).

## Verification
- Built subagent-driven: 5 code tasks, each with a two-stage review; whole-branch review verdict **READY TO MERGE** (no Critical/Important).
- Static gates green: `composer parallel-lint`, `composer lint`, `yarn lint`, `yarn typecheck`, `composer lint:md`.
- **Local rollout verified**: rebuilt `litcal-api` on `development` (#666), applied the additive OpenFGA model (new version with all 3 scoped test types), recreated containers — `/calendars` 200, API sees the scoped types, frontend serves the new UI.

## CI note
`e2e.yml` is `workflow_dispatch`-only (PR auto-run is deferred — issue #353), so the Playwright suite (incl. the new scoped-test spec) must be dispatched manually on this branch. The async option race for `selectOption('IT')` on the CalendarSelect-mounted control is mitigated by Playwright's auto-wait, but the first CI run should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permission requests and admin permissions now use **calendar scope** and **calendar ID** for calendar-backed access.
  * Added/expanded **calendar test scopes** (National, Diocesan, General Roman) across request and grant flows.
* **Bug Fixes**
  * Improved reliability of permission resubmission and permission/grant submission when calendar selectors load asynchronously.
  * Calendar scope changes now correctly rebuild the available calendar ID options and prevent stale selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->