### PR TITLE
ci(dependabot): group npm updates (eslint pair + dev-dependencies)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -40,3 +40,17 @@ updates:
     target-branch: "development"
     labels:
       - "javascript dependencies"
+    # Batch npm updates into fewer PRs. Groups are matched in the order they are
+    # declared — a dependency joins the FIRST group whose patterns match — so the
+    # `eslint` group must precede the catch-all `dev-dependencies` group. eslint
+    # and @eslint/js share a hard major-version lock (@eslint/js@10's shared
+    # config references rules that only exist in eslint@10 core), so they must
+    # bump together in a single PR or the config fails to load.
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+      dev-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

Dependabot does **not** group packages by default — each dependency gets its own PR. That split `@eslint/js` (#367, → 10.0.1) from `eslint` core (left at 9.32.0). Because `@eslint/js@10`'s shared config enables `preserve-caught-error` (a rule new in `eslint@10` core), `yarn lint` crashes at config load:

```
TypeError: Key "rules": Key "preserve-caught-error": Could not find "preserve-caught-error" in plugin "@".
```

`eslint` and `@eslint/js` are a major-version-locked pair and must bump together.

## What

Two groups on the npm ecosystem:

- **`eslint`** — `eslint` + `@eslint/*`, so the locked pair always bumps in one PR.
- **`dev-dependencies`** — catch-all (`*`) so the remaining devDeps batch into fewer PRs. (All npm deps here are devDependencies.)

Groups match in declaration order (first match wins), so `eslint` precedes the catch-all. The repo default branch is `development`, so this takes effect once merged here.

## Follow-up

- Close #367 — once `eslint@10` core clears the 7-day cooldown, Dependabot reopens a single grouped `eslint` PR bumping both, and the config loads. (eslint 10 is a major; it may need other config tweaks, but it'll at least run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to group related package updates into fewer pull requests, helping keep maintenance changes more organized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->