### PR TITLE
ci(e2e): promote to pull_request + nightly; build frontend from the PR checkout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,22 +3,49 @@ name: E2E
 # End-to-end Playwright suite against the full docker stack
 # (Postgres + Zitadel + OpenFGA + Mailpit + API + frontend).
 #
+# Triggers:
+#   pull_request (frontend-affecting paths) — the PR's own frontend is built from
+#     the checkout via docker-compose.ci.yml (COMPOSE_FILE on the job). Draft PRs
+#     are skipped.
+#   schedule (nightly) — safety-net run on the default branch.
+#   workflow_dispatch — manual, with the `project` selector below.
+# Automated runs (pull_request / schedule) run the `rbac` project only.
+#
 # The `project` workflow_dispatch input selects which Playwright project runs:
 #   rbac (default) — the scoped-admin-review RBAC suite (rbac-setup seeds users)
 #   chromium / firefox / webkit — the calendar-data form specs
 #       (national / diocesan / wider-region / missals; these depend on the
-#        `setup` project's /auth/login with TEST_USERNAME/TEST_PASSWORD)
+#        `setup` project's /auth/login with TEST_USERNAME/TEST_PASSWORD, predate
+#        the Zitadel-based auth, and are NOT yet fixed for CI — see issue #353)
 #   all — every project
-# Push-triggered iteration runs `rbac`.
 #
-# FIRST ITERATION — being validated against a real runner (env contract,
-# healthcheck timing, the ~1.1 GB API image build). Once green, promote it:
-# add `pull_request` + a nightly `schedule` trigger, and a compose override that
-# builds litcal-frontend from the PR checkout. NOTE: the calendar-form projects
-# predate the Zitadel-based auth, so they may need their test user / login flow
-# updated before they pass in CI.
+# litcal-api builds from #development (the merge target); only litcal-frontend is
+# rebuilt from the checkout (docker-compose.ci.yml).
 
 on:
+  pull_request:
+    paths:
+      - 'assets/**'
+      - 'includes/**'
+      - 'layout/**'
+      - 'src/**'
+      - 'i18n/**'
+      - '*.php'
+      - 'e2e/**'
+      - 'scripts/**'
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - 'docker-compose.ci.yml'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.pnp.cjs'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.env.example'
+      - '.github/workflows/e2e.yml'
+  schedule:
+    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       project:
@@ -43,7 +70,14 @@ jobs:
   e2e:
     name: E2E (Playwright + full docker stack)
     runs-on: ubuntu-latest
+    # Skip draft PRs — the heavy full-stack run isn't worth it until ready for review.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     timeout-minutes: 45
+    env:
+      # Build litcal-frontend from the checkout (the PR head) instead of the base
+      # compose's #development git build, so the PR's frontend is what's tested.
+      # See docker-compose.ci.yml. Applies to every `docker compose` call below.
+      COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,19 @@
+# CI-only compose override for the E2E workflow (.github/workflows/e2e.yml).
+#
+# The base docker-compose.yml builds `litcal-frontend` from
+# github.com/Liturgical-Calendar/LiturgicalCalendarFrontend.git#development, so a
+# pull request's own frontend changes would NOT be exercised by the e2e suite.
+# This override rebuilds the frontend image from the checked-out repository (the
+# PR head on `pull_request`), mirroring how the API source data is checked out.
+#
+# `litcal-api` intentionally stays on the base `#development` build: a frontend PR
+# should run against the development API (the merge target), not a branch build.
+#
+# Applied via `COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml` in the
+# workflow. NOT auto-loaded locally — only `docker-compose.override.yml` is — so
+# local development is unaffected.
+services:
+  litcal-frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
Closes #353.

## What

Promotes the E2E workflow (`.github/workflows/e2e.yml`) from `workflow_dispatch`-only to automated triggers, and makes a PR's own frontend the image under test.

### 1. Triggers
- **`pull_request`** on frontend-affecting paths only (`assets/`, `includes/`, `layout/`, `src/`, `i18n/`, top-level `*.php`, `e2e/`, `scripts/`, `Dockerfile`, `docker-compose*.yml`, `playwright.config.ts`, `package.json`, `yarn.lock`, `.pnp.cjs`, `composer.*`, `.env.example`, the workflow itself).
- **`schedule`** — nightly (`0 3 * * *`) safety-net run on the default branch.
- **`workflow_dispatch`** retained (with the `project` selector).
- **Draft PRs are skipped** (`if:` guard) and `concurrency: cancel-in-progress` avoids redundant runs on rapid pushes.
- Automated runs use the **`rbac`** project only (`inputs.project || 'rbac'`).

### 2. Frontend built from the PR checkout
`docker-compose.yml` builds `litcal-frontend` from `…/LiturgicalCalendarFrontend.git#development`, so a PR's frontend changes were **not** exercised. New tracked **`docker-compose.ci.yml`** overrides `litcal-frontend.build` to the checkout context (`.`), applied via `COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml` on the job. `litcal-api` intentionally stays on `#development` (a frontend PR should run against the merge-target API). The CI override is **not** auto-loaded locally (only `docker-compose.override.yml` is), so local dev is unaffected.

### 3. Calendar-form projects
Still excluded: the `chromium`/`firefox`/`webkit` form specs predate the Zitadel auth (they use `setup`'s `/auth/login` with `TEST_USERNAME`/`TEST_PASSWORD`). Automated runs only execute `rbac`; fixing/enabling them remains tracked in #353's scope.

## Acceptance (per #353)
- ✅ E2E runs automatically (pull_request + nightly) without a manual dispatch.
- ✅ A PR's frontend changes are reflected (frontend image built from the PR via `docker-compose.ci.yml`).
- ✅ `rbac` stays the only automated project; form projects explicitly excluded with the #353 note.

## Self-test
This PR touches `e2e.yml` + `docker-compose.ci.yml` (both in the path filter), so opening it triggers the new `pull_request` e2e run — building the frontend from this PR's checkout and running `rbac` end-to-end. A green run proves the promotion.

## Validation
- `docker compose -f docker-compose.yml -f docker-compose.ci.yml config` confirms `litcal-frontend` builds from the checkout context and `litcal-api` is unchanged.
- Workflow YAML parses with triggers `[pull_request, schedule, workflow_dispatch]` and the `COMPOSE_FILE` job env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)