### PR TITLE
fix(extending): satisfy eslint 10 lint rules (unblock grouped eslint bump #373)

### DIFF
--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -303,7 +303,7 @@ async function handleAuthError(response, retryRequest, fullFlowCallback) {
             authRetryCounters.delete(retryRequest);
             console.error('Token refresh failed:', error.message);
             showLoginModal(fullFlowCallback);
-            throw new Error('Authentication required');
+            throw new Error('Authentication required', { cause: error });
         }
     } else if (response.status === 403) {
         toastr.error('You do not have permission to perform this action', 'Permission Denied');
@@ -1637,7 +1637,7 @@ const updateRegionalCalendarForm = (data) => {
  */
 const fetchRegionalCalendarData = (headers) => {
     // Only fetch data for calendars that already exist
-    let calendarExists = false;
+    let calendarExists;
     console.log(`fetchRegionCalendarData: API.category: <${API.category}>, API.key: <${API.key}>`);
     if (API.category === 'nation') {
         calendarExists = LitCalMetadata.national_calendars_keys.includes(API.key);


### PR DESCRIPTION
## Why

The Dependabot grouping (PR #372) is working: #373 now bumps **`eslint` + `@eslint/js` to v10 together**, so the flat config loads instead of crashing. eslint 10 then runs and enforces two stricter recommended rules against real code in `assets/js/extending.js`:

```
306:13  error  There is no `cause` attached to the symptom error being thrown  preserve-caught-error
1640:9  error  The value assigned to 'calendarExists' is not used in subsequent statements  no-useless-assignment
```

## What

- **`preserve-caught-error`** (line 306): the token-refresh `catch (error)` block threw `new Error('Authentication required')` and discarded the caught error. Now `new Error('Authentication required', { cause: error })` — preserves the original failure for debugging; control flow and `.message` consumers unchanged.
- **`no-useless-assignment`** (line 1640): `calendarExists` was initialised to `false` but unconditionally reassigned in both the `if`/`else` branches before being read. Dropped the dead `= false` initialiser.

Both are improvements independent of the eslint version.

## Verification

- `eslint@10.5.0` (the version #373 pins): `yarn lint` → **clean** (both errors gone)
- `eslint@9.x` (current `development`): `yarn lint` → **clean** (no regression)
- Only `assets/js/extending.js` changes here — the eslint version bump stays with #373.

## Follow-up

Merge this, then rebase **#373** — its eslint-10 lint run will pass against the now-clean code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)