### PR TITLE
fix(rbac): remove deleter relation from permission UI

### DIFF
--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -94,10 +94,9 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                     <label for="filterRelation" class="form-label"><?php echo htmlspecialchars($relationLabel, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
                     <select class="form-select form-select-sm" id="filterRelation">
                         <option value=""><?php echo htmlspecialchars(_('All'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                        <option value="admin"><?php echo htmlspecialchars(pgettext('permission relation', 'Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="viewer"><?php echo htmlspecialchars(_('Viewer'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         <option value="editor"><?php echo htmlspecialchars(_('Editor'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                        <option value="deleter"><?php echo htmlspecialchars(_('Deleter'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                        <option value="admin"><?php echo htmlspecialchars(pgettext('permission relation', 'Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                     </select>
                 </div>
             </div>
@@ -290,10 +289,9 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                         <label for="grantRelation" class="form-label"><?php echo htmlspecialchars(_('Relation'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></label>
                         <select class="form-select" id="grantRelation" required>
                             <option value=""><?php echo htmlspecialchars(_('Select relation...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="admin"><?php echo htmlspecialchars(pgettext('permission relation', 'Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="viewer"><?php echo htmlspecialchars(_('Viewer'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                             <option value="editor"><?php echo htmlspecialchars(_('Editor'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
-                            <option value="deleter"><?php echo htmlspecialchars(_('Deleter'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+                            <option value="admin"><?php echo htmlspecialchars(pgettext('permission relation', 'Admin'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
                         </select>
                     </div>
                     <div class="mb-3">
@@ -401,10 +399,9 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                 testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests')); ?>,
                 testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests')); ?>,
                 // Relation display names
-                admin: <?php echo json_encode(pgettext('permission relation', 'Admin')); ?>,
                 viewer: <?php echo json_encode(_('Viewer')); ?>,
                 editor: <?php echo json_encode(_('Editor')); ?>,
-                deleter: <?php echo json_encode(_('Deleter')); ?>,
+                admin: <?php echo json_encode(pgettext('permission relation', 'Admin')); ?>,
                 // Validation
                 allFieldsRequired: <?php echo json_encode(_('All fields are required.')); ?>,
                 // Access requests review section

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -180,17 +180,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Relation display names and badge classes
     const relationNames = {
-        'admin': config.i18n.admin,
         'viewer': config.i18n.viewer,
         'editor': config.i18n.editor,
-        'deleter': config.i18n.deleter
+        'admin': config.i18n.admin
     };
 
     const relationBadgeClasses = {
-        'admin': 'bg-dark',
         'viewer': 'bg-info',
         'editor': 'bg-primary',
-        'deleter': 'bg-danger'
+        'admin': 'bg-dark'
     };
 
     /**

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -74,16 +74,14 @@ document.addEventListener('DOMContentLoaded', async function() {
     const relationNames = {
         'viewer': config.i18n.viewer,
         'editor': config.i18n.editor,
-        'admin': config.i18n.admin,
-        'deleter': config.i18n.deleter
+        'admin': config.i18n.admin
     };
 
     // Relation badge classes
     const relationBadgeClasses = {
         'viewer': 'bg-info',
         'editor': 'bg-primary',
-        'admin': 'bg-warning text-dark',
-        'deleter': 'bg-danger'
+        'admin': 'bg-warning text-dark'
     };
 
     // Status display info
@@ -317,10 +315,9 @@ document.addEventListener('DOMContentLoaded', async function() {
                         <label class="form-label form-label-sm mb-1">${escapeHtml(config.i18n.relation)}</label>
                         <select class="form-select form-select-sm perm-relation" required>
                             <option value="">${escapeHtml(config.i18n.selectRelation)}</option>
-                            <option value="admin">${escapeHtml(config.i18n.admin)}</option>
                             <option value="viewer">${escapeHtml(config.i18n.viewer)}</option>
                             <option value="editor">${escapeHtml(config.i18n.editor)}</option>
-                            <option value="deleter">${escapeHtml(config.i18n.deleter)}</option>
+                            <option value="admin">${escapeHtml(config.i18n.admin)}</option>
                         </select>
                     </div>
                     <div class="col-md-4">

--- a/e2e/rbac/support/requestAccess.ts
+++ b/e2e/rbac/support/requestAccess.ts
@@ -30,7 +30,7 @@ export interface AccessRequestOptions {
     permission: {
         objectType: 'national_calendar' | 'diocesan_calendar' | 'wider_region' | 'general_roman_calendar' | 'national_calendar_test' | 'diocesan_calendar_test' | 'general_roman_calendar_test';
         objectId: string;
-        relation: 'admin' | 'editor' | 'viewer' | 'deleter';
+        relation: 'viewer' | 'editor' | 'admin';
     };
     justification?: string;
 }

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -257,7 +257,6 @@ if (!$authHelper->emailVerified) {
                 viewer: <?php echo json_encode(_('Viewer'), $jsonFlags); ?>,
                 editor: <?php echo json_encode(_('Editor'), $jsonFlags); ?>,
                 admin: <?php echo json_encode(pgettext('permission relation', 'Admin'), $jsonFlags); ?>,
-                deleter: <?php echo json_encode(_('Deleter'), $jsonFlags); ?>,
                 // Status labels
                 statusPending: <?php echo json_encode(_('Pending'), $jsonFlags); ?>,
                 statusApproved: <?php echo json_encode(_('Approved'), $jsonFlags); ?>,


### PR DESCRIPTION
## Why

The API dropped the `deleter` OpenFGA relation in #668 — delete is now folded into `admin` (the final model has no `deleter`). The frontend should no longer offer or display it as a grantable/filterable permission relation.

## What

Removed `deleter` everywhere it appears as an RBAC **relation**, and ordered `admin` **last** (after `viewer`, `editor`) consistently across all relation lists:

- **`admin-permissions.php`** — filter `<option>` list, grant `<option>` list, and the `config.i18n` relation map.
- **`permission-requests.php`** — the `config.i18n` relation map.
- **`assets/js/admin-permissions.js`** — `relationNames` + `relationBadgeClasses` maps.
- **`assets/js/permission-requests.js`** — `relationNames` + `relationBadgeClasses` maps and the dynamic relation `<option>`.
- **`e2e/rbac/support/requestAccess.ts`** — the relation type union.

Valid relations are now `viewer | editor | admin`, matching the API's `VALID_RELATIONS`.

## Not changed

- **Delete-operation code** (deleting a calendar via `DELETE`, now authorized by `admin`) in `extending.js` and the e2e specs — that functionality is unchanged.
- **i18n files** — the now-unused `_('Deleter')` string drops out of `litcal.pot` on the next CI regeneration; no manual `.po`/`.pot` edit needed.

## Testing

- `composer parallel-lint`, `composer lint` (phpcs), `composer analyse` (phpstan), `composer test` (PHPUnit 4/4) — all pass.
- ESLint/tsc run in CI (`node_modules` not installed locally); edits are comma-clean and the type union is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the **deleter** relation from permission-related dropdowns and access request screens.
  * Updated relation labels and badges so only **viewer**, **editor**, and **admin** appear consistently.
  * Improved permission request behavior by preventing selection of an unsupported relation value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->