### PR TITLE
Add redis service for the WS test server response cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,6 +277,18 @@ services:
       - litcal
     restart: "no"
 
+  # Cache backend for the WebSocket test server's API-response cache (see litcal-api below).
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    networks:
+      - litcal
+
   litcal-api:
     image: litcal-api:latest
     build: https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI.git#development
@@ -317,6 +329,11 @@ services:
       OPENFGA_API_URL: http://openfga:8080
       OPENFGA_STORE_ID: ${OPENFGA_STORE_ID:-}
       OPENFGA_MODEL_ID: ${OPENFGA_MODEL_ID:-}
+      # The WebSocket test server (LitCalTestServer.php) caches API responses; Health.php prefers
+      # Redis and only falls back to APCu, which is disabled under the CLI SAPI the WS server runs
+      # on — so without Redis every request is a cache miss.
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
     ports:
       - "127.0.0.1:${API_PORT:-8000}:8000"
       - "127.0.0.1:${WS_PORT:-8082}:8082"
@@ -337,6 +354,8 @@ services:
         condition: service_completed_successfully
       litcal-migrate:
         condition: service_completed_successfully
+      redis:
+        condition: service_healthy
 
   litcal-frontend:
     image: litcal-frontend:latest


### PR DESCRIPTION
## Why

The `litcal-api` container also runs the WebSocket test server (`LitCalTestServer.php`), whose `Health.php` caches API responses to speed up repeated/restarted test runs. It **prefers Redis** and only falls back to APCu — but APCu is disabled under the **CLI SAPI** the WS server runs on (`apc.enable_cli=Off`) and there was no Redis in the stack. Result: every request was a cache miss, so each run recomputed everything.

## What

- Add a `redis:7-alpine` service (healthcheck `redis-cli ping`, on the `litcal` network).
- Point `litcal-api` at it via `REDIS_HOST=redis` / `REDIS_PORT=6379`, with `depends_on: redis (service_healthy)`.

Requires the **php-redis extension** in the API image — added in LiturgicalCalendarAPI (PR #685). Without both, the WS server keeps falling back to the (disabled) APCu path.

## Verified locally

With Redis wired up, a full run for the General Roman calendar:

| Run | Cache | Wall time |
|-----|-------|-----------|
| 1 | cold | ~30.5 s (89 misses) |
| 2 | warm | ~4.7 s (132 hits) |

Redis keyspace ended at 264 hits / 89 misses, 89 keys. Results unchanged (Source Data still correctly reports its 2 failures).

## Note on production

This fixes the **docker stack**. Production (Plesk) runs the WS server outside this image, so it needs either its own Redis + `REDIS_*` config, or `apc.enable_cli=1` for the WS CLI process — separate from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)