### PR TITLE
docker: live-reload bind mounts for litcal-tests (override example)

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -35,3 +35,17 @@ services:
   litcal-tests:
     build:
       context: ../UnitTestInterface
+    # Live-reload: mount source read-only so edits reflect without rebuilding the
+    # image (UnitTestInterface has no build step). vendor/ is deliberately NOT
+    # mounted so the image's `composer install` is used. Add new top-level pages
+    # or directories here if you create them.
+    volumes:
+      - ../UnitTestInterface/src:/var/www/html/src:ro
+      - ../UnitTestInterface/includes:/var/www/html/includes:ro
+      - ../UnitTestInterface/layout:/var/www/html/layout:ro
+      - ../UnitTestInterface/components:/var/www/html/components:ro
+      - ../UnitTestInterface/assets:/var/www/html/assets:ro
+      - ../UnitTestInterface/i18n:/var/www/html/i18n:ro
+      - ../UnitTestInterface/index.php:/var/www/html/index.php:ro
+      - ../UnitTestInterface/admin.php:/var/www/html/admin.php:ro
+      - ../UnitTestInterface/resources.php:/var/www/html/resources.php:ro


### PR DESCRIPTION
## What

Add read-only source bind mounts to the `litcal-tests` service in `docker-compose.override.example.yml`.

## Why

Unlike `litcal-frontend` (which mounts its PHP sources for live editing), `litcal-tests` had no bind mounts — so every change to the UnitTestInterface source required an image rebuild. UnitTestInterface has no build step, so mounting its source read-only gives instant reflection (refresh the browser; PHP re-reads per request).

## Details

- Mounts mirror the paths the UnitTestInterface `Dockerfile` `COPY`s: `src`, `includes`, `layout`, `components`, `assets`, `i18n`, and the top-level `index.php`/`admin.php`/`resources.php`.
- `vendor/` is intentionally **not** mounted, so the image's `composer install` (built `--no-dev`) is used rather than the host's.
- Read-only, matching the existing `litcal-frontend` override style.
- This is the tracked **template**; users mirror the relevant services into their local (gitignored) `docker-compose.override.yml`.

## Validation

`docker compose -f docker-compose.yml -f docker-compose.override.example.yml config` merges cleanly and the mounts resolve onto `litcal-tests` as read-only binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live-reload support for the local test environment, so code and UI changes appear immediately without rebuilding containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->