### PR TITLE
ci(deploy): reload php-fpm after deploy via tmp/restart.txt sentinel

### DIFF
--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -103,6 +103,13 @@ logs/
 # in a pre-rsync SSH-exec step so PHP can still write to it.
 /cache/*
 
+# --- DEPLOY RESTART SENTINEL (server-managed) ---
+# After rsync, the deploy drops tmp/restart.txt; a root-side systemd
+# path-watcher on the VPS (litcal-fpm-reload.path) reloads php-fpm so new
+# .mo translations take effect, then removes the file. Exclude the contents
+# so --delete never races the sentinel; the dir is created pre-rsync.
+/tmp/*
+
 # --- Dev-only symlink to local liturgy-components-js checkout ---
 /assets/components-js
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -210,10 +210,11 @@ jobs:
           DEPLOY_PATH: ${{ vars.VPS_APP_PATH }}
         run: |
           set -euo pipefail
-          remote_cmd=$(printf 'mkdir -p %q %q %q' \
+          remote_cmd=$(printf 'mkdir -p %q %q %q %q' \
             "${DEPLOY_PATH}" \
             "${DEPLOY_PATH}/cache" \
-            "${DEPLOY_PATH}/logs")
+            "${DEPLOY_PATH}/logs" \
+            "${DEPLOY_PATH}/tmp")
           ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
@@ -239,6 +240,33 @@ jobs:
             --exclude-from=.github/deploy/rsync-exclude.txt \
             -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
             ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"
+
+      - name: Signal php-fpm reload (apply new translations / code)
+        env:
+          VPS_USER: ${{ secrets.VPS_USERNAME }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+          DEPLOY_PATH: ${{ vars.VPS_APP_PATH }}
+        run: |
+          set -euo pipefail
+          # Drop the restart sentinel. A root-side systemd path-watcher on the
+          # VPS (litcal-fpm-reload.path) detects tmp/restart.txt, gracefully
+          # reloads php-fpm so freshly-deployed .mo translations take effect
+          # (php-fpm caches each .mo in the worker for its whole lifetime), then
+          # removes the file. The chrooted deploy user has no sudo to reload
+          # php-fpm itself, hence this Passenger-style file hand-off.
+          remote_cmd=$(printf 'mkdir -p %q && touch %q' \
+            "${DEPLOY_PATH}/tmp" \
+            "${DEPLOY_PATH}/tmp/restart.txt")
+          ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o ConnectTimeout=10 \
+            -o ServerAliveInterval=15 \
+            -o ServerAliveCountMax=2 \
+            "${VPS_USER}@${VPS_HOST}" \
+            "${remote_cmd}"
 
       - name: Post-deploy health check
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -249,16 +249,24 @@ jobs:
           DEPLOY_PATH: ${{ vars.VPS_APP_PATH }}
         run: |
           set -euo pipefail
-          # Drop the restart sentinel. A root-side systemd path-watcher on the
-          # VPS (litcal-fpm-reload.path) detects tmp/restart.txt, gracefully
-          # reloads php-fpm so freshly-deployed .mo translations take effect
-          # (php-fpm caches each .mo in the worker for its whole lifetime), then
-          # removes the file. The chrooted deploy user has no sudo to reload
-          # php-fpm itself, hence this Passenger-style file hand-off.
-          remote_cmd=$(printf 'mkdir -p %q && touch %q' \
+          # Drop the restart sentinel, then wait for the watcher to consume it.
+          # A root-side systemd path-watcher on the VPS (litcal-fpm-reload.path)
+          # detects tmp/restart.txt, gracefully reloads php-fpm so freshly-
+          # deployed .mo translations take effect (php-fpm caches each .mo in the
+          # worker for its whole lifetime), then removes the file. The chrooted
+          # deploy user has no sudo to reload php-fpm itself, hence this
+          # Passenger-style file hand-off.
+          #
+          # Touching the file only proves we asked; the watcher deleting it is
+          # what proves the reload ran. So in the same remote shell we touch the
+          # sentinel and then poll until it disappears (up to ~60s), exiting
+          # non-zero on timeout so the deploy fails rather than silently
+          # continuing with a stale php-fpm.
+          remote_cmd=$(printf 'set -e; mkdir -p %q; touch %q; i=0; while [ "$i" -lt 30 ]; do [ -e %q ] || exit 0; sleep 2; i=$((i+1)); done; exit 1' \
             "${DEPLOY_PATH}/tmp" \
+            "${DEPLOY_PATH}/tmp/restart.txt" \
             "${DEPLOY_PATH}/tmp/restart.txt")
-          ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
+          if ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile=~/.ssh/known_hosts \
@@ -266,7 +274,12 @@ jobs:
             -o ServerAliveInterval=15 \
             -o ServerAliveCountMax=2 \
             "${VPS_USER}@${VPS_HOST}" \
-            "${remote_cmd}"
+            "${remote_cmd}"; then
+            echo "php-fpm reload sentinel consumed by the watcher; reload completed."
+          else
+            echo "::error::php-fpm reload not confirmed: ${DEPLOY_PATH}/tmp/restart.txt was not consumed within ~60s (or the signal connection failed)." >&2
+            exit 1
+          fi
 
       - name: Post-deploy health check
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -382,7 +382,13 @@ services:
       API_PORT: ${API_PORT:-8000}
       API_BASE_PATH: ""
       WS_PROTOCOL: ws
-      WS_HOST: localhost
+      # The browser builds the WebSocket URL from this value and connects from
+      # the host, NOT from inside the container — so it must be an address the
+      # host's browser can reach. The API container publishes 8082 on IPv4 only
+      # (127.0.0.1:8082). Modern Chrome resolves "localhost" to IPv6 ::1 first
+      # and (unlike HTTP) does not fall back to IPv4 for WebSockets, so
+      # ws://localhost:8082 fails. Pin to 127.0.0.1 to force the working IPv4 path.
+      WS_HOST: 127.0.0.1
       WS_PORT: ${WS_PORT:-8082}
       LITCAL_FRONTEND_URL: http://localhost:${FRONTEND_PORT:-3000}
       ZITADEL_ISSUER: ${ZITADEL_ISSUER:-}


### PR DESCRIPTION
## Why

PHP's `gettext` caches each `.mo` in the php-fpm worker for the worker's entire lifetime. So after a translations deploy, the new `.mo` is on disk but running workers keep serving the old one — e.g. the permission-relation dropdown showed "Admin" instead of "Amministratore" until a manual `systemctl reload`. The deploy's SSH user is the **chrooted Plesk vhost user with no sudo**, so it can't reload php-fpm itself.

## Approach — Passenger-style sentinel hand-off

After rsync, the deploy drops `tmp/restart.txt`. A **root-side systemd path-watcher on the VPS** (`litcal-fpm-reload.path`, installed out-of-band) detects it, **gracefully reloads** `plesk-php84-fpm` (recycling workers → busting the gettext cache), and removes the file ("restart once"). This keeps the privileged action server-side — no sudo key in CI, no chroot workaround.

## Changes (this PR — the CI half)

- **`deploy.yaml`**: create `tmp/` in the "ensure dirs" step; add a post-rsync step that `touch`es `tmp/restart.txt` over the existing SSH channel.
- **`rsync-exclude.txt`**: exclude `/tmp/*` (mirrors `/cache/*`) so `--delete` never races the sentinel and the dir survives.

## Server side (already installed + tested on staging)

`/usr/local/sbin/litcal-fpm-reload.sh` + `litcal-fpm-reload.{service,path}` watch `LiturgicalCalendar-staging/tmp/restart.txt`. Verified end-to-end: touching the sentinel as the vhost user triggers the watcher within ~1s → php-fpm workers recycle (PID changes) → sentinel removed → logged via `journalctl -t litcal-fpm-reload`. (Production gets its own `.path` unit when it ships the new stack.)

## Notes

- `reload` is graceful (no dropped requests); it recycles all PHP-8.4 pools' workers, which is harmless.
- Local dev has no root watcher, so there a translation change still needs a container recreate — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by preserving a restart marker during syncs, reducing the chance of deployment races and missed reloads.
  * Added a post-deploy step to trigger a web server reload after updates, helping changes take effect more consistently.
  * Fixed local WebSocket connectivity in container-based test setups by using a host address that works reliably on all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->