### PR TITLE
ci(codeql): use unified javascript-typescript language identifier

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,8 +33,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use the unified 'javascript-typescript' identifier (CodeQL analyzes JS
+        # and TS as one language family). This also fixes the status-check name:
+        # the job reports as "Analyze (javascript-typescript)", which is the exact
+        # context the `development` branch protection requires. With the old
+        # 'javascript' value the job reported "Analyze (javascript)", so the
+        # required context was never satisfied and PRs sat permanently BLOCKED.
+        language: [ 'javascript-typescript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript-typescript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:


### PR DESCRIPTION
## Problem

Dependabot minor/patch PRs with auto-merge enabled were sitting permanently in a `BLOCKED` merge state **even though every check passed**.

Root cause is a branch-protection required-check name mismatch:

- The `development` branch protection requires the status context **`Analyze (javascript-typescript)`**.
- The CodeQL workflow matrix was `language: [ 'javascript' ]`, so the job reported as **`Analyze (javascript)`**.

The required context was therefore never reported, so GitHub kept the PR `BLOCKED` (waiting on a check that would never arrive) and `gh pr merge --auto` never completed. This affected e.g. #365 (markdownlint-cli2, all green) which could not auto-merge.

## Fix

Switch the matrix to the unified `javascript-typescript` identifier (CodeQL analyzes JS and TS as a single language family). The job now reports `Analyze (javascript-typescript)`, matching the existing required context exactly. **No branch-protection change is needed.**

This PR is self-consistent: `pull_request` runs use the workflow file from the PR head, so this PR's own CodeQL run reports the new name and satisfies its own required gate.

## Follow-up (after merge)

Existing open Dependabot PRs won't pick up the new check name until rebased onto the fixed `development`. Comment `@dependabot rebase` on the green minor PRs (e.g. #365) to unblock and let auto-merge complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security scanning to use the unified JavaScript/TypeScript language identifier.
  * Aligned the reported status-check name with branch protection requirements, helping the workflow pass consistently on the development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->