### PR TITLE
ci(e2e): skip the full-stack E2E suite on translation-only PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,12 +24,16 @@ name: E2E
 
 on:
   pull_request:
+    # Frontend-affecting paths only. NB: i18n/** is intentionally NOT listed —
+    # translation-only PRs (e.g. Weblate) don't change E2E behaviour, so they
+    # skip the ~7-min full-stack run. Any translation-driven regression is still
+    # caught by the nightly `schedule` run below. (E2E is not a required check,
+    # so excluding a PR here never leaves it stuck waiting on a missing status.)
     paths:
       - 'assets/**'
       - 'includes/**'
       - 'layout/**'
       - 'src/**'
-      - 'i18n/**'
       - '*.php'
       - 'e2e/**'
       - 'scripts/**'


### PR DESCRIPTION
## Why

The E2E workflow's `pull_request` trigger listed `i18n/**` in its paths allowlist, so **Weblate translation PRs** (which touch only `i18n/*.po` / `*.pot` / `*.mo`) kicked off the **~7-minute** Playwright + full-docker-stack run — even though translations don't change any E2E behaviour.

## What

Drop `i18n/**` from the E2E `pull_request` paths allowlist. All genuinely E2E-affecting paths are kept (`src/**`, `*.php`, `assets/**`, `e2e/**`, `scripts/**`, Docker/compose, `package.json`/`composer.json`, etc.). A PR that changes code *and* translations still runs E2E via the code paths; only translation-*only* PRs skip it.

## Why this is safe

- **E2E is not a required status check** on `development` (only `CodeQL` and `Analyze (javascript-typescript)` are), so excluding a PR from the workflow never leaves it stuck "waiting" on a missing status.
- Doc/markdown-only PRs already skip E2E (never in the allowlist).
- Any translation-driven regression is still caught by the existing **nightly `schedule`** run on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)