### PR TITLE
ci(e2e): skip-companion so E2E can be a required check (no path-filter BLOCK)

### DIFF
--- a/.github/workflows/e2e-required-skip.yml
+++ b/.github/workflows/e2e-required-skip.yml
@@ -1,0 +1,55 @@
+name: E2E (skip companion)
+
+# Companion to e2e.yml that lets "E2E (Playwright + full docker stack)" be a
+# REQUIRED status check without blocking PRs that don't touch frontend code.
+#
+# e2e.yml is path-filtered: it only runs on frontend-affecting paths and is
+# deliberately skipped for docs-only and i18n/Weblate translation PRs. GitHub's
+# branch protection cannot tell "skipped by path filter" from "still pending":
+# when the real workflow never triggers, the required context is never reported
+# and the PR sits BLOCKED forever.
+#
+# This workflow runs on the COMPLEMENT of e2e.yml's `paths` (via paths-ignore)
+# and emits a check with the EXACT same job name, reporting success instantly.
+# So for every non-draft PR exactly one of the two reports the required context:
+#   - touches frontend paths  -> e2e.yml runs the real suite
+#   - touches nothing relevant -> this companion reports green in seconds
+#
+# IMPORTANT: keep this paths-ignore list in sync with the `paths` list in
+# e2e.yml. If a path is added there, add it here too, or translation/docs PRs
+# that also touch the new path could trigger both workflows.
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'assets/**'
+      - 'includes/**'
+      - 'layout/**'
+      - 'src/**'
+      - '*.php'
+      - 'e2e/**'
+      - 'scripts/**'
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - 'docker-compose.ci.yml'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.pnp.cjs'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.env.example'
+      - '.github/workflows/e2e.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    # This name MUST match the job name in e2e.yml exactly so both produce the
+    # same required status context.
+    name: E2E (Playwright + full docker stack)
+    runs-on: ubuntu-latest
+    steps:
+      - name: No frontend changes — E2E not required
+        run: echo "No frontend-affecting paths changed; reporting the E2E gate green without running the full stack."


### PR DESCRIPTION
## Why

You asked to make **E2E a required check**. Naively adding `E2E (Playwright + full docker stack)` to branch protection would **re-create the bug we just fixed in #369**: `e2e.yml` is path-filtered (frontend paths only; docs-only and i18n/Weblate translation PRs are skipped on purpose), and GitHub can't tell "skipped by path filter" from "pending" — so those PRs would sit `BLOCKED` forever waiting on a status that never arrives. The author of `e2e.yml` even notes this in a comment.

## What

GitHub's documented "[handling skipped but required checks](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/troubleshooting-required-status-checks)" pattern: a companion workflow that

- triggers on the **complement** of `e2e.yml`'s `paths` (`paths-ignore` with the same list), and
- emits a check with the **identical job name** `E2E (Playwright + full docker stack)`, reporting success in seconds.

So for every non-draft PR, exactly one of the two reports the required context:

| PR touches… | e2e.yml | companion | required context |
|---|---|---|---|
| frontend paths | runs real suite | skipped | real pass/fail |
| only docs / i18n | skipped | runs | instant green |

A PR touching both still runs the real suite; the trivial companion finishes seconds earlier, so the real (slower) result is the latest and governs.

> ⚠️ Maintenance note: the `paths-ignore` list here must stay in sync with the `paths` list in `e2e.yml`.

## Sequencing (after merge)

1. Merge #370 (PnP → node_modules) so the real E2E is green on `development`.
2. Merge this PR so the companion exists.
3. Add `E2E (Playwright + full docker stack)` to `development` required status checks.
4. Rebase the open Dependabot PRs (#362–#368) so they pick up both and re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)