### PR TITLE
feat: admin-tests page — CRUD of liturgical test definitions in the admin area (Phase 2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@
 !admin-applications.php
 !admin-dashboard.php
 !admin-permissions.php
+!admin-tests.php
 !admin-role-requests.php
 !admin-users.php
 !decrees.php

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ api/*
 !admin-dashboard.php
 !admin-permissions.php
 !admin-role-requests.php
+!admin-tests.php
 !admin-users.php
 !decrees.php
 !developer-dashboard.php

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,22 +3,26 @@ project_name: "LiturgicalCalendarFrontend"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   haxe                java                julia               kotlin              lua
-#   markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -67,54 +71,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project based on the project name or path.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
-#       for example by saying that the information retrieved from a memory file is no longer correct
-#       or no longer relevant for the project.
-#  * `edit_memory`: Replaces content matching a regular expression in a memory.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_file`: Finds files in the given relative paths
-#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
-#  * `find_symbol`: Performs a global (or local) search using the language server backend.
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
-#       for clients that do not read the initial instructions when the MCP server is connected.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
-#       is relevant to the current task. You can infer whether the information
-#       is relevant from the memory file name.
-#       You should not read the same memory file multiple times in the same conversation.
-#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
-#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
-#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
-#       For JB, we use a separate tool.
-#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
-#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
-#  * `safe_delete_symbol`:
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
-#       The memory name should be meaningful.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -125,11 +92,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -140,6 +110,7 @@ initial_prompt: |
   - Dont push immediately after committing — CodeRabbit rate-limits. Batch commits or wait for explicit ask.
   - gettext: ALWAYS use numbered placeholders (`%1$d`, `%2$s`); never positional (`%d`, `%s`) — translators must be able to reorder.
   - Public API endpoints (Metadata, Missals, Decrees, Temporale) MUST use `credentials: omit` — they return wildcard CORS, incompatible with `credentials: include`.
+
 # time budget (seconds) per tool call for the retrieval of additional symbol information
 # such as docstrings or parameter information.
 # This overrides the corresponding setting in the global configuration; see the documentation there.
@@ -157,3 +128,19 @@ read_only_memory_patterns: []
 # Extends the list from the global configuration, merging the two lists.
 # Example: ["_archive/.*", "_episodes/.*"]
 ignored_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/admin-dashboard.php
+++ b/admin-dashboard.php
@@ -137,6 +137,51 @@ if (!$hasCalendarRole) {
                 </div>
             </div>
         </div>
+        <div class="col-12 col-md-6 col-lg-4 mb-4">
+            <div class="card admin-block shadow h-100 border-dark">
+                <div class="card-body text-center d-flex flex-column">
+                    <div class="admin-block-icon mb-3">
+                        <i class="fas fa-vial fa-3x text-info"></i>
+                    </div>
+                    <h5 class="card-title"><?php echo htmlspecialchars(_('Test Definitions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h5>
+                    <p class="card-text text-muted small flex-grow-1">
+                        <?php echo htmlspecialchars(_('Manage liturgical accuracy tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </p>
+                    <div class="admin-block-actions mt-auto">
+                        <a href="admin-tests.php" class="btn btn-dark btn-sm">
+                            <i class="fas fa-tasks me-1"></i><?php echo htmlspecialchars(_('Manage'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <?php if (!$isAdmin && $authHelper->hasRole('test_editor')) : ?>
+    <hr class="my-4">
+    <h4 class="mb-3 text-black" style="--bs-text-opacity: .6;">
+        <i class="fas fa-user-shield me-2"></i><?php echo htmlspecialchars(_('Administration'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+    </h4>
+    <div class="row">
+        <div class="col-12 col-md-6 col-lg-4 mb-4">
+            <div class="card admin-block shadow h-100 border-dark">
+                <div class="card-body text-center d-flex flex-column">
+                    <div class="admin-block-icon mb-3">
+                        <i class="fas fa-vial fa-3x text-info"></i>
+                    </div>
+                    <h5 class="card-title"><?php echo htmlspecialchars(_('Test Definitions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h5>
+                    <p class="card-text text-muted small flex-grow-1">
+                        <?php echo htmlspecialchars(_('Manage liturgical accuracy tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </p>
+                    <div class="admin-block-actions mt-auto">
+                        <a href="admin-tests.php" class="btn btn-dark btn-sm">
+                            <i class="fas fa-tasks me-1"></i><?php echo htmlspecialchars(_('Manage'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <?php endif; ?>
 

--- a/admin-dashboard.php
+++ b/admin-dashboard.php
@@ -137,24 +137,7 @@ if (!$hasCalendarRole) {
                 </div>
             </div>
         </div>
-        <div class="col-12 col-md-6 col-lg-4 mb-4">
-            <div class="card admin-block shadow h-100 border-dark">
-                <div class="card-body text-center d-flex flex-column">
-                    <div class="admin-block-icon mb-3">
-                        <i class="fas fa-vial fa-3x text-info"></i>
-                    </div>
-                    <h5 class="card-title"><?php echo htmlspecialchars(_('Test Definitions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h5>
-                    <p class="card-text text-muted small flex-grow-1">
-                        <?php echo htmlspecialchars(_('Manage liturgical accuracy tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                    </p>
-                    <div class="admin-block-actions mt-auto">
-                        <a href="admin-tests.php" class="btn btn-dark btn-sm">
-                            <i class="fas fa-tasks me-1"></i><?php echo htmlspecialchars(_('Manage'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <?php include('./includes/admin-tests-card.php'); ?>
     </div>
     <?php endif; ?>
 
@@ -164,24 +147,7 @@ if (!$hasCalendarRole) {
         <i class="fas fa-user-shield me-2"></i><?php echo htmlspecialchars(_('Administration'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
     </h4>
     <div class="row">
-        <div class="col-12 col-md-6 col-lg-4 mb-4">
-            <div class="card admin-block shadow h-100 border-dark">
-                <div class="card-body text-center d-flex flex-column">
-                    <div class="admin-block-icon mb-3">
-                        <i class="fas fa-vial fa-3x text-info"></i>
-                    </div>
-                    <h5 class="card-title"><?php echo htmlspecialchars(_('Test Definitions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h5>
-                    <p class="card-text text-muted small flex-grow-1">
-                        <?php echo htmlspecialchars(_('Manage liturgical accuracy tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                    </p>
-                    <div class="admin-block-actions mt-auto">
-                        <a href="admin-tests.php" class="btn btn-dark btn-sm">
-                            <i class="fas fa-tasks me-1"></i><?php echo htmlspecialchars(_('Manage'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <?php include('./includes/admin-tests-card.php'); ?>
     </div>
     <?php endif; ?>
 

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -328,7 +328,7 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                 requiredFields:      <?php echo json_encode(_('Please fill in all required fields.')); ?>,
                 denied403:           <?php echo json_encode(_('You do not have permission to perform this action.')); ?>,
                 conflict409:         <?php echo json_encode(_('A test with that name already exists.')); ?>,
-                setYear:             <?php echo json_encode(_('set year')); ?>,
+                setYear:             <?php echo json_encode(_('set pivot year')); ?>,
                 toggleAssertion:     <?php echo json_encode(_('toggle assertion')); ?>,
                 removeYear:          <?php echo json_encode(_('remove')); ?>,
                 sundayInYear:        <?php echo json_encode(_('In the year %1$s, %2$s falls on a Sunday')); ?>,

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -211,7 +211,7 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                             <div class="year-grid mt-2" id="yearGrid"></div>
                             <div class="d-flex flex-wrap align-items-center column-gap-3 row-gap-1 small text-muted mt-2" id="yearGridLegend">
                                 <span><span class="legend-chip me-1"></span><?php echo htmlspecialchars(_('included'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
-                                <span><span class="legend-chip bg-light me-1"></span><?php echo htmlspecialchars(_('falls on a Sunday'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip sunday me-1"></span><?php echo htmlspecialchars(_('falls on a Sunday'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip bg-info me-1"></span><?php echo htmlspecialchars(_('pivot year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip bg-warning me-1"></span><?php echo htmlspecialchars(_('event not expected'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip deleted me-1"></span><?php echo htmlspecialchars(_('excluded — click to restore'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -320,7 +320,11 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                 diocesanCalendar:    <?php echo json_encode(_('Diocesan Calendar')); ?>,
                 requiredFields:      <?php echo json_encode(_('Please fill in all required fields.')); ?>,
                 denied403:           <?php echo json_encode(_('You do not have permission to perform this action.')); ?>,
-                conflict409:         <?php echo json_encode(_('A test with that name already exists.')); ?>
+                conflict409:         <?php echo json_encode(_('A test with that name already exists.')); ?>,
+                setYear:             <?php echo json_encode(_('set year')); ?>,
+                removeYear:          <?php echo json_encode(_('remove')); ?>,
+                sundayInYear:        <?php echo json_encode(_('In the year %1$s, %2$s falls on a Sunday')); ?>,
+                excludedRestore:     <?php echo json_encode(_('%s excluded — click to restore')); ?>
             }
         };
     </script>

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -209,7 +209,7 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                                 <div class="range-slider__progress"></div>
                             </div>
                             <div class="year-grid mt-2" id="yearGrid"></div>
-                            <div class="d-flex flex-wrap align-items-center column-gap-3 row-gap-1 small text-muted mt-2" id="yearGridLegend">
+                            <div class="d-flex flex-wrap align-items-center gap-3 small text-muted mt-2" id="yearGridLegend">
                                 <span><span class="legend-chip me-1"></span><?php echo htmlspecialchars(_('included'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip sunday me-1"></span><?php echo htmlspecialchars(_('falls on a Sunday'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip bg-info me-1"></span><?php echo htmlspecialchars(_('pivot year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
@@ -329,6 +329,7 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                 denied403:           <?php echo json_encode(_('You do not have permission to perform this action.')); ?>,
                 conflict409:         <?php echo json_encode(_('A test with that name already exists.')); ?>,
                 setYear:             <?php echo json_encode(_('set year')); ?>,
+                toggleAssertion:     <?php echo json_encode(_('toggle assertion')); ?>,
                 removeYear:          <?php echo json_encode(_('remove')); ?>,
                 sundayInYear:        <?php echo json_encode(_('In the year %1$s, %2$s falls on a Sunday')); ?>,
                 excludedRestore:     <?php echo json_encode(_('%s excluded — click to restore')); ?>

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * Admin Tests Management Page
+ *
+ * Allows test_editor / admin users to create, edit, delete, and view
+ * liturgical test definitions via the /tests API. Per-row edit/delete are
+ * gated against the caller's scopes from GET /auth/test-scopes; the API is
+ * the hard backstop.
+ */
+
+include_once 'includes/common.php';
+include_once 'includes/messages.php';
+
+// Require authentication - redirect to home if not logged in
+if (!$authHelper->isAuthenticated) {
+    header('Location: index.php');
+    exit;
+}
+
+// This is an admin page: test editors, global admins, and resource-admins may
+// enter. Per-row gating (below, in JS) governs what each user may change.
+$isGlobalAdmin   = $authHelper->hasRole('admin');
+$hasTestEditor   = $authHelper->hasRole('test_editor');
+$isResourceAdmin = $authHelper->isResourceAdmin();
+
+if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
+    header('Location: admin-dashboard.php');
+    exit;
+}
+
+?>
+<!doctype html>
+<html lang="<?php echo htmlspecialchars($i18n->LOCALE, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+<head>
+    <title><?php
+        $testsTitle    = _('Test Definitions');
+        $calendarTitle = _('Catholic Liturgical Calendar');
+        echo htmlspecialchars($testsTitle, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        echo ' - ';
+        echo htmlspecialchars($calendarTitle, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    ?></title>
+    <?php include_once('./layout/head.php'); ?>
+</head>
+<body class="sb-nav-fixed">
+    <?php include_once('./layout/header.php'); ?>
+
+    <h1 class="h3 mb-4 text-black" style="--bs-text-opacity: .6;">
+        <i class="fas fa-vial me-2 text-info"></i><?php echo htmlspecialchars(_('Test Definitions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+    </h1>
+
+    <p class="text-muted mb-4"><?php
+        echo htmlspecialchars(
+            _('Create, edit, and delete liturgical accuracy test definitions.'),
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8'
+        );
+    ?></p>
+
+    <!-- Filters -->
+    <div class="card shadow mb-4">
+        <div class="card-body">
+            <div class="row g-2 align-items-end">
+                <div class="col-md-4">
+                    <label class="form-label" for="filterTestName">
+                        <?php echo htmlspecialchars(_('Filter by name'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </label>
+                    <input type="text" class="form-control" id="filterTestName" />
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="filterTestScope">
+                        <?php echo htmlspecialchars(_('Filter by scope'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </label>
+                    <input type="text" class="form-control" id="filterTestScope"
+                        placeholder="<?php echo htmlspecialchars(_('USA, diocese id, ...'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>" />
+                </div>
+                <div class="col-md-4 text-end">
+                    <button type="button" class="btn btn-outline-secondary" id="refreshTestsBtn">
+                        <i class="fas fa-rotate"></i> <?php echo htmlspecialchars(_('Refresh'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                    <button type="button" class="btn btn-primary" id="createTestBtn" data-requires-auth>
+                        <i class="fas fa-plus"></i> <?php echo htmlspecialchars(_('New Test'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tests table -->
+    <div class="card shadow mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span><?php echo htmlspecialchars(_('Tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+            <span class="badge bg-secondary" id="testsCount">0</span>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th><?php echo htmlspecialchars(_('Name'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></th>
+                            <th><?php echo htmlspecialchars(_('Event'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></th>
+                            <th><?php echo htmlspecialchars(_('Scope'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></th>
+                            <th><?php echo htmlspecialchars(_('Type'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></th>
+                            <th><?php echo htmlspecialchars(_('Years'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></th>
+                            <th class="text-end"><?php echo htmlspecialchars(_('Actions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody id="testsTableBody"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <!-- Editor modal -->
+    <div class="modal fade" id="testEditorModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="testEditorModalLabel">
+                        <?php echo htmlspecialchars(_('Test Definition'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"
+                        aria-label="<?php echo htmlspecialchars(_('Close'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="testEditorAlerts"></div>
+                    <form id="testEditorForm" novalidate>
+                        <!-- Step 1: test type -->
+                        <div class="mb-3">
+                            <label class="form-label fw-bold">
+                                <?php echo htmlspecialchars(_('Test type'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                            </label>
+                            <div class="btn-group d-flex flex-wrap" role="group" id="testTypeGroup">
+                                <input type="radio" class="btn-check" name="testType" id="tt-exact"
+                                    value="exactCorrespondence" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-exact">
+                                    <i class="fas fa-vial me-1"></i><?php echo htmlspecialchars(_('Exact date'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <input type="radio" class="btn-check" name="testType" id="tt-since"
+                                    value="exactCorrespondenceSince" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-since">
+                                    <i class="fas fa-right-from-bracket me-1"></i><?php echo htmlspecialchars(_('Exact since year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <input type="radio" class="btn-check" name="testType" id="tt-until"
+                                    value="exactCorrespondenceUntil" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-until">
+                                    <i class="fas fa-right-to-bracket me-1"></i><?php echo htmlspecialchars(_('Exact until year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <input type="radio" class="btn-check" name="testType" id="tt-variable"
+                                    value="variableCorrespondence" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-variable">
+                                    <i class="fas fa-square-root-variable me-1"></i><?php echo htmlspecialchars(_('Variable by year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label" for="testName">
+                                    <?php echo htmlspecialchars(_('Name'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <input type="text" class="form-control" id="testName"
+                                    pattern="^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$" required />
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="testScopeType">
+                                    <?php echo htmlspecialchars(_('Scope'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <select class="form-select" id="testScopeType">
+                                    <option value="general_roman_calendar">
+                                        <?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                    </option>
+                                    <option value="national_calendar">
+                                        <?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                    </option>
+                                    <option value="diocesan_calendar">
+                                        <?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                    </option>
+                                </select>
+                                <div id="testScopeIdMount" class="mt-2"></div>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="testEventKey">
+                                    <?php echo htmlspecialchars(_('Liturgical event'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <input type="text" class="form-control" id="testEventKey"
+                                    list="testEventKeyList" required />
+                                <datalist id="testEventKeyList"></datalist>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label" for="testDescription">
+                                    <?php echo htmlspecialchars(_('Description'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <textarea class="form-control" id="testDescription" rows="2" required></textarea>
+                            </div>
+                        </div>
+
+                        <!-- Step 3: year range -->
+                        <div class="mt-3">
+                            <label class="form-label fw-bold">
+                                <?php echo htmlspecialchars(_('Year range'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                            </label>
+                            <div class="range-slider flat" id="yearsRangeSlider"
+                                 style="--min:1970; --max:2050; --value-a:1999; --value-b:2030; --text-value-a:'1999'; --text-value-b:'2030';">
+                                <input type="range" id="lowerRange" min="1970" max="2050" value="1999" />
+                                <output></output>
+                                <input type="range" id="upperRange" min="1970" max="2050" value="2030" />
+                                <output></output>
+                                <div class="range-slider__progress"></div>
+                            </div>
+                            <div class="year-grid mt-2" id="yearGrid"></div>
+                        </div>
+
+                        <!-- Step 4: base date -->
+                        <div class="mt-3 col-md-4">
+                            <label class="form-label" for="baseDate">
+                                <?php echo htmlspecialchars(_('Base date'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                            </label>
+                            <input type="date" class="form-control" id="baseDate"
+                                min="1970-01-01" max="2050-12-31" />
+                        </div>
+
+                        <!-- Step 5: per-year assertions -->
+                        <div class="mt-3">
+                            <label class="form-label fw-bold">
+                                <?php echo htmlspecialchars(_('Per-year assertions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                            </label>
+                            <div id="assertionsContainer"></div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        <?php echo htmlspecialchars(_('Cancel'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                    <button type="button" class="btn btn-primary" id="saveTestBtn" data-requires-auth>
+                        <?php echo htmlspecialchars(_('Save'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Comment modal -->
+    <div class="modal fade" id="testCommentModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        <?php echo htmlspecialchars(_('Assertion comment'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"
+                        aria-label="<?php echo htmlspecialchars(_('Close'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="commentYear" />
+                    <textarea class="form-control" id="commentText" rows="3"></textarea>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        <?php echo htmlspecialchars(_('Cancel'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                    <button type="button" class="btn btn-primary" id="saveCommentBtn">
+                        <?php echo htmlspecialchars(_('Save comment'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Delete modal -->
+    <div class="modal fade" id="deleteTestModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        <?php echo htmlspecialchars(_('Delete Test'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"
+                        aria-label="<?php echo htmlspecialchars(_('Close'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="deleteTestAlerts"></div>
+                    <p id="deleteTestConfirmText"></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                        <?php echo htmlspecialchars(_('Cancel'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                    <button type="button" class="btn btn-danger" id="confirmDeleteTestBtn" data-requires-auth>
+                        <?php echo htmlspecialchars(_('Delete'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Config for JavaScript -->
+    <script>
+        window.AdminTestsConfig = {
+            apiUrl:        <?php echo json_encode($apiBaseUrl); ?>,
+            isGlobalAdmin: <?php echo json_encode($isGlobalAdmin); ?>,
+            hasTestEditor: <?php echo json_encode($hasTestEditor); ?>,
+            locale:        <?php echo json_encode($i18n->LOCALE); ?>,
+            i18n: {
+                loading:             <?php echo json_encode(_('Loading...')); ?>,
+                noTests:             <?php echo json_encode(_('No tests found.')); ?>,
+                failedToLoad:        <?php echo json_encode(_('Failed to load tests. Please try again later.')); ?>,
+                createSuccess:       <?php echo json_encode(_('Test created successfully.')); ?>,
+                updateSuccess:       <?php echo json_encode(_('Test updated successfully.')); ?>,
+                deleteSuccess:       <?php echo json_encode(_('Test deleted successfully.')); ?>,
+                saving:              <?php echo json_encode(_('Saving...')); ?>,
+                deleting:            <?php echo json_encode(_('Deleting...')); ?>,
+                edit:                <?php echo json_encode(_('Edit')); ?>,
+                delete:              <?php echo json_encode(_('Delete')); ?>,
+                confirmDelete:       <?php echo json_encode(_('Are you sure you want to delete the test "%s"?')); ?>,
+                generalRomanCalendar: <?php echo json_encode(_('General Roman Calendar')); ?>,
+                nationalCalendar:    <?php echo json_encode(_('National Calendar')); ?>,
+                diocesanCalendar:    <?php echo json_encode(_('Diocesan Calendar')); ?>,
+                requiredFields:      <?php echo json_encode(_('Please fill in all required fields.')); ?>,
+                denied403:           <?php echo json_encode(_('You do not have permission to perform this action.')); ?>,
+                conflict409:         <?php echo json_encode(_('A test with that name already exists.')); ?>
+            }
+        };
+    </script>
+
+    <?php include_once('./layout/footer.php'); ?>
+</body>
+</html>

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -209,6 +209,13 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                                 <div class="range-slider__progress"></div>
                             </div>
                             <div class="year-grid mt-2" id="yearGrid"></div>
+                            <div class="d-flex flex-wrap align-items-center column-gap-3 row-gap-1 small text-muted mt-2" id="yearGridLegend">
+                                <span><span class="legend-chip me-1"></span><?php echo htmlspecialchars(_('included'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip bg-light me-1"></span><?php echo htmlspecialchars(_('falls on a Sunday'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip bg-info me-1"></span><?php echo htmlspecialchars(_('pivot year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip bg-warning me-1"></span><?php echo htmlspecialchars(_('event not expected'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip deleted me-1"></span><?php echo htmlspecialchars(_('excluded — click to restore'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                            </div>
                         </div>
 
                         <!-- Step 4: base date -->

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -301,7 +301,8 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
             apiUrl:        <?php echo json_encode($apiBaseUrl); ?>,
             isGlobalAdmin: <?php echo json_encode($isGlobalAdmin); ?>,
             hasTestEditor: <?php echo json_encode($hasTestEditor); ?>,
-            locale:        <?php echo json_encode($i18n->LOCALE); ?>,
+            <?php // BCP-47 (en-US), not gettext/ICU (en_US): Intl.DateTimeFormat rejects underscore tags. ?>
+            locale:        <?php echo json_encode(str_replace('_', '-', $i18n->LOCALE)); ?>,
             i18n: {
                 loading:             <?php echo json_encode(_('Loading...')); ?>,
                 noTests:             <?php echo json_encode(_('No tests found.')); ?>,

--- a/admin-tests.php
+++ b/admin-tests.php
@@ -210,7 +210,7 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                             </div>
                             <div class="year-grid mt-2" id="yearGrid"></div>
                             <div class="d-flex flex-wrap align-items-center gap-3 small text-muted mt-2" id="yearGridLegend">
-                                <span><span class="legend-chip me-1"></span><?php echo htmlspecialchars(_('included'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip me-1"></span><?php echo htmlspecialchars(_('event expected'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip sunday me-1"></span><?php echo htmlspecialchars(_('falls on a Sunday'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip bg-info me-1"></span><?php echo htmlspecialchars(_('pivot year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip bg-warning me-1"></span><?php echo htmlspecialchars(_('event not expected'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>

--- a/assets/css/admin-tests.css
+++ b/assets/css/admin-tests.css
@@ -82,3 +82,13 @@
     height: 1.25rem;
     border: none;
 }
+
+/* Sunday marker: additive upright cross drawn as a background-image so it
+   layers OVER the semantic background colors (beige/info/warning) instead of
+   competing with them in a precedence chain. */
+.year-grid .testYearSpan.sunday,
+.legend-chip.sunday {
+    background-image:
+        linear-gradient(to right, transparent 44%, rgba(220, 53, 69, 0.3) 44%, rgba(220, 53, 69, 0.3) 56%, transparent 56%),
+        linear-gradient(to bottom, transparent 44%, rgba(220, 53, 69, 0.3) 44%, rgba(220, 53, 69, 0.3) 56%, transparent 56%);
+}

--- a/assets/css/admin-tests.css
+++ b/assets/css/admin-tests.css
@@ -1,0 +1,42 @@
+@import url('multi-range-slider.css');
+
+/* Per-year assertion cards: native CSS grid (replaces Isotope fitRows). */
+.assertions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.5rem;
+}
+
+.assertion-card {
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+.assertion-card .assertionText {
+    resize: vertical;
+}
+
+/* Year-range overview grid (Sundays / excluded / pivot shading). */
+.year-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.year-grid .testYearSpan {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.25rem;
+    cursor: default;
+    user-select: none;
+}
+
+.year-grid .testYearSpan.deleted {
+    opacity: 0.3;
+}
+
+.btn-xs {
+    padding: 0.1rem 0.3rem;
+    font-size: 0.75rem;
+    line-height: 1.2;
+}

--- a/assets/css/admin-tests.css
+++ b/assets/css/admin-tests.css
@@ -1,4 +1,4 @@
-@import url('multi-range-slider.css');
+@import 'multi-range-slider.css';
 
 /* Per-year assertion cards: native CSS grid (replaces Isotope fitRows). */
 .assertions-grid {

--- a/assets/css/admin-tests.css
+++ b/assets/css/admin-tests.css
@@ -61,6 +61,24 @@
     opacity: 1 !important;
 }
 
+/* Pivot hammer (Since/Until only — spec R6): the pivot is an EXCLUSIVE state
+   (one per test), so the affordance reveals on span hover instead of sitting
+   on all thirty spans. Opacity (not display) keeps span geometry stable and
+   leaves the icon a functional tap target on touch devices. !important beats
+   Bootstrap's opacity-50 utility. The variable-type fa-repeat icon is per-year
+   state and stays always visible. */
+.year-grid .testYearSpan .hammerYear.fa-hammer {
+    opacity: 0 !important;
+}
+
+.year-grid .testYearSpan:hover .hammerYear.fa-hammer {
+    opacity: 0.5 !important;
+}
+
+.year-grid .testYearSpan .hammerYear.fa-hammer:hover {
+    opacity: 1 !important;
+}
+
 .btn-xs {
     padding: 0.1rem 0.3rem;
     font-size: 0.75rem;

--- a/assets/css/admin-tests.css
+++ b/assets/css/admin-tests.css
@@ -31,8 +31,34 @@
     user-select: none;
 }
 
+.year-grid .testYearSpan.deleted,
+.legend-chip.deleted {
+    background: repeating-linear-gradient(
+        45deg,
+        red,
+        red 5px,
+        white 8px,
+        white 12px
+    );
+    cursor: not-allowed;
+}
+
+/* The base .testYearSpan padding stays in effect, so the clickable area is
+   ~19px wide even though the visible stripe content is 3px (same as the
+   original, where the 3px width sat inside the span's 3px/5px padding). */
 .year-grid .testYearSpan.deleted {
-    opacity: 0.3;
+    width: 3px;
+    height: 32px;
+}
+
+.year-grid .testYearSpan .hammerYear,
+.year-grid .testYearSpan .removeYear {
+    cursor: pointer;
+}
+
+.year-grid .testYearSpan .hammerYear:hover,
+.year-grid .testYearSpan .removeYear:hover {
+    opacity: 1 !important;
 }
 
 .btn-xs {

--- a/assets/css/admin-tests.css
+++ b/assets/css/admin-tests.css
@@ -66,3 +66,19 @@
     font-size: 0.75rem;
     line-height: 1.2;
 }
+
+/* Legend chips reuse the exact grid classes so legend and grid cannot drift. */
+.legend-chip {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.25rem;
+    vertical-align: text-bottom;
+}
+
+.legend-chip.deleted {
+    width: 5px;
+    height: 1.25rem;
+    border: none;
+}

--- a/assets/css/multi-range-slider.css
+++ b/assets/css/multi-range-slider.css
@@ -1,0 +1,313 @@
+/**
+ * inspired by https://github.com/yairEO/ui-range
+ */
+@charset "UTF-8";
+.range-slider.flat {
+  --thumb-size: 25px;
+  --track-height: calc(var(--thumb-size) / 3);
+  --progress-shadow: none;
+  --progress-flll-shadow: none;
+  --thumb-shadow: 0 0 0 7px var(--primary-color) inset, 0 0 0 99px white inset;
+  --thumb-shadow-hover: 0 0 0 9px var(--primary-color) inset,
+      0 0 0 99px white inset;
+  --thumb-shadow-active: 0 0 0 13px var(--primary-color) inset;
+  --min:1970;
+  --max:2050;
+  --value-a:1999;
+  --value-b:2030;
+  --text-value-a:"1999";
+  --text-value-b:"2030";
+  --suffix:"";
+}
+
+.range-slider {
+  --primary-color: #0366d6;
+  --value-offset-y: var(--ticks-gap);
+  --value-active-color: white;
+  --value-background: transparent;
+  --value-background-hover: var(--primary-color);
+  --value-font: 700 12px/1 Arial;
+  --fill-color: var(--primary-color);
+  --progress-background: #eee;
+  --progress-radius: 20px;
+  --track-height: calc(var(--thumb-size) / 2);
+  --min-max-font: 12px Arial;
+  --min-max-opacity: 0.5;
+  --min-max-x-offset: 10%; /* 50% to center */
+  --thumb-size: 22px;
+  --thumb-color: white;
+  --thumb-shadow: 0 0 3px rgba(0, 0, 0, 0.4), 0 0 1px rgba(0, 0, 0, 0.5) inset,
+      0 0 0 99px var(--thumb-color) inset;
+  --thumb-shadow-active: 0 0 0 calc(var(--thumb-size) / 4) inset
+      var(--thumb-color),
+      0 0 0 99px var(--primary-color) inset, 0 0 3px rgba(0, 0, 0, 0.4);
+  --thumb-shadow-hover: var(--thumb-shadow);
+  --ticks-thickness: 1px;
+  --ticks-height: 5px;
+  --ticks-gap: var(
+      --ticks-height,
+      0
+  ); /* vertical space between the ticks and the progress bar */
+  --ticks-color: silver;
+  /* ⚠️ BELOW VARIABLES SHOULD NOT BE CHANGED */
+  --step: 1;
+  --ticks-count: Calc(var(--max) - var(--min)) / var(--step);
+  --maxTicksAllowed: 30;
+  --too-many-ticks: Min(1, Max(var(--ticks-count) - var(--maxTicksAllowed), 0));
+  --x-step: Max(
+      var(--step),
+      var(--too-many-ticks) * (var(--max) - var(--min))
+  ); /* manipulate the number of steps if too many ticks exist, so there would only be 2 */
+  --tickInterval: 100/ ((var(--max) - var(--min)) / var(--step)) * var(--tickEvery, 1);
+  --tickIntervalPerc: calc(
+      (100% - var(--thumb-size)) / ((var(--max) - var(--min)) / var(--x-step)) *
+      var(--tickEvery, 1)
+  );
+  --value-a: Clamp(
+      var(--min),
+      var(--value, 0),
+      var(--max)
+  ); /* default value ("--value" is used in single-range markup) */
+  --value-b: var(--value, 0); /* default value */
+  --text-value-a: var(--text-value, "");
+  --completed-a: calc(
+      (var(--value-a) - var(--min)) / (var(--max) - var(--min)) * 100
+  );
+  --completed-b: calc(
+      (var(--value-b) - var(--min)) / (var(--max) - var(--min)) * 100
+  );
+  --ca: Min(var(--completed-a), var(--completed-b));
+  --cb: Max(var(--completed-a), var(--completed-b));
+  /* breakdown of the below super-complex brain-breaking CSS math:
+  /* "clamp" is used to ensure either "-1" or "1"
+  /* "calc" is used to inflat the outcome into a huge number, to get rid of any value between -1 & 1
+  /* if absolute diff of both completed % is above "5" (%)
+  /* ".001" bumps the value just a bit, to avoid a scenario where calc resulted in "0" (then clamp will also be "0")
+  */
+  --thumbs-too-close: Clamp(
+      -1,
+      1000 * (Min(1, Max(var(--cb) - var(--ca) - 5, -1)) + 0.001),
+      1
+  );
+  --thumb-close-to-min: Min(1, Max(var(--ca) - 2, 0)); /* 2% threshold */
+  --thumb-close-to-max: Min(1, Max(98 - var(--cb), 0)); /* 2% threshold */
+  display: inline-block;
+  height: max(var(--track-height), var(--thumb-size));
+  /* margin: calc((var(--thumb-size) - var(--track-height)) * -.25) var(--thumb-size) 0; */
+  background: linear-gradient(to right, var(--ticks-color) var(--ticks-thickness), transparent 1px) repeat-x;
+  background-size: var(--tickIntervalPerc) var(--ticks-height);
+  background-position-x: calc(var(--thumb-size) / 2 - var(--ticks-thickness) / 2);
+  background-position-y: var(--flip-y, bottom);
+  padding-bottom: var(--flip-y, var(--ticks-gap));
+  padding-top: calc(var(--flip-y) * var(--ticks-gap));
+  position: relative;
+  z-index: 1;
+  /* mix/max texts */
+}
+.range-slider[data-ticks-position=top] {
+  --flip-y: 1;
+}
+.range-slider::before, .range-slider::after {
+  --offset: calc(var(--thumb-size) / 2);
+  content: counter(x);
+  display: var(--show-min-max, block);
+  font: var(--min-max-font);
+  position: absolute;
+  bottom: var(--flip-y, -2.5ch);
+  top: calc(-2.5ch * var(--flip-y));
+  opacity: clamp(0, var(--at-edge), var(--min-max-opacity));
+  transform: translateX(calc(var(--min-max-x-offset) * var(--before, -1) * -1)) scale(var(--at-edge));
+  pointer-events: none;
+}
+.range-slider::before {
+  --before: 1;
+  --at-edge: var(--thumb-close-to-min);
+  counter-reset: x var(--min);
+  left: var(--offset);
+}
+.range-slider::after {
+  --at-edge: var(--thumb-close-to-max);
+  counter-reset: x var(--max);
+  right: var(--offset);
+}
+.range-slider__values {
+  position: relative;
+  top: 50%;
+  line-height: 0;
+  text-align: justify;
+  width: 100%;
+  pointer-events: none;
+  margin: 0 auto;
+  z-index: 5;
+  /* trick so "justify" will work */
+}
+.range-slider__values::after {
+  content: "";
+  width: 100%;
+  display: inline-block;
+  height: 0;
+  background: red;
+}
+.range-slider__progress {
+  --start-end: calc(var(--thumb-size) / 2);
+  --clip-end: calc(100% - (var(--cb)) * 1%);
+  --clip-start: calc(var(--ca) * 1%);
+  --clip: inset(-20px var(--clip-end) -20px var(--clip-start));
+  position: absolute;
+  left: var(--start-end);
+  right: var(--start-end);
+  top: calc(var(--ticks-gap) * var(--flip-y, 0) + var(--thumb-size) / 2 - var(--track-height) / 2);
+  /*  transform: var(--flip-y, translateY(-50%) translateZ(0)); */
+  height: calc(var(--track-height));
+  background: var(--progress-background, #eee);
+  pointer-events: none;
+  z-index: -1;
+  border-radius: var(--progress-radius);
+  /* fill area */
+  /* shadow-effect */
+}
+.range-slider__progress::before {
+  content: "";
+  position: absolute;
+  /* left: Clamp(0%, calc(var(--ca) * 1%), 100%); // confine to 0 or above */
+  /* width: Min(100%, calc((var(--cb) - var(--ca)) * 1%)); // confine to maximum 100% */
+  left: 0;
+  right: 0;
+  clip-path: var(--clip);
+  top: 0;
+  bottom: 0;
+  background: var(--fill-color, black);
+  box-shadow: var(--progress-flll-shadow);
+  z-index: 1;
+  border-radius: inherit;
+}
+.range-slider__progress::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  box-shadow: var(--progress-shadow);
+  pointer-events: none;
+  border-radius: inherit;
+}
+.range-slider > input {
+  -webkit-appearance: none;
+  width: 100%;
+  height: var(--thumb-size);
+  margin: 0;
+  position: absolute;
+  left: 0;
+  top: calc(50% - max(var(--track-height), var(--thumb-size)) / 2 + var(--ticks-gap) / 2 * var(--flip-y, -1));
+  cursor: -webkit-grab;
+  cursor: grab;
+  outline: none;
+  background: none;
+  /* non-multiple range should not clip start of progress bar */
+}
+.range-slider > input:not(:only-of-type) {
+  pointer-events: none;
+}
+.range-slider > input::-webkit-slider-thumb {
+  appearance: none;
+  height: var(--thumb-size);
+  width: var(--thumb-size);
+  transform: var(--thumb-transform);
+  border-radius: var(--thumb-radius, 50%);
+  background: var(--thumb-color);
+  box-shadow: var(--thumb-shadow);
+  border: none;
+  pointer-events: auto;
+  transition: 0.1s;
+}
+.range-slider > input::-moz-range-thumb {
+  appearance: none;
+  height: var(--thumb-size);
+  width: var(--thumb-size);
+  transform: var(--thumb-transform);
+  border-radius: var(--thumb-radius, 50%);
+  background: var(--thumb-color);
+  box-shadow: var(--thumb-shadow);
+  border: none;
+  pointer-events: auto;
+  transition: 0.1s;
+}
+.range-slider > input::-ms-thumb {
+  appearance: none;
+  height: var(--thumb-size);
+  width: var(--thumb-size);
+  transform: var(--thumb-transform);
+  border-radius: var(--thumb-radius, 50%);
+  background: var(--thumb-color);
+  box-shadow: var(--thumb-shadow);
+  border: none;
+  pointer-events: auto;
+  transition: 0.1s;
+}
+.range-slider > input:hover {
+  --thumb-shadow: var(--thumb-shadow-hover);
+}
+.range-slider > input:hover + output {
+  --value-background: var(--value-background-hover);
+  --y-offset: -5px;
+  color: var(--value-active-color);
+  box-shadow: 0 0 0 3px var(--value-background);
+}
+.range-slider > input:active {
+  --thumb-shadow: var(--thumb-shadow-active);
+  cursor: grabbing;
+  z-index: 2; /* when sliding left thumb over the right or vice-versa, make sure the moved thumb is on top */
+}
+.range-slider > input:active + output {
+  transition: 0s;
+}
+.range-slider > input:nth-of-type(1) {
+  --is-left-most: Clamp(0, (var(--value-a) - var(--value-b)) * 99999, 1);
+}
+.range-slider > input:nth-of-type(1) + output {
+  --value: var(--value-a);
+  --x-offset: calc(var(--completed-a) * -1%);
+}
+.range-slider > input:nth-of-type(1) + output:not(:only-of-type) {
+  --flip: calc(var(--thumbs-too-close) * -1);
+}
+.range-slider > input:nth-of-type(1) + output::after {
+  content: var(--prefix, "") var(--text-value-a) var(--suffix, "");
+}
+.range-slider > input:nth-of-type(2) {
+  --is-left-most: Clamp(0, (var(--value-b) - var(--value-a)) * 99999, 1);
+}
+.range-slider > input:nth-of-type(2) + output {
+  --value: var(--value-b);
+}
+.range-slider > input:only-of-type ~ .range-slider__progress {
+  --clip-start: 0;
+}
+.range-slider > input + output {
+  --flip: -1;
+  --x-offset: calc(var(--completed-b) * -1%);
+  --pos: calc(
+      ((var(--value) - var(--min)) / (var(--max) - var(--min))) * 100%
+  );
+  pointer-events: none;
+  position: absolute;
+  z-index: 5;
+  background: var(--value-background);
+  border-radius: 10px;
+  padding: 2px 4px;
+  left: var(--pos);
+  transform: translate(var(--x-offset), calc(150% * var(--flip) - (var(--y-offset, 0px) + var(--value-offset-y)) * var(--flip)));
+  transition: all 0.12s ease-out, left 0s;
+}
+.range-slider > input + output::after {
+  content: var(--prefix, "") var(--text-value-b) var(--suffix, "");
+  font: var(--value-font);
+}
+
+.range-slider {
+  /*width: clamp(300px, 50vw, 800px);*/
+  width: 99%;
+  min-width: 200px;
+  margin-top: 25px;
+}

--- a/assets/css/multi-range-slider.css
+++ b/assets/css/multi-range-slider.css
@@ -21,6 +21,11 @@
 }
 
 .range-slider {
+  /* merged from the trailing duplicate .range-slider block (CodeFactor: no-duplicate-selectors) */
+  /*width: clamp(300px, 50vw, 800px);*/
+  width: 99%;
+  min-width: 200px;
+  margin-top: 25px;
   --primary-color: #0366d6;
   --value-offset-y: var(--ticks-gap);
   --value-active-color: white;
@@ -200,7 +205,6 @@
   position: absolute;
   left: 0;
   top: calc(50% - max(var(--track-height), var(--thumb-size)) / 2 + var(--ticks-gap) / 2 * var(--flip-y, -1));
-  cursor: -webkit-grab;
   cursor: grab;
   outline: none;
   background: none;
@@ -303,11 +307,4 @@
 .range-slider > input + output::after {
   content: var(--prefix, "") var(--text-value-b) var(--suffix, "");
   font: var(--value-font);
-}
-
-.range-slider {
-  /*width: clamp(300px, 50vw, 800px);*/
-  width: 99%;
-  min-width: 200px;
-  margin-top: 25px;
 }

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -262,32 +262,28 @@ export class AssertionsBuilder {
     }
 
     /**
-     * Exclude a year from the test: record it in model.excludes (sorted,
-     * deduped) and drop its assertion. No-op if the year has no assertion.
+     * Exclude a year from the test by removing its assertion. Assertion
+     * absence is the single source of truth for year exclusion — model.excludes
+     * (a calendar-scope field, not a year list) is never mutated here.
+     * Chainable; no-op when the year has no assertion (including double-exclude).
      */
     excludeYear(year) {
         const y = Number(year);
         if (!this.model.assertions.some((a) => a.year === y)) return this;
-        const current = this.model.excludes ?? [];
-        if (!current.includes(y)) {
-            this.model.excludes = [...current, y].sort((a, b) => a - b);
-        }
         this.model.assertions = this.model.assertions.filter((a) => a.year !== y);
         return this;
     }
 
     /**
-     * Restore a previously excluded year, re-creating its assertion with the
-     * same rules generate() uses (pivot- and baseMonthDay-aware). excludes
-     * returns to null when the last exclusion is removed, so serialize()
-     * drops the key. No-op if the year is not excluded.
+     * Restore a year by creating its assertion with the same rules generate()
+     * uses (pivot- and baseMonthDay-aware). No-op when the year already has
+     * an assertion (assertion presence IS inclusion). Chainable. model.excludes
+     * is never mutated.
      */
     includeYear(year) {
         const y = Number(year);
-        const current = this.model.excludes ?? [];
-        if (!current.includes(y)) return this;
-        const remaining = current.filter((x) => x !== y);
-        this.model.excludes = remaining.length ? remaining : null;
+        // No-op if the year already has an assertion — assertion presence IS inclusion.
+        if (this.model.assertions.some((a) => a.year === y)) return this;
 
         let notExists = false;
         if (this.model.test_type === TestType.ExactCorrespondenceSince && this.model.year_since !== null) {

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -188,4 +188,71 @@ export class AssertionsBuilder {
         this.model.assertions = assertions;
         return this;
     }
+
+    #find(year) {
+        return this.model.assertions.find((a) => a.year === year) ?? null;
+    }
+
+    toggleAssert(year) {
+        const a = this.#find(year);
+        if (!a) return this;
+        if (a.assert === AssertType.EventTypeExact) {
+            a.assert = AssertType.EventNotExists;
+            a.expected_value = null;
+            a.assertion = a.assertion.replace('should fall on', 'should not exist on');
+        } else {
+            a.assert = AssertType.EventTypeExact;
+            if (this.baseMonthDay) {
+                a.expected_value = AssertionsBuilder.#expectedValue(year, this.baseMonthDay.month, this.baseMonthDay.day);
+            }
+            a.assertion = a.assertion.replace('should not exist on', 'should fall on');
+        }
+        return this;
+    }
+
+    setExpectedDate(year, iso) {
+        const a = this.#find(year);
+        if (a) a.expected_value = iso;
+        return this;
+    }
+
+    setAssertionText(year, text) {
+        const a = this.#find(year);
+        if (a) a.assertion = text;
+        return this;
+    }
+
+    setComment(year, text) {
+        const a = this.#find(year);
+        if (!a) return this;
+        if (text === '' || text === null || text === undefined) {
+            delete a.comment;
+        } else {
+            a.comment = text;
+        }
+        return this;
+    }
+
+    excludeYear(year) {
+        this.model.assertions = this.model.assertions.filter((a) => a.year !== year);
+        return this;
+    }
+
+    setPivot(year) {
+        if (this.model.test_type === TestType.ExactCorrespondenceSince) {
+            this.model.year_since = year;
+        } else if (this.model.test_type === TestType.ExactCorrespondenceUntil) {
+            this.model.year_until = year;
+        }
+        this.model.assertions.forEach((a) => {
+            const notExists = this.model.test_type === TestType.ExactCorrespondenceSince
+                ? a.year < year
+                : a.year > year;
+            const isNot = a.assert === AssertType.EventNotExists;
+            if (notExists !== isNot) {
+                this.toggleAssert(a.year);
+            }
+        });
+        return this;
+    }
 }

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -1,0 +1,43 @@
+/**
+ * State-first Assertions Builder for the admin-tests editor.
+ * The in-memory model is the single source of truth; serialize() reads the
+ * model, never the DOM. Ported from UnitTestInterface (Isotope removed,
+ * contenteditable replaced by <textarea>).
+ * @module AssertionsBuilder
+ */
+
+export const TestType = Object.freeze({
+    ExactCorrespondence:      'exactCorrespondence',
+    ExactCorrespondenceSince: 'exactCorrespondenceSince',
+    ExactCorrespondenceUntil: 'exactCorrespondenceUntil',
+    VariableCorrespondence:   'variableCorrespondence',
+});
+
+export const AssertType = Object.freeze({
+    EventNotExists: 'eventNotExists',
+    EventTypeExact: 'eventExists AND hasExpectedDate',
+});
+
+export const LitGrade = Object.freeze({
+    WEEKDAY: 0, COMMEMORATION: 1, OPTIONAL_MEMORIAL: 2, MEMORIAL: 3,
+    FEAST: 4, FEAST_OF_THE_LORD: 5, SOLEMNITY: 6, HIGHER_SOLEMNITY: 7,
+    stringVals: ['weekday', 'commemoration', 'optional memorial', 'Memorial',
+        'FEAST', 'FEAST OF THE LORD', 'SOLEMNITY', 'HIGHER SOLEMNITY'],
+    toString: (n) => LitGrade.stringVals[parseInt(n, 10)],
+});
+
+/**
+ * A single per-year assertion. `comment` is only set when non-empty so it is
+ * omitted from serialization (matching the schema's optional `comment`).
+ */
+export class Assertion {
+    constructor(year, expected_value, assert, assertion, comment = null) {
+        this.year = year;
+        this.expected_value = expected_value;
+        this.assert = assert;
+        this.assertion = assertion;
+        if (comment !== null && comment !== '') {
+            this.comment = comment;
+        }
+    }
+}

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -77,9 +77,14 @@ export class AssertionsBuilder {
         this.model.excludes = def.excludes ?? null;
         this.model.year_since = def.year_since ?? null;
         this.model.year_until = def.year_until ?? null;
-        this.model.assertions = (def.assertions ?? []).map(
-            (a) => new Assertion(a.year, a.expected_value, a.assert, a.assertion, a.comment ?? null)
-        );
+        // Normalize to year order (spec R4): the corpus does not guarantee it
+        // (some definitions group assertions by assert type), and the model
+        // invariant is "assertions are always year-ordered" — generate()
+        // produces sorted output and includeYear() maintains it. This also
+        // keeps #deriveBaseMonthDay's earliest-year tiebreak honest.
+        this.model.assertions = (def.assertions ?? [])
+            .map((a) => new Assertion(a.year, a.expected_value, a.assert, a.assertion, a.comment ?? null))
+            .sort((a, b) => a.year - b.year);
         this.baseMonthDay = AssertionsBuilder.#deriveBaseMonthDay(this.model.assertions);
         return this;
     }

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -128,4 +128,64 @@ export class AssertionsBuilder {
         if (Number.isNaN(d.getTime())) return null;
         return { month: d.getUTCMonth() + 1, day: d.getUTCDate() };
     }
+
+    /** Build description text from an event, e.g. "The Memorial of 'X' should fall on July 31". */
+    static #describe(event, locale) {
+        const grade = event.grade_lcl ?? '';
+        let onDate = 'the expected date';
+        if (event.month && event.day) {
+            const d = new Date(Date.UTC(1970, Number(event.month) - 1, Number(event.day)));
+            onDate = new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric', timeZone: 'UTC' }).format(d);
+        }
+        return `The ${grade} of '${event.name}' should fall on ${onDate}`;
+    }
+
+    /** RFC 3339 UTC-midnight string for an event's month/day in a given year. */
+    static #expectedValue(year, month, day) {
+        const iso = new Date(Date.UTC(year, Number(month) - 1, Number(day))).toISOString();
+        return `${iso.split('T')[0]}T00:00:00+00:00`;
+    }
+
+    /**
+     * Rebuild the assertions array from an event, a year range, and the test type.
+     * @param {{event:object, minYear:number, maxYear:number, pivotYear?:number|null, excludedYears?:number[]}} opts
+     */
+    generate({ event, minYear, maxYear, pivotYear = null, excludedYears = [] }) {
+        this.event = event;
+        this.baseMonthDay = (event.month && event.day)
+            ? { month: Number(event.month), day: Number(event.day) }
+            : null;
+        const description = AssertionsBuilder.#describe(event, this.locale);
+        this.model.description = description;
+        this.model.event_key = event.event_key;
+
+        this.model.year_since = null;
+        this.model.year_until = null;
+        if (this.model.test_type === TestType.ExactCorrespondenceSince) {
+            this.model.year_since = pivotYear;
+        } else if (this.model.test_type === TestType.ExactCorrespondenceUntil) {
+            this.model.year_until = pivotYear;
+        }
+
+        const notExistsAssertion = description.replace('should fall on', 'should not exist on');
+        const excluded = new Set(excludedYears.map(Number));
+        const assertions = [];
+        for (let year = minYear; year <= maxYear; year++) {
+            if (excluded.has(year)) continue;
+            let notExists = false;
+            if (this.model.test_type === TestType.ExactCorrespondenceSince && pivotYear !== null) {
+                notExists = year < pivotYear;
+            } else if (this.model.test_type === TestType.ExactCorrespondenceUntil && pivotYear !== null) {
+                notExists = year > pivotYear;
+            }
+            if (notExists || !this.baseMonthDay) {
+                assertions.push(new Assertion(year, null, AssertType.EventNotExists, notExistsAssertion));
+            } else {
+                const ev = AssertionsBuilder.#expectedValue(year, this.baseMonthDay.month, this.baseMonthDay.day);
+                assertions.push(new Assertion(year, ev, AssertType.EventTypeExact, description));
+            }
+        }
+        this.model.assertions = assertions;
+        return this;
+    }
 }

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -56,7 +56,11 @@ const EMPTY_MODEL = () => ({
 
 export class AssertionsBuilder {
     constructor({ locale = 'en' } = {}) {
-        this.locale = locale;
+        // Normalize gettext/ICU-style locales (en_US) to BCP-47 (en-US):
+        // Intl.DateTimeFormat throws a RangeError on underscore tags, and the
+        // page locale originates from PHP's \Locale::acceptFromHttp(), which
+        // returns the underscore form.
+        this.locale = (locale || 'en').replace(/_/g, '-');
         this.model = EMPTY_MODEL();
         this.baseMonthDay = null;
         this.event = null;

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -196,16 +196,22 @@ export class AssertionsBuilder {
     toggleAssert(year) {
         const a = this.#find(year);
         if (!a) return this;
+        // Rebuild the sentence from the canonical description (set by
+        // generate()/load()), never from a.assertion: the per-year text is
+        // user-editable via setAssertionText, so substring replacement on it
+        // silently no-ops once an editor rewrites the phrase, desyncing the
+        // text from assert/expected_value. Toggling always restores canon.
+        const canonical = this.model.description || a.assertion;
         if (a.assert === AssertType.EventTypeExact) {
             a.assert = AssertType.EventNotExists;
             a.expected_value = null;
-            a.assertion = a.assertion.replace('should fall on', 'should not exist on');
+            a.assertion = canonical.replace('should fall on', 'should not exist on');
         } else {
             a.assert = AssertType.EventTypeExact;
             if (this.baseMonthDay) {
                 a.expected_value = AssertionsBuilder.#expectedValue(year, this.baseMonthDay.month, this.baseMonthDay.day);
             }
-            a.assertion = a.assertion.replace('should not exist on', 'should fall on');
+            a.assertion = canonical.replace('should not exist on', 'should fall on');
         }
         return this;
     }

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -41,3 +41,91 @@ export class Assertion {
         }
     }
 }
+
+const EMPTY_MODEL = () => ({
+    name: '',
+    event_key: '',
+    description: '',
+    test_type: TestType.ExactCorrespondence,
+    applies_to: null,
+    excludes: null,
+    year_since: null,
+    year_until: null,
+    assertions: [],
+});
+
+export class AssertionsBuilder {
+    constructor({ locale = 'en' } = {}) {
+        this.locale = locale;
+        this.model = EMPTY_MODEL();
+        this.baseMonthDay = null;
+        this.event = null;
+    }
+
+    /** Populate the model from an existing LitCalTest definition. */
+    load(def) {
+        this.model = EMPTY_MODEL();
+        this.model.name = def.name ?? '';
+        this.model.event_key = def.event_key ?? '';
+        this.model.description = def.description ?? '';
+        this.model.test_type = def.test_type ?? TestType.ExactCorrespondence;
+        this.model.applies_to = def.applies_to ?? null;
+        this.model.excludes = def.excludes ?? null;
+        this.model.year_since = def.year_since ?? null;
+        this.model.year_until = def.year_until ?? null;
+        this.model.assertions = (def.assertions ?? []).map(
+            (a) => new Assertion(a.year, a.expected_value, a.assert, a.assertion, a.comment ?? null)
+        );
+        this.baseMonthDay = AssertionsBuilder.#deriveBaseMonthDay(this.model.assertions);
+        return this;
+    }
+
+    /** Update editor-form metadata (never touches the assertions array). */
+    setMeta({ name, event_key, description, test_type, applies_to, excludes } = {}) {
+        if (name !== undefined) this.model.name = name;
+        if (event_key !== undefined) this.model.event_key = event_key;
+        if (description !== undefined) this.model.description = description;
+        if (test_type !== undefined) this.model.test_type = test_type;
+        if (applies_to !== undefined) this.model.applies_to = applies_to;
+        if (excludes !== undefined) this.model.excludes = excludes;
+        return this;
+    }
+
+    /** Produce a schema-valid LitCalTest object from the model. */
+    serialize() {
+        const m = this.model;
+        const out = {
+            name: m.name,
+            event_key: m.event_key,
+            description: m.description,
+            test_type: m.test_type,
+        };
+        if (m.applies_to) out.applies_to = m.applies_to;
+        if (m.excludes) out.excludes = m.excludes;
+        if (m.test_type === TestType.ExactCorrespondenceSince && m.year_since !== null) {
+            out.year_since = m.year_since;
+        }
+        if (m.test_type === TestType.ExactCorrespondenceUntil && m.year_until !== null) {
+            out.year_until = m.year_until;
+        }
+        out.assertions = m.assertions.map((a) => {
+            const item = {
+                year: a.year,
+                expected_value: a.expected_value,
+                assert: a.assert,
+                assertion: a.assertion,
+            };
+            if ('comment' in a) item.comment = a.comment;
+            return item;
+        });
+        return out;
+    }
+
+    static #deriveBaseMonthDay(assertions) {
+        const first = assertions.find((a) => a.expected_value);
+        if (!first) return null;
+        const d = new Date(first.expected_value);
+        if (Number.isNaN(d.getTime())) return null;
+        return { month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+    }
+}

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -255,4 +255,91 @@ export class AssertionsBuilder {
         });
         return this;
     }
+
+    #formatDate(iso) {
+        if (!iso) return '---';
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return '---';
+        return new Intl.DateTimeFormat(this.locale, { dateStyle: 'medium', timeZone: 'UTC' }).format(d);
+    }
+
+    render(container) {
+        container.innerHTML = '';
+        container.classList.add('assertions-grid');
+
+        this.model.assertions.forEach((a) => {
+            const notExists = a.assert === AssertType.EventNotExists;
+            const bg = notExists ? 'bg-warning' : 'bg-success';
+            const fg = notExists ? 'text-dark' : 'text-white';
+
+            const card = document.createElement('div');
+            card.className = `assertion-card d-flex flex-column border ${bg} ${fg}`;
+            card.dataset.year = String(a.year);
+
+            const yearP = document.createElement('p');
+            yearP.className = 'text-center mb-0 fw-bold testYear';
+            yearP.textContent = String(a.year);
+            card.appendChild(yearP);
+
+            // ASSERT THAT row
+            const assertRow = document.createElement('div');
+            assertRow.className = 'd-flex justify-content-between align-items-center px-1 border-bottom';
+            const assertLabel = document.createElement('span');
+            assertLabel.className = 'fw-bold small';
+            assertLabel.textContent = 'ASSERT:';
+            const assertVal = document.createElement('span');
+            assertVal.className = 'assert small text-end';
+            assertVal.textContent = a.assert;
+            const toggleBtn = document.createElement('button');
+            toggleBtn.type = 'button';
+            toggleBtn.className = 'btn btn-xs btn-danger ms-1 toggleAssert';
+            toggleBtn.innerHTML = '<i class="fas fa-repeat" aria-hidden="true"></i>';
+            assertRow.append(assertLabel, assertVal, toggleBtn);
+            card.appendChild(assertRow);
+
+            // EXPECT VALUE row
+            const dateRow = document.createElement('div');
+            dateRow.className = 'd-flex justify-content-between align-items-center px-1 border-bottom';
+            const dateLabel = document.createElement('span');
+            dateLabel.className = 'fw-bold small';
+            dateLabel.textContent = 'DATE:';
+            const dateVal = document.createElement('span');
+            dateVal.className = 'expectedValue small';
+            dateVal.setAttribute('data-value', a.expected_value ?? '');
+            dateVal.textContent = this.#formatDate(a.expected_value);
+            const editBtn = document.createElement('button');
+            editBtn.type = 'button';
+            editBtn.className = `btn btn-xs editDate ms-1${a.expected_value ? ' btn-danger' : ' btn-secondary disabled'}`;
+            editBtn.disabled = !a.expected_value;
+            editBtn.innerHTML = '<i class="fas fa-pen-to-square" aria-hidden="true"></i>';
+            dateRow.append(dateLabel, dateVal, editBtn);
+            card.appendChild(dateRow);
+
+            // ASSERTION textarea + comment button
+            const textRow = document.createElement('div');
+            textRow.className = 'd-flex flex-column p-1';
+            const textHeader = document.createElement('div');
+            textHeader.className = 'd-flex justify-content-between align-items-center';
+            const textLabel = document.createElement('span');
+            textLabel.className = 'fw-bold small';
+            textLabel.textContent = 'ASSERTION:';
+            const hasComment = 'comment' in a;
+            const commentBtn = document.createElement('button');
+            commentBtn.type = 'button';
+            commentBtn.className = `btn btn-xs comment ms-1 ${hasComment ? 'btn-dark' : 'btn-secondary'}`;
+            commentBtn.title = hasComment ? a.comment : 'add a comment';
+            commentBtn.innerHTML = hasComment
+                ? '<i class="fas fa-comment-dots" aria-hidden="true"></i>'
+                : '<i class="fas fa-comment-medical" aria-hidden="true"></i>';
+            textHeader.append(textLabel, commentBtn);
+            const textarea = document.createElement('textarea');
+            textarea.className = 'form-control form-control-sm assertionText';
+            textarea.rows = 2;
+            textarea.value = a.assertion;
+            textRow.append(textHeader, textarea);
+            card.appendChild(textRow);
+
+            container.appendChild(card);
+        });
+    }
 }

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -243,11 +243,6 @@ export class AssertionsBuilder {
         return this;
     }
 
-    excludeYear(year) {
-        this.model.assertions = this.model.assertions.filter((a) => a.year !== year);
-        return this;
-    }
-
     setPivot(year) {
         if (this.model.test_type === TestType.ExactCorrespondenceSince) {
             this.model.year_since = year;
@@ -263,6 +258,59 @@ export class AssertionsBuilder {
                 this.toggleAssert(a.year);
             }
         });
+        return this;
+    }
+
+    /**
+     * Exclude a year from the test: record it in model.excludes (sorted,
+     * deduped) and drop its assertion. No-op if the year has no assertion.
+     */
+    excludeYear(year) {
+        const y = Number(year);
+        if (!this.model.assertions.some((a) => a.year === y)) return this;
+        const current = this.model.excludes ?? [];
+        if (!current.includes(y)) {
+            this.model.excludes = [...current, y].sort((a, b) => a - b);
+        }
+        this.model.assertions = this.model.assertions.filter((a) => a.year !== y);
+        return this;
+    }
+
+    /**
+     * Restore a previously excluded year, re-creating its assertion with the
+     * same rules generate() uses (pivot- and baseMonthDay-aware). excludes
+     * returns to null when the last exclusion is removed, so serialize()
+     * drops the key. No-op if the year is not excluded.
+     */
+    includeYear(year) {
+        const y = Number(year);
+        const current = this.model.excludes ?? [];
+        if (!current.includes(y)) return this;
+        const remaining = current.filter((x) => x !== y);
+        this.model.excludes = remaining.length ? remaining : null;
+
+        let notExists = false;
+        if (this.model.test_type === TestType.ExactCorrespondenceSince && this.model.year_since !== null) {
+            notExists = y < this.model.year_since;
+        } else if (this.model.test_type === TestType.ExactCorrespondenceUntil && this.model.year_until !== null) {
+            notExists = y > this.model.year_until;
+        }
+        const description = this.model.description;
+        if (notExists || !this.baseMonthDay) {
+            this.model.assertions.push(
+                new Assertion(y, null, AssertType.EventNotExists, description.replace('should fall on', 'should not exist on'))
+            );
+        } else {
+            this.model.assertions.push(
+                new Assertion(
+                    y,
+                    AssertionsBuilder.#expectedValue(y, this.baseMonthDay.month, this.baseMonthDay.day),
+                    AssertType.EventTypeExact,
+                    description
+                )
+            );
+        }
+        this.model.assertions.sort((a, b) => a.year - b.year);
         return this;
     }
 

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -125,12 +125,30 @@ export class AssertionsBuilder {
         return out;
     }
 
+    /**
+     * Mode (most frequent month/day) of the dated assertions, earliest-year
+     * tiebreak (spec R3.1). Transfer years (e.g. a June 24 solemnity
+     * anticipated to June 23) are outliers, so the majority reflects the
+     * canonical date better than the first assertion. The UI further prefers
+     * the event catalog's month/day when available; this is the fallback.
+     */
     static #deriveBaseMonthDay(assertions) {
-        const first = assertions.find((a) => a.expected_value);
-        if (!first) return null;
-        const d = new Date(first.expected_value);
-        if (Number.isNaN(d.getTime())) return null;
-        return { month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+        const counts = new Map();
+        for (const a of assertions) {
+            if (!a.expected_value) continue;
+            const d = new Date(a.expected_value);
+            if (Number.isNaN(d.getTime())) continue;
+            const key = `${d.getUTCMonth() + 1}-${d.getUTCDate()}`;
+            const entry = counts.get(key);
+            if (entry) entry.count += 1;
+            else counts.set(key, { count: 1, month: d.getUTCMonth() + 1, day: d.getUTCDate() });
+        }
+        let best = null;
+        for (const entry of counts.values()) {
+            // strict > keeps the earliest-seen (earliest year) entry on ties
+            if (!best || entry.count > best.count) best = entry;
+        }
+        return best ? { month: best.month, day: best.day } : null;
     }
 
     /** Build description text from an event, e.g. "The Memorial of 'X' should fall on July 31". */

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { TestType, AssertType, LitGrade, Assertion } from '../AssertionsBuilder.js';
+
+describe('enums', () => {
+    it('exposes the four test types', () => {
+        expect(TestType.ExactCorrespondence).toBe('exactCorrespondence');
+        expect(TestType.ExactCorrespondenceSince).toBe('exactCorrespondenceSince');
+        expect(TestType.ExactCorrespondenceUntil).toBe('exactCorrespondenceUntil');
+        expect(TestType.VariableCorrespondence).toBe('variableCorrespondence');
+    });
+
+    it('exposes the two assert types', () => {
+        expect(AssertType.EventNotExists).toBe('eventNotExists');
+        expect(AssertType.EventTypeExact).toBe('eventExists AND hasExpectedDate');
+    });
+
+    it('maps liturgical grades to strings', () => {
+        expect(LitGrade.toString(LitGrade.FEAST)).toBe('FEAST');
+    });
+});
+
+describe('Assertion', () => {
+    it('omits comment when not provided', () => {
+        const a = new Assertion(2024, null, AssertType.EventNotExists, 'x');
+        expect('comment' in a).toBe(false);
+        expect(a.year).toBe(2024);
+    });
+
+    it('keeps comment when provided', () => {
+        const a = new Assertion(2024, null, AssertType.EventNotExists, 'x', 'note');
+        expect(a.comment).toBe('note');
+    });
+});

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -114,3 +114,48 @@ describe('load + serialize round-trip', () => {
         expect(b.baseMonthDay).toEqual({ month: 7, day: 31 });
     });
 });
+
+const event = { event_key: 'StIgnatiusOfLoyola', name: 'Saint Ignatius of Loyola', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 };
+
+describe('generate', () => {
+    it('exactCorrespondence: every year asserts eventExists with a UTC midnight date', () => {
+        const b = new AssertionsBuilder({ locale: 'en' });
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondence' });
+        b.generate({ event, minYear: 2023, maxYear: 2025 });
+        const out = b.serialize();
+        expect(out.assertions.map((a) => a.year)).toEqual([2023, 2024, 2025]);
+        expect(out.assertions.every((a) => a.assert === 'eventExists AND hasExpectedDate')).toBe(true);
+        expect(out.assertions[1].expected_value).toBe('2024-07-31T00:00:00+00:00');
+        expect(out.description).toBe("The Memorial of 'Saint Ignatius of Loyola' should fall on July 31");
+    });
+
+    it('exactCorrespondenceSince: years before the pivot assert eventNotExists', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondenceSince' });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2025 });
+        const out = b.serialize();
+        expect(out.year_since).toBe(2025);
+        expect(out.assertions.find((a) => a.year === 2024).assert).toBe('eventNotExists');
+        expect(out.assertions.find((a) => a.year === 2024).expected_value).toBe(null);
+        expect(out.assertions.find((a) => a.year === 2025).assert).toBe('eventExists AND hasExpectedDate');
+        expect(out.assertions.find((a) => a.year === 2024).assertion)
+            .toBe("The Memorial of 'Saint Ignatius of Loyola' should not exist on July 31");
+    });
+
+    it('exactCorrespondenceUntil: years after the pivot assert eventNotExists', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondenceUntil' });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2025 });
+        const out = b.serialize();
+        expect(out.year_until).toBe(2025);
+        expect(out.assertions.find((a) => a.year === 2026).assert).toBe('eventNotExists');
+        expect(out.assertions.find((a) => a.year === 2025).assert).toBe('eventExists AND hasExpectedDate');
+    });
+
+    it('skips excluded years', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondence' });
+        b.generate({ event, minYear: 2023, maxYear: 2025, excludedYears: [2024] });
+        expect(b.serialize().assertions.map((a) => a.year)).toEqual([2023, 2025]);
+    });
+});

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -377,10 +377,10 @@ describe('excludeYear / includeYear', () => {
         return b;
     };
 
-    it('excludeYear removes the assertion and records the exclusion (sorted, deduped)', () => {
+    it('excludeYear removes the assertion; model.excludes stays null; chainable/dedup', () => {
         const b = build();
-        b.excludeYear(2025).excludeYear(2024).excludeYear(2025);
-        expect(b.model.excludes).toEqual([2024, 2025]);
+        b.excludeYear(2025).excludeYear(2024).excludeYear(2025); // second exclude of 2025 is a no-op
+        expect(b.model.excludes).toBe(null);
         expect(b.model.assertions.map((a) => a.year)).toEqual([2026]);
     });
 
@@ -391,7 +391,13 @@ describe('excludeYear / includeYear', () => {
         expect(b.model.assertions).toHaveLength(3);
     });
 
-    it('includeYear restores an exact assertion with expected_value from baseMonthDay', () => {
+    it('serialize() after excludeYear does not contain an excludes key (schema correctness)', () => {
+        const b = build();
+        b.excludeYear(2026);
+        expect('excludes' in b.serialize()).toBe(false);
+    });
+
+    it('includeYear restores an exact assertion with expected_value from baseMonthDay (exclude then include)', () => {
         const b = build();
         b.excludeYear(2025).includeYear(2025);
         expect(b.model.excludes).toBe(null);
@@ -401,12 +407,9 @@ describe('excludeYear / includeYear', () => {
         expect(b.model.assertions.map((x) => x.year)).toEqual([2024, 2025, 2026]);
     });
 
-    it('includeYear respects the since-pivot (restores eventNotExists before it)', () => {
+    it('includeYear respects the since-pivot (creates eventNotExists + "should not exist on" before pivot)', () => {
         const b = new AssertionsBuilder({ locale: 'en' });
-        b.setMeta({
-            event_key: event.event_key,
-            test_type: 'exactCorrespondenceSince',
-        });
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondenceSince' });
         b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2026 });
         b.excludeYear(2024).includeYear(2024);
         const a = b.model.assertions.find((x) => x.year === 2024);
@@ -414,32 +417,51 @@ describe('excludeYear / includeYear', () => {
         expect(a.assertion).toContain('should not exist on');
     });
 
-    it('serialize emits excludes while excluded and drops the key after restore', () => {
+    it('includeYear is a no-op when the year already has an assertion', () => {
         const b = build();
-        b.excludeYear(2026);
-        expect(b.serialize().excludes).toEqual([2026]);
-        b.includeYear(2026);
-        expect('excludes' in b.serialize()).toBe(false);
-    });
-
-    it('includeYear is a no-op when the year is not excluded', () => {
-        const b = build();
-        b.includeYear(2025);
+        b.includeYear(2025); // 2025 already has an assertion — assertion presence IS inclusion
         expect(b.model.excludes).toBe(null);
         expect(b.model.assertions).toHaveLength(3);
     });
 
+    it('sparse-load: includeYear(2025) creates an assertion; model.excludes remains null; serialize has no excludes key', () => {
+        // Real-world case: source definitions like NativityJohnBaptistTest have
+        // assertions only for specific years (2022/2033/2044), every other year
+        // in the span is excluded by omission. model.excludes is never populated.
+        const b = new AssertionsBuilder({ locale: 'en' });
+        b.load({
+            name: 'SparseTest',
+            event_key: 'StIgnatiusOfLoyola',
+            description: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+            test_type: 'exactCorrespondence',
+            assertions: [2022, 2033, 2044].map((year) => ({
+                year,
+                expected_value: `${year}-07-31T00:00:00+00:00`,
+                assert: 'eventExists AND hasExpectedDate',
+                assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+            })),
+        });
+        b.includeYear(2025);
+        expect(b.model.excludes).toBe(null);
+        const a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a).not.toBeUndefined();
+        expect(a.assert).toBe('eventExists AND hasExpectedDate');
+        expect(a.expected_value).toBe('2025-07-31T00:00:00+00:00');
+        expect('excludes' in b.serialize()).toBe(false);
+    });
+
     it('generate skips excludedYears so regeneration preserves exclusions', () => {
-        // model-level guarantee behind the regenerate() wiring in admin-tests.js
+        // model-level guarantee behind regenerate() wiring; excludedYears are
+        // derived from asserted-span gaps (not model.excludes, which stays null).
         const b = build();
         b.excludeYear(2025);
         b.generate({
             event,
             minYear: 2024,
             maxYear: 2026,
-            excludedYears: b.model.excludes ?? [],
+            excludedYears: [2025], // derived from asserted span gaps, not model.excludes
         });
         expect(b.model.assertions.map((a) => a.year)).toEqual([2024, 2026]);
-        expect(b.model.excludes).toEqual([2025]);
+        expect(b.model.excludes).toBe(null);
     });
 });

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -238,3 +238,101 @@ describe('render', () => {
         expect(card2025.querySelector('.editDate').classList.contains('disabled')).toBe(true);
     });
 });
+
+describe('coverage hardening', () => {
+    it('generate variableCorrespondence: all in-range years are eventExists', () => {
+        const event = { event_key: 'VEvent', name: 'Variable Event', grade: 3, grade_lcl: 'Memorial', month: 6, day: 15 };
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: 'VEvent', test_type: 'variableCorrespondence' });
+        b.generate({ event, minYear: 2020, maxYear: 2022 });
+        const out = b.serialize();
+        expect(out.assertions.map((a) => a.year)).toEqual([2020, 2021, 2022]);
+        expect(out.assertions.every((a) => a.assert === 'eventExists AND hasExpectedDate')).toBe(true);
+        expect(out.assertions[0].expected_value).toBe('2020-06-15T00:00:00+00:00');
+        expect('year_since' in out).toBe(false);
+        expect('year_until' in out).toBe(false);
+    });
+
+    it('generate with an event lacking month/day forces every year to eventNotExists', () => {
+        const movable = { event_key: 'Movable', name: 'Movable Feast', grade: 6, grade_lcl: 'SOLEMNITY' };
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: 'Movable', test_type: 'exactCorrespondence' });
+        b.generate({ event: movable, minYear: 2020, maxYear: 2021 });
+        expect(b.baseMonthDay).toBe(null);
+        const out = b.serialize();
+        expect(out.assertions.every((a) => a.assert === 'eventNotExists')).toBe(true);
+        expect(out.assertions.every((a) => a.expected_value === null)).toBe(true);
+    });
+
+    it('generate Since with a null pivot leaves all years eventExists and omits year_since', () => {
+        const event = { event_key: 'SEvent', name: 'Since Event', grade: 4, grade_lcl: 'FEAST', month: 3, day: 19 };
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: 'SEvent', test_type: 'exactCorrespondenceSince' });
+        b.generate({ event, minYear: 2024, maxYear: 2025, pivotYear: null });
+        const out = b.serialize();
+        expect(out.assertions.every((a) => a.assert === 'eventExists AND hasExpectedDate')).toBe(true);
+        expect('year_since' in out).toBe(false);
+    });
+
+    it('setPivot on an Until test marks years after the pivot as eventNotExists', () => {
+        const event = { event_key: 'UEvent', name: 'Until Event', grade: 4, grade_lcl: 'FEAST', month: 5, day: 1 };
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: 'UEvent', test_type: 'exactCorrespondenceUntil' });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2026 });
+        b.setPivot(2024);
+        expect(b.model.year_until).toBe(2024);
+        const at = (y) => b.model.assertions.find((a) => a.year === y);
+        expect(at(2024).assert).toBe('eventExists AND hasExpectedDate');
+        expect(at(2025).assert).toBe('eventNotExists');
+        expect(at(2025).expected_value).toBe(null);
+        expect(at(2026).assert).toBe('eventNotExists');
+    });
+
+    it('toggleAssert back to Exact keeps expected_value null when there is no base date', () => {
+        const b = new AssertionsBuilder();
+        b.load({
+            name: 'NoBaseTest',
+            event_key: 'NB',
+            description: "The FEAST of 'NB' should fall on July 4",
+            test_type: 'variableCorrespondence',
+            assertions: [
+                { year: 2024, expected_value: null, assert: 'eventNotExists', assertion: "The FEAST of 'NB' should not exist on July 4" },
+            ],
+        });
+        expect(b.baseMonthDay).toBe(null);
+        b.toggleAssert(2024);
+        const a = b.model.assertions.find((x) => x.year === 2024);
+        expect(a.assert).toBe('eventExists AND hasExpectedDate');
+        expect(a.expected_value).toBe(null);
+        expect(a.assertion).toContain('should fall on');
+    });
+
+    it('render exposes grid class, color classes, comment icon, textarea', () => {
+        const event = { event_key: 'REvent', name: 'Render Event', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 };
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: 'REvent', test_type: 'variableCorrespondence' });
+        b.generate({ event, minYear: 2024, maxYear: 2025 });
+        b.toggleAssert(2025);                 // 2025 -> eventNotExists
+        b.setComment(2024, 'a note');         // 2024 has a comment
+        const container = document.createElement('div');
+        b.render(container);
+
+        expect(container.classList.contains('assertions-grid')).toBe(true);
+
+        const card2024 = container.querySelector('[data-year="2024"]');
+        const card2025 = container.querySelector('[data-year="2025"]');
+        expect(card2024.classList.contains('bg-success')).toBe(true);
+        expect(card2024.classList.contains('text-white')).toBe(true);
+        expect(card2025.classList.contains('bg-warning')).toBe(true);
+        expect(card2025.classList.contains('text-dark')).toBe(true);
+
+        // comment icon swap
+        expect(card2024.querySelector('.comment .fa-comment-dots')).not.toBeNull();
+        expect(card2025.querySelector('.comment .fa-comment-medical')).not.toBeNull();
+
+        // editable sentence is a textarea, not contenteditable
+        const ta = card2024.querySelector('textarea.assertionText');
+        expect(ta).not.toBeNull();
+        expect(ta.getAttribute('contenteditable')).toBe(null);
+    });
+});

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -31,3 +31,68 @@ describe('Assertion', () => {
         expect(a.comment).toBe('note');
     });
 });
+
+import { AssertionsBuilder } from '../AssertionsBuilder.js';
+
+const sampleExact = {
+    name: 'StIgnatiusOfLoyolaTest',
+    event_key: 'StIgnatiusOfLoyola',
+    description: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+    test_type: 'exactCorrespondence',
+    applies_to: { national_calendar: 'USA' },
+    assertions: [
+        { year: 2024, expected_value: '2024-07-31T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31" },
+        { year: 2025, expected_value: '2025-07-31T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31", comment: 'note' },
+    ],
+};
+
+const sampleSince = {
+    name: 'SomeFeastTest',
+    event_key: 'SomeFeast',
+    description: "The FEAST of 'Some Feast' should fall on March 19",
+    test_type: 'exactCorrespondenceSince',
+    year_since: 2026,
+    assertions: [
+        { year: 2025, expected_value: null, assert: 'eventNotExists', assertion: "The FEAST of 'Some Feast' should not exist on March 19" },
+        { year: 2026, expected_value: '2026-03-19T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The FEAST of 'Some Feast' should fall on March 19" },
+    ],
+};
+
+describe('load + serialize round-trip', () => {
+    it('round-trips an exactCorrespondence test (applies_to + comment preserved)', () => {
+        const out = new AssertionsBuilder().load(sampleExact).serialize();
+        expect(out).toEqual(sampleExact);
+    });
+
+    it('round-trips an exactCorrespondenceSince test (year_since preserved)', () => {
+        const out = new AssertionsBuilder().load(sampleSince).serialize();
+        expect(out).toEqual(sampleSince);
+    });
+
+    it('omits year_since/year_until/applies_to/excludes when not applicable', () => {
+        const out = new AssertionsBuilder().load({
+            name: 'BareTest', event_key: 'Bare', description: 'd',
+            test_type: 'exactCorrespondence',
+            assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }],
+        }).serialize();
+        expect('year_since' in out).toBe(false);
+        expect('year_until' in out).toBe(false);
+        expect('applies_to' in out).toBe(false);
+        expect('excludes' in out).toBe(false);
+    });
+
+    it('setMeta updates name/description/event_key/test_type without touching assertions', () => {
+        const b = new AssertionsBuilder().load(sampleExact);
+        b.setMeta({ name: 'RenamedTest', description: 'new desc', test_type: 'variableCorrespondence' });
+        const out = b.serialize();
+        expect(out.name).toBe('RenamedTest');
+        expect(out.description).toBe('new desc');
+        expect(out.test_type).toBe('variableCorrespondence');
+        expect(out.assertions).toHaveLength(2);
+    });
+
+    it('derives baseMonthDay from the first eventExists assertion', () => {
+        const b = new AssertionsBuilder().load(sampleExact);
+        expect(b.baseMonthDay).toEqual({ month: 7, day: 31 });
+    });
+});

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -182,6 +182,21 @@ describe('mutators', () => {
         expect(a.assertion).toContain('should fall on');
     });
 
+    it('toggleAssert rewrites canonical text even after a user edit (no substring dependency)', () => {
+        const b = build();
+        // Simulate a user rewriting the sentence so the "should fall on"
+        // phrase is gone — substring replacement would silently no-op here.
+        b.setAssertionText(2025, 'Totally custom sentence written by an editor');
+        b.toggleAssert(2025);
+        let a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventNotExists');
+        expect(a.assertion).toContain('should not exist on');
+        b.toggleAssert(2025);
+        a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventExists AND hasExpectedDate');
+        expect(a.assertion).toContain('should fall on');
+    });
+
     it('setExpectedDate updates the RFC3339 value', () => {
         const b = build();
         b.setExpectedDate(2024, '2024-08-01T00:00:00+00:00');

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -132,6 +132,26 @@ describe('load + serialize round-trip', () => {
         expect(b.baseMonthDay).toEqual({ month: 6, day: 24 });
     });
 
+    it('load() sorts assertions by year (corpus may group by assert type)', () => {
+        // spec R4: e.g. StJaneFrancesDeChantalTest stores all eventExists
+        // assertions first, then the eventNotExists block — the model must
+        // normalize to year order so cards render chronologically.
+        const grouped = {
+            name: 'GroupedTest',
+            event_key: 'StJaneFrancesDeChantal',
+            description: 'x',
+            test_type: 'variableCorrespondence',
+            assertions: [
+                { year: 2001, expected_value: '2001-12-12T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
+                { year: 2010, expected_value: '2010-12-12T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
+                { year: 1971, expected_value: null, assert: 'eventNotExists', assertion: 'x' },
+                { year: 2005, expected_value: null, assert: 'eventNotExists', assertion: 'x' },
+            ],
+        };
+        const b = new AssertionsBuilder().load(grouped);
+        expect(b.model.assertions.map((a) => a.year)).toEqual([1971, 2001, 2005, 2010]);
+    });
+
     it('baseMonthDay mode tiebreak goes to the earliest year', () => {
         const tied = {
             name: 'TiedTest',

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -58,6 +58,18 @@ const sampleSince = {
     ],
 };
 
+const sampleUntil = {
+    name: 'SomeUntilTest',
+    event_key: 'SomeUntilEvent',
+    description: "The FEAST of 'Some Feast' should fall on March 19 until 2028",
+    test_type: 'exactCorrespondenceUntil',
+    year_until: 2028,
+    assertions: [
+        { year: 2028, expected_value: '2028-03-19T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The FEAST of 'Some Feast' should fall on March 19" },
+        { year: 2029, expected_value: null, assert: 'eventNotExists', assertion: "The FEAST of 'Some Feast' should not exist on March 19" },
+    ],
+};
+
 describe('load + serialize round-trip', () => {
     it('round-trips an exactCorrespondence test (applies_to + comment preserved)', () => {
         const out = new AssertionsBuilder().load(sampleExact).serialize();
@@ -67,6 +79,11 @@ describe('load + serialize round-trip', () => {
     it('round-trips an exactCorrespondenceSince test (year_since preserved)', () => {
         const out = new AssertionsBuilder().load(sampleSince).serialize();
         expect(out).toEqual(sampleSince);
+    });
+
+    it('round-trips an exactCorrespondenceUntil test (year_until preserved)', () => {
+        const out = new AssertionsBuilder().load(sampleUntil).serialize();
+        expect(out).toEqual(sampleUntil);
     });
 
     it('omits year_since/year_until/applies_to/excludes when not applicable', () => {
@@ -83,10 +100,11 @@ describe('load + serialize round-trip', () => {
 
     it('setMeta updates name/description/event_key/test_type without touching assertions', () => {
         const b = new AssertionsBuilder().load(sampleExact);
-        b.setMeta({ name: 'RenamedTest', description: 'new desc', test_type: 'variableCorrespondence' });
+        b.setMeta({ name: 'RenamedTest', description: 'new desc', event_key: 'RenamedKeyEvent', test_type: 'variableCorrespondence' });
         const out = b.serialize();
         expect(out.name).toBe('RenamedTest');
         expect(out.description).toBe('new desc');
+        expect(out.event_key).toBe('RenamedKeyEvent');
         expect(out.test_type).toBe('variableCorrespondence');
         expect(out.assertions).toHaveLength(2);
     });

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -214,3 +214,27 @@ describe('mutators', () => {
         expect(b.model.assertions.find((x) => x.year === 2026).assert).toBe('eventExists AND hasExpectedDate');
     });
 });
+
+describe('render', () => {
+    it('renders one card per assertion with textarea, toggle, and color classes', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ test_type: 'variableCorrespondence' });
+        b.generate({ event, minYear: 2024, maxYear: 2025 });
+        b.toggleAssert(2025); // make 2025 eventNotExists
+        const container = document.createElement('div');
+        b.render(container);
+
+        const cards = container.querySelectorAll('[data-year]');
+        expect(cards).toHaveLength(2);
+
+        const card2024 = container.querySelector('[data-year="2024"]');
+        expect(card2024.querySelector('.assert').textContent).toBe('eventExists AND hasExpectedDate');
+        expect(card2024.querySelector('textarea.assertionText')).not.toBeNull();
+        expect(card2024.querySelector('.toggleAssert')).not.toBeNull();
+        expect(card2024.querySelector('.expectedValue').getAttribute('data-value')).toBe('2024-07-31T00:00:00+00:00');
+
+        const card2025 = container.querySelector('[data-year="2025"]');
+        expect(card2025.querySelector('.assert').textContent).toBe('eventNotExists');
+        expect(card2025.querySelector('.editDate').classList.contains('disabled')).toBe(true);
+    });
+});

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -368,3 +368,78 @@ describe('locale normalization', () => {
         expect(() => b.render(container)).not.toThrow();
     });
 });
+
+describe('excludeYear / includeYear', () => {
+    const build = () => {
+        const b = new AssertionsBuilder({ locale: 'en' });
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondence' });
+        b.generate({ event, minYear: 2024, maxYear: 2026 });
+        return b;
+    };
+
+    it('excludeYear removes the assertion and records the exclusion (sorted, deduped)', () => {
+        const b = build();
+        b.excludeYear(2025).excludeYear(2024).excludeYear(2025);
+        expect(b.model.excludes).toEqual([2024, 2025]);
+        expect(b.model.assertions.map((a) => a.year)).toEqual([2026]);
+    });
+
+    it('excludeYear is a no-op for years without an assertion', () => {
+        const b = build();
+        b.excludeYear(1999);
+        expect(b.model.excludes).toBe(null);
+        expect(b.model.assertions).toHaveLength(3);
+    });
+
+    it('includeYear restores an exact assertion with expected_value from baseMonthDay', () => {
+        const b = build();
+        b.excludeYear(2025).includeYear(2025);
+        expect(b.model.excludes).toBe(null);
+        const a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventExists AND hasExpectedDate');
+        expect(a.expected_value).toBe('2025-07-31T00:00:00+00:00');
+        expect(b.model.assertions.map((x) => x.year)).toEqual([2024, 2025, 2026]);
+    });
+
+    it('includeYear respects the since-pivot (restores eventNotExists before it)', () => {
+        const b = new AssertionsBuilder({ locale: 'en' });
+        b.setMeta({
+            event_key: event.event_key,
+            test_type: 'exactCorrespondenceSince',
+        });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2026 });
+        b.excludeYear(2024).includeYear(2024);
+        const a = b.model.assertions.find((x) => x.year === 2024);
+        expect(a.assert).toBe('eventNotExists');
+        expect(a.assertion).toContain('should not exist on');
+    });
+
+    it('serialize emits excludes while excluded and drops the key after restore', () => {
+        const b = build();
+        b.excludeYear(2026);
+        expect(b.serialize().excludes).toEqual([2026]);
+        b.includeYear(2026);
+        expect('excludes' in b.serialize()).toBe(false);
+    });
+
+    it('includeYear is a no-op when the year is not excluded', () => {
+        const b = build();
+        b.includeYear(2025);
+        expect(b.model.excludes).toBe(null);
+        expect(b.model.assertions).toHaveLength(3);
+    });
+
+    it('generate skips excludedYears so regeneration preserves exclusions', () => {
+        // model-level guarantee behind the regenerate() wiring in admin-tests.js
+        const b = build();
+        b.excludeYear(2025);
+        b.generate({
+            event,
+            minYear: 2024,
+            maxYear: 2026,
+            excludedYears: b.model.excludes ?? [],
+        });
+        expect(b.model.assertions.map((a) => a.year)).toEqual([2024, 2026]);
+        expect(b.model.excludes).toEqual([2025]);
+    });
+});

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -113,6 +113,39 @@ describe('load + serialize round-trip', () => {
         const b = new AssertionsBuilder().load(sampleExact);
         expect(b.baseMonthDay).toEqual({ month: 7, day: 31 });
     });
+
+    it('derives baseMonthDay as the MODE of dated assertions (transfer years are outliers)', () => {
+        // spec R3.1: a test mixing canonical (June 24) and transferred (June 23)
+        // dates must derive the canonical majority, not the first assertion.
+        const mixed = {
+            name: 'MixedTest',
+            event_key: 'NativityJohnBaptist',
+            description: "The Solemnity 'Nativity of John the Baptist' should fall on June 24",
+            test_type: 'exactCorrespondence',
+            assertions: [
+                { year: 2022, expected_value: '2022-06-23T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
+                { year: 2023, expected_value: '2023-06-24T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
+                { year: 2024, expected_value: '2024-06-24T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
+            ],
+        };
+        const b = new AssertionsBuilder().load(mixed);
+        expect(b.baseMonthDay).toEqual({ month: 6, day: 24 });
+    });
+
+    it('baseMonthDay mode tiebreak goes to the earliest year', () => {
+        const tied = {
+            name: 'TiedTest',
+            event_key: 'SomeEvent',
+            description: 'x',
+            test_type: 'exactCorrespondence',
+            assertions: [
+                { year: 2022, expected_value: '2022-06-23T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
+                { year: 2023, expected_value: '2023-06-24T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
+            ],
+        };
+        const b = new AssertionsBuilder().load(tied);
+        expect(b.baseMonthDay).toEqual({ month: 6, day: 23 });
+    });
 });
 
 const event = { event_key: 'StIgnatiusOfLoyola', name: 'Saint Ignatius of Loyola', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 };

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -351,3 +351,20 @@ describe('coverage hardening', () => {
         expect(ta.getAttribute('contenteditable')).toBe(null);
     });
 });
+
+describe('locale normalization', () => {
+    it('accepts a gettext/ICU-style underscore locale (en_US) without throwing', () => {
+        // PHP \Locale::acceptFromHttp() yields en_US; Intl.DateTimeFormat throws
+        // a RangeError on underscore tags unless the builder normalizes to BCP-47.
+        const event = { event_key: 'LEvent', name: 'Locale Event', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 };
+        const b = new AssertionsBuilder({ locale: 'en_US' });
+        expect(b.locale).toBe('en-US');
+        b.setMeta({ event_key: 'LEvent', test_type: 'exactCorrespondence' });
+        expect(() => b.generate({ event, minYear: 2024, maxYear: 2025 })).not.toThrow();
+        const out = b.serialize();
+        expect(out.assertions).toHaveLength(2);
+        expect(out.description).toBe("The Memorial of 'Locale Event' should fall on July 31");
+        const container = document.createElement('div');
+        expect(() => b.render(container)).not.toThrow();
+    });
+});

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -159,3 +159,58 @@ describe('generate', () => {
         expect(b.serialize().assertions.map((a) => a.year)).toEqual([2023, 2025]);
     });
 });
+
+describe('mutators', () => {
+    const build = () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ test_type: 'variableCorrespondence' });
+        b.generate({ event, minYear: 2024, maxYear: 2026 });
+        return b;
+    };
+
+    it('toggleAssert flips eventExists -> eventNotExists and back', () => {
+        const b = build();
+        b.toggleAssert(2025);
+        let a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventNotExists');
+        expect(a.expected_value).toBe(null);
+        expect(a.assertion).toContain('should not exist on');
+        b.toggleAssert(2025);
+        a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventExists AND hasExpectedDate');
+        expect(a.expected_value).toBe('2025-07-31T00:00:00+00:00');
+        expect(a.assertion).toContain('should fall on');
+    });
+
+    it('setExpectedDate updates the RFC3339 value', () => {
+        const b = build();
+        b.setExpectedDate(2024, '2024-08-01T00:00:00+00:00');
+        expect(b.model.assertions.find((x) => x.year === 2024).expected_value).toBe('2024-08-01T00:00:00+00:00');
+    });
+
+    it('setAssertionText and setComment work; empty comment removes it', () => {
+        const b = build();
+        b.setAssertionText(2024, 'custom sentence');
+        expect(b.model.assertions.find((x) => x.year === 2024).assertion).toBe('custom sentence');
+        b.setComment(2024, 'a note');
+        expect(b.model.assertions.find((x) => x.year === 2024).comment).toBe('a note');
+        b.setComment(2024, '');
+        expect('comment' in b.model.assertions.find((x) => x.year === 2024)).toBe(false);
+    });
+
+    it('excludeYear removes the assertion', () => {
+        const b = build();
+        b.excludeYear(2025);
+        expect(b.model.assertions.map((x) => x.year)).toEqual([2024, 2026]);
+    });
+
+    it('setPivot re-splits a Since test', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ test_type: 'exactCorrespondenceSince' });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2024 });
+        b.setPivot(2026);
+        expect(b.model.year_since).toBe(2026);
+        expect(b.model.assertions.find((x) => x.year === 2024).assert).toBe('eventNotExists');
+        expect(b.model.assertions.find((x) => x.year === 2026).assert).toBe('eventExists AND hasExpectedDate');
+    });
+});

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -357,7 +357,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const pivot = (tt === TestType.ExactCorrespondenceSince || tt === TestType.ExactCorrespondenceUntil)
             ? minYear
             : null;
-        builder.generate({ event, minYear, maxYear, pivotYear: pivot });
+        // Preserve exclusions when the event/type/slider changes; generate()
+        // skips excluded years, so without this every regeneration would
+        // silently restore them.
+        builder.generate({
+            event,
+            minYear,
+            maxYear,
+            pivotYear: pivot,
+            excludedYears: builder.model.excludes ?? [],
+        });
         document.getElementById('testDescription').value = builder.model.description;
         document.getElementById('baseDate').value = event.month && event.day
             ? `${minYear}-${String(event.month).padStart(2, '0')}-${String(event.day).padStart(2, '0')}`
@@ -449,14 +458,32 @@ document.addEventListener('DOMContentLoaded', () => {
         builder.render(assertionsContainer);
     });
 
-    // For Since/Until types, clicking a year in the overview grid sets the pivot
-    // (year_since / year_until) and re-splits the assertions around it.
+    // Year-grid interactions (ported from UnitTestInterface, state-first):
+    //   hammer  → Since/Until: set the pivot; Variable: toggle that year
+    //   x-mark  → exclude the year (collapses to the striped bar)
+    //   striped bar → restore the year
+    //   span body   → no action (the icons are the affordances)
     document.getElementById('yearGrid').addEventListener('click', (ev) => {
         const span = ev.target.closest('.testYearSpan');
         if (!span) return;
-        const tt = selectedTestType();
-        if (tt !== TestType.ExactCorrespondenceSince && tt !== TestType.ExactCorrespondenceUntil) return;
-        builder.setPivot(Number(span.dataset.year));
+        const year = Number(span.dataset.year);
+        if (span.classList.contains('deleted')) {
+            builder.includeYear(year);
+        } else if (ev.target.closest('.removeYear')) {
+            builder.excludeYear(year);
+        } else if (ev.target.closest('.hammerYear')) {
+            const tt = selectedTestType();
+            if (
+                tt === TestType.ExactCorrespondenceSince ||
+                tt === TestType.ExactCorrespondenceUntil
+            ) {
+                builder.setPivot(year);
+            } else if (tt === TestType.VariableCorrespondence) {
+                builder.toggleAssert(year);
+            }
+        } else {
+            return;
+        }
         builder.render(assertionsContainer);
         renderYearGrid();
     });

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -216,9 +216,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     async function loadEvents(appliesTo) {
+        // The events catalog is public — omit credentials. EventsHandler serves a
+        // wildcard Access-Control-Allow-Origin, and browsers reject wildcard ACAO
+        // on credentialed requests (breaks the split-origin docker e2e stack).
         const res = await fetch(apiUrl + eventsPath(appliesTo), {
             headers: { Accept: 'application/json', 'Accept-Language': config.locale },
-            credentials: 'include',
         });
         const json = await res.json();
         events = json.litcal_events ?? [];

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -1,0 +1,151 @@
+/**
+ * admin-tests page module. Bespoke (not the status-workflow factory), modeled
+ * on admin-permissions.js. Internal seam: generic CRUD plumbing vs.
+ * test-specific logic, so it can later seed a shared admin-page factory.
+ */
+import {
+    ApiClient,
+    CalendarSelect,
+    CalendarSelectFilter,
+} from '@liturgical-calendar/components-js';
+import { AssertionsBuilder, TestType } from './AssertionsBuilder.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const config = window.AdminTestsConfig;
+    if (!config) {
+        console.error('AdminTestsConfig not found');
+        return;
+    }
+    const { apiUrl, i18n } = config;
+
+    // ---- generic seam -----------------------------------------------------
+
+    async function fetchJson(method, path, body) {
+        const opts = {
+            method,
+            headers: { Accept: 'application/json' },
+            credentials: 'include',
+        };
+        if (body !== undefined) {
+            opts.headers['Content-Type'] = 'application/json';
+            opts.body = JSON.stringify(body);
+        }
+        const res = await fetch(apiUrl + path, opts);
+        const text = await res.text();
+        const data = text ? JSON.parse(text) : null;
+        if (!res.ok) {
+            throw { status: res.status, body: data };
+        }
+        return data;
+    }
+
+    /** Mirror TestScopeResolver: derive a test's scope object from applies_to. */
+    function deriveScope(appliesTo) {
+        if (appliesTo && appliesTo.diocesan_calendar) {
+            return { object_type: 'diocesan_calendar_test', object_id: appliesTo.diocesan_calendar };
+        }
+        if (appliesTo && appliesTo.national_calendar) {
+            return { object_type: 'national_calendar_test', object_id: appliesTo.national_calendar };
+        }
+        return { object_type: 'general_roman_calendar_test', object_id: 'general_roman_calendar' };
+    }
+
+    function gateByScope(scopeObj, scopes) {
+        return scopes.some((s) => s.object_type === scopeObj.object_type && s.object_id === scopeObj.object_id);
+    }
+
+    function showModalAlert(modalEl, type, message) {
+        const area = modalEl.querySelector('[id$="Alerts"]');
+        if (!area) return;
+        area.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">`
+            + `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
+    }
+
+    // ---- state ------------------------------------------------------------
+
+    const state = {
+        tests: [],
+        scopes: { is_global_admin: false, editor: [], admin: [] },
+        editing: null,
+    };
+
+    function scopeLabel(appliesTo) {
+        const s = deriveScope(appliesTo);
+        if (s.object_type === 'national_calendar_test') return `${i18n.nationalCalendar}: ${s.object_id}`;
+        if (s.object_type === 'diocesan_calendar_test') return `${i18n.diocesanCalendar}: ${s.object_id}`;
+        return i18n.generalRomanCalendar;
+    }
+
+    function yearRange(test) {
+        const years = test.assertions.map((a) => a.year);
+        return years.length ? `${Math.min(...years)}–${Math.max(...years)}` : '';
+    }
+
+    function canEdit(test) {
+        return state.scopes.is_global_admin || gateByScope(deriveScope(test.applies_to), state.scopes.editor);
+    }
+
+    function canDelete(test) {
+        return state.scopes.is_global_admin || gateByScope(deriveScope(test.applies_to), state.scopes.admin);
+    }
+
+    function renderTableRows() {
+        const tbody = document.getElementById('testsTableBody');
+        const nameFilter = document.getElementById('filterTestName').value.trim().toLowerCase();
+        const scopeFilter = document.getElementById('filterTestScope').value.trim().toLowerCase();
+        const rows = state.tests.filter((t) => {
+            const matchesName = !nameFilter || t.name.toLowerCase().includes(nameFilter);
+            const matchesScope = !scopeFilter || scopeLabel(t.applies_to).toLowerCase().includes(scopeFilter);
+            return matchesName && matchesScope;
+        });
+        document.getElementById('testsCount').textContent = String(rows.length);
+        tbody.innerHTML = '';
+        if (!rows.length) {
+            tbody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">${i18n.noTests}</td></tr>`;
+            return;
+        }
+        rows.forEach((t) => {
+            const tr = document.createElement('tr');
+            const editBtn = canEdit(t)
+                ? `<button type="button" class="btn btn-sm btn-outline-primary editTestBtn" data-name="${t.name}"><i class="fas fa-pen"></i> ${i18n.edit}</button>`
+                : '';
+            const delBtn = canDelete(t)
+                ? `<button type="button" class="btn btn-sm btn-outline-danger deleteTestBtn ms-1" data-name="${t.name}"><i class="fas fa-trash"></i> ${i18n.delete}</button>`
+                : '';
+            tr.innerHTML = `
+                <td><code>${t.name}</code></td>
+                <td>${t.event_key}</td>
+                <td>${scopeLabel(t.applies_to)}</td>
+                <td>${t.test_type}</td>
+                <td>${yearRange(t)}</td>
+                <td class="text-end">${editBtn}${delBtn}</td>`;
+            tbody.appendChild(tr);
+        });
+    }
+
+    async function loadTests() {
+        const tbody = document.getElementById('testsTableBody');
+        tbody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">${i18n.loading}</td></tr>`;
+        try {
+            const [scopes, testsResp] = await Promise.all([
+                fetchJson('GET', '/auth/test-scopes').catch(() => ({ is_global_admin: false, editor: [], admin: [] })),
+                fetchJson('GET', '/tests'),
+            ]);
+            state.scopes = scopes;
+            state.tests = testsResp.litcal_tests ?? [];
+            renderTableRows();
+        } catch (err) {
+            console.error('Failed to load tests', err);
+            tbody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">${i18n.failedToLoad}</td></tr>`;
+        }
+    }
+
+    document.getElementById('refreshTestsBtn').addEventListener('click', loadTests);
+    document.getElementById('filterTestName').addEventListener('input', renderTableRows);
+    document.getElementById('filterTestScope').addEventListener('input', renderTableRows);
+
+    // Expose internals for later tasks (editor/delete wiring appended below).
+    window.__adminTests = { state, fetchJson, deriveScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, ApiClient };
+
+    loadTests();
+});

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -564,6 +564,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 slider.style.setProperty('--text-value-a', `"${lo}"`);
                 slider.style.setProperty('--value-b', String(hi));
                 slider.style.setProperty('--text-value-b', `"${hi}"`);
+                // Restore the base date from the loaded assertions (spec R3):
+                // load() derived baseMonthDay from the first dated assertion —
+                // authoritative over the event catalog's month/day. The year
+                // component is presentational only; the field's change handler
+                // expands month/day across every asserted year.
+                document.getElementById('baseDate').value = builder.baseMonthDay
+                    ? `${String(lo).padStart(4, '0')}-${String(builder.baseMonthDay.month).padStart(2, '0')}-${String(builder.baseMonthDay.day).padStart(2, '0')}`
+                    : '';
                 renderYearGrid();
             }
             loadEvents(test.applies_to)

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -564,18 +564,36 @@ document.addEventListener('DOMContentLoaded', () => {
                 slider.style.setProperty('--text-value-a', `"${lo}"`);
                 slider.style.setProperty('--value-b', String(hi));
                 slider.style.setProperty('--text-value-b', `"${hi}"`);
-                // Restore the base date from the loaded assertions (spec R3):
-                // load() derived baseMonthDay from the first dated assertion —
-                // authoritative over the event catalog's month/day. The year
-                // component is presentational only; the field's change handler
-                // expands month/day across every asserted year.
+                // Provisional base date (spec R3/R3.1): load() derived
+                // baseMonthDay as the MODE of the dated assertions — shown
+                // until the events catalog resolves below, which is the
+                // authoritative source (the canonical date; assertions hold
+                // resolved, possibly transferred dates). The year component is
+                // presentational only; the field's change handler expands
+                // month/day across every asserted year.
                 document.getElementById('baseDate').value = builder.baseMonthDay
                     ? `${String(lo).padStart(4, '0')}-${String(builder.baseMonthDay.month).padStart(2, '0')}-${String(builder.baseMonthDay.day).padStart(2, '0')}`
                     : '';
                 renderYearGrid();
             }
             loadEvents(test.applies_to)
-                .then(() => builder.render(assertionsContainer))
+                .then(() => {
+                    // Catalog override (spec R3.1): the base date is a Sunday-
+                    // coincidence assist on the event's CANONICAL month/day, so
+                    // the catalog wins over the assertions-mode fallback when it
+                    // knows the event's fixed date. Set the field value and
+                    // builder.baseMonthDay directly — dispatching 'change' here
+                    // would rewrite every assertion's expected_value.
+                    const catalogEvent = events.find((e) => e.event_key === test.event_key);
+                    if (catalogEvent && catalogEvent.month && catalogEvent.day && years.length) {
+                        const lo = Math.min(...years);
+                        builder.baseMonthDay = { month: Number(catalogEvent.month), day: Number(catalogEvent.day) };
+                        document.getElementById('baseDate').value =
+                            `${String(lo).padStart(4, '0')}-${String(catalogEvent.month).padStart(2, '0')}-${String(catalogEvent.day).padStart(2, '0')}`;
+                        renderYearGrid(); // Sunday crosses re-derive from the canonical date
+                    }
+                    builder.render(assertionsContainer);
+                })
                 .catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
         } else {
             builder.load({ name: '', event_key: '', description: '', test_type: TestType.ExactCorrespondence, assertions: [] });

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -269,30 +269,82 @@ document.addEventListener('DOMContentLoaded', () => {
         return { minYear: Math.min(a, b), maxYear: Math.max(a, b) };
     }
 
+    /**
+     * Port of UnitTestInterface's computeYearDateAttrs: title + Sunday flag
+     * for the event's fixed date in the given year (empty when the event has
+     * no fixed month/day).
+     */
+    function yearDateAttrs(year) {
+        if (!builder.baseMonthDay) return { title: '', sunday: false };
+        const d = new Date(
+            Date.UTC(year, builder.baseMonthDay.month - 1, builder.baseMonthDay.day),
+        );
+        const sunday = d.getUTCDay() === 0;
+        const fmt = new Intl.DateTimeFormat(config.locale, {
+            dateStyle: 'long',
+            timeZone: 'UTC',
+        });
+        const title = sunday
+            ? i18n.sundayInYear
+                .replace('%1$s', String(year))
+                .replace('%2$s', fmt.format(d))
+            : fmt.format(d);
+        return { title, sunday };
+    }
+
     function renderYearGrid() {
         const grid = document.getElementById('yearGrid');
         const { minYear, maxYear } = sliderYears();
+        const tt = builder.model.test_type;
+        const excluded = new Set(builder.model.excludes ?? []);
+        const notExists = new Set(
+            builder.model.assertions
+                .filter((a) => a.assert === AssertType.EventNotExists)
+                .map((a) => a.year),
+        );
+        const pivot =
+            tt === TestType.ExactCorrespondenceSince
+                ? builder.model.year_since
+                : tt === TestType.ExactCorrespondenceUntil
+                    ? builder.model.year_until
+                    : null;
+        const showHammer = tt !== TestType.ExactCorrespondence;
         grid.innerHTML = '';
         for (let y = minYear; y <= maxYear; y++) {
             const span = document.createElement('span');
             span.className = `testYearSpan year-${y}`;
             span.dataset.year = String(y);
-            span.textContent = String(y);
+            if (excluded.has(y)) {
+                span.classList.add('deleted');
+                span.title = i18n.excludedRestore.replace('%s', String(y));
+                grid.appendChild(span);
+                continue;
+            }
+            if (showHammer) {
+                const hammer = document.createElement('i');
+                hammer.className = 'fas fa-hammer me-1 opacity-50 hammerYear';
+                hammer.setAttribute('role', 'button');
+                hammer.setAttribute('aria-hidden', 'true');
+                hammer.title = i18n.setYear;
+                span.appendChild(hammer);
+            }
+            span.appendChild(document.createTextNode(String(y)));
+            const xmark = document.createElement('i');
+            xmark.className = 'fas fa-circle-xmark ms-1 opacity-50 removeYear';
+            xmark.setAttribute('role', 'button');
+            xmark.setAttribute('aria-hidden', 'true');
+            xmark.title = i18n.removeYear;
+            span.appendChild(xmark);
+            const { title, sunday } = yearDateAttrs(y);
+            if (title) span.title = title;
+            if (y === pivot) {
+                span.classList.add('bg-info');
+            } else if (notExists.has(y)) {
+                span.classList.add('bg-warning');
+            } else if (sunday) {
+                span.classList.add('bg-light');
+            }
             grid.appendChild(span);
-        }
-        const pivot = builder.model.test_type === TestType.ExactCorrespondenceSince
-            ? builder.model.year_since
-            : builder.model.test_type === TestType.ExactCorrespondenceUntil
-                ? builder.model.year_until
-                : null;
-        if (pivot !== null) {
-            grid.querySelectorAll('.testYearSpan').forEach((span) => {
-                const y = Number(span.dataset.year);
-                if (y === pivot) span.classList.add('bg-info');
-                else if (builder.model.test_type === TestType.ExactCorrespondenceSince ? y < pivot : y > pivot) {
-                    span.classList.add('bg-warning');
-                }
-            });
         }
     }
 

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -323,12 +323,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 continue;
             }
             if (showHammer) {
-                const hammer = document.createElement('i');
-                hammer.className = 'fas fa-hammer me-1 opacity-50 hammerYear';
-                hammer.setAttribute('role', 'button');
-                hammer.setAttribute('aria-hidden', 'true');
-                hammer.title = i18n.setYear;
-                span.appendChild(hammer);
+                // Icon semantics per test type (spec R5): Since/Until = hammer
+                // ("set the pivot year"); Variable = fa-repeat ("toggle
+                // assertion", matching the per-year cards' toggle button). The
+                // behavioral hook class (hammerYear) is shared — only the
+                // visual icon and title differ.
+                const isVariable = tt === TestType.VariableCorrespondence;
+                const actionIcon = document.createElement('i');
+                actionIcon.className = `fas ${isVariable ? 'fa-repeat' : 'fa-hammer'} me-1 opacity-50 hammerYear`;
+                actionIcon.setAttribute('role', 'button');
+                actionIcon.setAttribute('aria-hidden', 'true');
+                actionIcon.title = isVariable ? i18n.toggleAssertion : i18n.setYear;
+                span.appendChild(actionIcon);
             }
             span.appendChild(document.createTextNode(String(y)));
             const xmark = document.createElement('i');

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -32,7 +32,12 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         const res = await fetch(apiUrl + path, opts);
         const text = await res.text();
-        const data = text ? JSON.parse(text) : null;
+        let data = null;
+        try {
+            data = text ? JSON.parse(text) : null;
+        } catch {
+            // non-JSON body — data stays null
+        }
         if (!res.ok) {
             throw { status: res.status, body: data };
         }
@@ -57,8 +62,17 @@ document.addEventListener('DOMContentLoaded', () => {
     function showModalAlert(modalEl, type, message) {
         const area = modalEl.querySelector('[id$="Alerts"]');
         if (!area) return;
-        area.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">`
-            + `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
+        area.innerHTML = '';
+        const alert = document.createElement('div');
+        alert.className = `alert alert-${type} alert-dismissible fade show`;
+        alert.setAttribute('role', 'alert');
+        alert.textContent = message;
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'btn-close';
+        closeBtn.setAttribute('data-bs-dismiss', 'alert');
+        alert.appendChild(closeBtn);
+        area.appendChild(alert);
     }
 
     // ---- state ------------------------------------------------------------
@@ -106,19 +120,48 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         rows.forEach((t) => {
             const tr = document.createElement('tr');
-            const editBtn = canEdit(t)
-                ? `<button type="button" class="btn btn-sm btn-outline-primary editTestBtn" data-name="${t.name}"><i class="fas fa-pen"></i> ${i18n.edit}</button>`
-                : '';
-            const delBtn = canDelete(t)
-                ? `<button type="button" class="btn btn-sm btn-outline-danger deleteTestBtn ms-1" data-name="${t.name}"><i class="fas fa-trash"></i> ${i18n.delete}</button>`
-                : '';
-            tr.innerHTML = `
-                <td><code>${t.name}</code></td>
-                <td>${t.event_key}</td>
-                <td>${scopeLabel(t.applies_to)}</td>
-                <td>${t.test_type}</td>
-                <td>${yearRange(t)}</td>
-                <td class="text-end">${editBtn}${delBtn}</td>`;
+
+            const nameTd = document.createElement('td');
+            const code = document.createElement('code');
+            code.textContent = t.name;
+            nameTd.appendChild(code);
+
+            const eventTd = document.createElement('td');
+            eventTd.textContent = t.event_key;
+
+            const scopeTd = document.createElement('td');
+            scopeTd.textContent = scopeLabel(t.applies_to);
+
+            const typeTd = document.createElement('td');
+            typeTd.textContent = t.test_type;
+
+            const yearsTd = document.createElement('td');
+            yearsTd.textContent = yearRange(t);
+
+            const actionsTd = document.createElement('td');
+            actionsTd.className = 'text-end';
+            if (canEdit(t)) {
+                const editBtn = document.createElement('button');
+                editBtn.type = 'button';
+                editBtn.className = 'btn btn-sm btn-outline-primary editTestBtn';
+                editBtn.dataset.name = t.name;
+                const ei = document.createElement('i');
+                ei.className = 'fas fa-pen';
+                editBtn.append(ei, document.createTextNode(' ' + i18n.edit));
+                actionsTd.appendChild(editBtn);
+            }
+            if (canDelete(t)) {
+                const delBtn = document.createElement('button');
+                delBtn.type = 'button';
+                delBtn.className = 'btn btn-sm btn-outline-danger deleteTestBtn ms-1';
+                delBtn.dataset.name = t.name;
+                const di = document.createElement('i');
+                di.className = 'fas fa-trash';
+                delBtn.append(di, document.createTextNode(' ' + i18n.delete));
+                actionsTd.appendChild(delBtn);
+            }
+
+            tr.append(nameTd, eventTd, scopeTd, typeTd, yearsTd, actionsTd);
             tbody.appendChild(tr);
         });
     }

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -333,7 +333,21 @@ document.addEventListener('DOMContentLoaded', () => {
             sel.appendTo(mount);
         }
     }
-    document.getElementById('testScopeType').addEventListener('change', () => { syncScopeIdField(); regenerate(); });
+    // Reload the /events datalist for the currently selected scope, then rebuild
+    // the assertions. Used whenever the scope changes, since national/diocesan
+    // calendars expose events the General Roman list does not.
+    function reloadEventsThenRegenerate() {
+        return loadEvents(selectedScope())
+            .then(regenerate)
+            .catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
+    }
+    document.getElementById('testScopeType').addEventListener('change', () => {
+        syncScopeIdField();
+        reloadEventsThenRegenerate();
+    });
+    // When a specific national/diocesan calendar is picked in the mounted
+    // CalendarSelect, its change event bubbles to the mount — reload its events.
+    document.getElementById('testScopeIdMount').addEventListener('change', reloadEventsThenRegenerate);
 
     function openEditor(test) {
         state.editing = test ? test.name : null;
@@ -351,7 +365,9 @@ document.addEventListener('DOMContentLoaded', () => {
             typeSel.value = scope.object_type === 'national_calendar_test' ? 'national_calendar'
                 : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
                 : 'general_roman_calendar';
-            loadEvents(test.applies_to).then(() => builder.render(assertionsContainer));
+            loadEvents(test.applies_to)
+                .then(() => builder.render(assertionsContainer))
+                .catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
         } else {
             builder.load({ name: '', event_key: '', description: '', test_type: TestType.ExactCorrespondence, assertions: [] });
             nameEl.value = '';
@@ -361,7 +377,7 @@ document.addEventListener('DOMContentLoaded', () => {
             document.getElementById('testDescription').value = '';
             document.getElementById('testScopeType').value = 'general_roman_calendar';
             assertionsContainer.innerHTML = '';
-            loadEvents(null);
+            loadEvents(null).catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
         }
         syncScopeIdField();
         editorModal.show();

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -429,5 +429,39 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    // ---- delete -----------------------------------------------------------
+
+    const deleteModalEl = document.getElementById('deleteTestModal');
+    const deleteModal = bootstrap.Modal.getOrCreateInstance(deleteModalEl);
+    let deleteTarget = null;
+
+    document.getElementById('testsTableBody').addEventListener('click', (ev) => {
+        const delBtn = ev.target.closest('.deleteTestBtn');
+        if (!delBtn) return;
+        deleteTarget = delBtn.dataset.name;
+        document.getElementById('deleteTestAlerts').innerHTML = '';
+        document.getElementById('deleteTestConfirmText').textContent = i18n.confirmDelete.replace('%s', deleteTarget);
+        deleteModal.show();
+    });
+
+    document.getElementById('confirmDeleteTestBtn').addEventListener('click', async () => {
+        if (!deleteTarget) return;
+        const btn = document.getElementById('confirmDeleteTestBtn');
+        btn.disabled = true;
+        const original = btn.textContent;
+        btn.textContent = i18n.deleting;
+        try {
+            await fetchJson('DELETE', `/tests/${encodeURIComponent(deleteTarget)}`);
+            deleteModal.hide();
+            await loadTests();
+        } catch (err) {
+            const msg = err.status === 403 ? i18n.denied403 : (err.body && err.body.message) ? err.body.message : i18n.failedToLoad;
+            showModalAlert(deleteModalEl, 'danger', msg);
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    });
+
     loadTests();
 });

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -30,7 +30,16 @@ document.addEventListener('DOMContentLoaded', () => {
             opts.headers['Content-Type'] = 'application/json';
             opts.body = JSON.stringify(body);
         }
-        const res = await fetch(apiUrl + path, opts);
+        // Abort after 15s so a stalled Save/Delete can't hang its modal
+        // indefinitely (same AbortController pattern as auth.js admin-scopes).
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 15000);
+        let res;
+        try {
+            res = await fetch(apiUrl + path, { ...opts, signal: controller.signal });
+        } finally {
+            clearTimeout(timeoutId);
+        }
         const text = await res.text();
         let data = null;
         try {
@@ -39,7 +48,12 @@ document.addEventListener('DOMContentLoaded', () => {
             // non-JSON body — data stays null
         }
         if (!res.ok) {
-            throw { status: res.status, body: data };
+            // A real Error (not a plain object) so callers get a stack trace;
+            // status/body carry the API detail the catch handlers switch on.
+            const err = new Error(`HTTP ${res.status}: ${method} ${path}`);
+            err.status = res.status;
+            err.body = data;
+            throw err;
         }
         return data;
     }
@@ -201,12 +215,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return document.querySelector('input[name="testType"]:checked')?.value ?? TestType.ExactCorrespondence;
     }
 
+    /**
+     * Three-state scope reading so the save flow can tell an explicit choice
+     * apart from an incomplete one:
+     *   null      — the user explicitly selected General Roman Calendar
+     *   undefined — a scoped type is selected but no calendar ID is picked yet
+     *   object    — a concrete { national_calendar | diocesan_calendar: id }
+     */
     function selectedScope() {
         const type = document.getElementById('testScopeType').value;
         if (type === 'general_roman_calendar') return null;
         const idEl = document.getElementById('testScopeId');
         const id = idEl ? idEl.value : '';
-        return id ? { [type]: id } : null;
+        return id ? { [type]: id } : undefined;
     }
 
     function eventsPath(appliesTo) {
@@ -222,6 +243,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const res = await fetch(apiUrl + eventsPath(appliesTo), {
             headers: { Accept: 'application/json', 'Accept-Language': config.locale },
         });
+        if (!res.ok) {
+            // Surface the failure to the callers' .catch/showModalAlert handlers
+            // instead of silently rendering an empty events datalist.
+            throw new Error(`${i18n.failedToLoad} (HTTP ${res.status})`);
+        }
         const json = await res.json();
         events = json.litcal_events ?? [];
         const datalist = document.getElementById('testEventKeyList');
@@ -490,7 +516,13 @@ document.addEventListener('DOMContentLoaded', () => {
             showModalAlert(editorModalEl, 'warning', i18n.requiredFields);
             return;
         }
-        const scopePayload = selectedScope() ?? (state.editing ? builder.model.applies_to : null);
+        // undefined = scoped type without an ID picked yet → when editing, keep
+        // the test's existing applies_to; null = explicit General Roman → clear
+        // any previous scope (this must NOT fall back to the old applies_to).
+        const chosen = selectedScope();
+        const scopePayload = chosen === undefined
+            ? (state.editing ? builder.model.applies_to : null)
+            : chosen;
         builder.setMeta({
             name: nameEl.value,
             event_key: document.getElementById('testEventKey').value,

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -8,7 +8,7 @@ import {
     CalendarSelect,
     CalendarSelectFilter,
 } from '@liturgical-calendar/components-js';
-import { AssertionsBuilder, TestType } from './AssertionsBuilder.js';
+import { AssertionsBuilder, TestType, AssertType } from './AssertionsBuilder.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const config = window.AdminTestsConfig;
@@ -252,6 +252,20 @@ document.addEventListener('DOMContentLoaded', () => {
             span.textContent = String(y);
             grid.appendChild(span);
         }
+        const pivot = builder.model.test_type === TestType.ExactCorrespondenceSince
+            ? builder.model.year_since
+            : builder.model.test_type === TestType.ExactCorrespondenceUntil
+                ? builder.model.year_until
+                : null;
+        if (pivot !== null) {
+            grid.querySelectorAll('.testYearSpan').forEach((span) => {
+                const y = Number(span.dataset.year);
+                if (y === pivot) span.classList.add('bg-info');
+                else if (builder.model.test_type === TestType.ExactCorrespondenceSince ? y < pivot : y > pivot) {
+                    span.classList.add('bg-warning');
+                }
+            });
+        }
     }
 
     function regenerate() {
@@ -302,6 +316,22 @@ document.addEventListener('DOMContentLoaded', () => {
             const a = builder.model.assertions.find((x) => x.year === year);
             document.getElementById('commentText').value = a && 'comment' in a ? a.comment : '';
             bootstrap.Modal.getOrCreateInstance(document.getElementById('testCommentModal')).show();
+        } else if (ev.target.closest('.editDate')) {
+            const dateVal = card.querySelector('.expectedValue');
+            const current = (dateVal.getAttribute('data-value') || '').split('T')[0];
+            const input = document.createElement('input');
+            input.type = 'date';
+            input.className = 'form-control form-control-sm';
+            input.value = current;
+            dateVal.replaceChildren(input);
+            input.focus();
+            input.addEventListener('change', () => {
+                if (input.value) {
+                    builder.setExpectedDate(year, `${input.value}T00:00:00+00:00`);
+                }
+                builder.render(assertionsContainer);
+            });
+            input.addEventListener('blur', () => builder.render(assertionsContainer));
         }
     });
     assertionsContainer.addEventListener('change', (ev) => {
@@ -317,6 +347,38 @@ document.addEventListener('DOMContentLoaded', () => {
         builder.setComment(year, document.getElementById('commentText').value);
         builder.render(assertionsContainer);
         bootstrap.Modal.getInstance(document.getElementById('testCommentModal')).hide();
+    });
+
+    // The base date drives per-year expected values. For events without a fixed
+    // month/day (movable feasts) this is the ONLY way to seed dates: setting it
+    // updates baseMonthDay so toggleAssert can restore dates, and refreshes every
+    // eventExists assertion to the new month/day in its own year.
+    document.getElementById('baseDate').addEventListener('change', (ev) => {
+        const v = ev.target.value; // YYYY-MM-DD
+        if (!v) return;
+        const [, m, d] = v.split('-').map(Number);
+        builder.baseMonthDay = { month: m, day: d };
+        builder.model.assertions.forEach((a) => {
+            if (a.assert === AssertType.EventTypeExact) {
+                builder.setExpectedDate(
+                    a.year,
+                    `${String(a.year).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}T00:00:00+00:00`,
+                );
+            }
+        });
+        builder.render(assertionsContainer);
+    });
+
+    // For Since/Until types, clicking a year in the overview grid sets the pivot
+    // (year_since / year_until) and re-splits the assertions around it.
+    document.getElementById('yearGrid').addEventListener('click', (ev) => {
+        const span = ev.target.closest('.testYearSpan');
+        if (!span) return;
+        const tt = selectedTestType();
+        if (tt !== TestType.ExactCorrespondenceSince && tt !== TestType.ExactCorrespondenceUntil) return;
+        builder.setPivot(Number(span.dataset.year));
+        builder.render(assertionsContainer);
+        renderYearGrid();
     });
 
     async function syncScopeIdField() {
@@ -349,7 +411,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // CalendarSelect, its change event bubbles to the mount — reload its events.
     document.getElementById('testScopeIdMount').addEventListener('change', reloadEventsThenRegenerate);
 
-    function openEditor(test) {
+    async function openEditor(test) {
         state.editing = test ? test.name : null;
         document.getElementById('testEditorAlerts').innerHTML = '';
         const nameEl = document.getElementById('testName');
@@ -357,7 +419,8 @@ document.addEventListener('DOMContentLoaded', () => {
             builder.load(test);
             nameEl.value = test.name;
             nameEl.setAttribute('readonly', '');
-            document.querySelector(`input[name="testType"][value="${test.test_type}"]`).checked = true;
+            const typeRadio = document.querySelector(`input[name="testType"][value="${test.test_type}"]`);
+            if (typeRadio) typeRadio.checked = true;
             document.getElementById('testEventKey').value = test.event_key;
             document.getElementById('testDescription').value = test.description;
             const scope = deriveScope(test.applies_to);
@@ -365,6 +428,22 @@ document.addEventListener('DOMContentLoaded', () => {
             typeSel.value = scope.object_type === 'national_calendar_test' ? 'national_calendar'
                 : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
                 : 'general_roman_calendar';
+            // Fix 4: Seed slider from loaded test assertions before any slider change fires
+            const years = test.assertions.map((a) => a.year);
+            if (years.length) {
+                const lo = Math.min(...years);
+                const hi = Math.max(...years);
+                const lower = document.getElementById('lowerRange');
+                const upper = document.getElementById('upperRange');
+                lower.value = String(lo);
+                upper.value = String(hi);
+                const slider = lower.parentNode;
+                slider.style.setProperty('--value-a', String(lo));
+                slider.style.setProperty('--text-value-a', `"${lo}"`);
+                slider.style.setProperty('--value-b', String(hi));
+                slider.style.setProperty('--text-value-b', `"${hi}"`);
+                renderYearGrid();
+            }
             loadEvents(test.applies_to)
                 .then(() => builder.render(assertionsContainer))
                 .catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
@@ -379,7 +458,17 @@ document.addEventListener('DOMContentLoaded', () => {
             assertionsContainer.innerHTML = '';
             loadEvents(null).catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
         }
-        syncScopeIdField();
+        await syncScopeIdField();
+        if (test) {
+            // Preselect the loaded test's calendar in the freshly-mounted select so
+            // selectedScope() round-trips applies_to instead of silently rescoping
+            // the test to General Roman (or 403ing a scoped editor).
+            const scope = deriveScope(test.applies_to);
+            const idEl = document.getElementById('testScopeId');
+            if (idEl && scope.object_type !== 'general_roman_calendar_test') {
+                idEl.value = scope.object_id;
+            }
+        }
         editorModal.show();
     }
 
@@ -399,12 +488,13 @@ document.addEventListener('DOMContentLoaded', () => {
             showModalAlert(editorModalEl, 'warning', i18n.requiredFields);
             return;
         }
+        const scopePayload = selectedScope() ?? (state.editing ? builder.model.applies_to : null);
         builder.setMeta({
             name: nameEl.value,
             event_key: document.getElementById('testEventKey').value,
             description: document.getElementById('testDescription').value,
             test_type: selectedTestType(),
-            applies_to: selectedScope(),
+            applies_to: scopePayload,
         });
         const payload = builder.serialize();
         btn.disabled = true;

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -296,7 +296,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const grid = document.getElementById('yearGrid');
         const { minYear, maxYear } = sliderYears();
         const tt = builder.model.test_type;
-        const excluded = new Set(builder.model.excludes ?? []);
+        // Excluded = assertion absence. The length guard prevents an all-striped
+        // grid in the create flow before the first generation.
+        const asserted = new Set(builder.model.assertions.map((a) => a.year));
         const notExists = new Set(
             builder.model.assertions
                 .filter((a) => a.assert === AssertType.EventNotExists)
@@ -314,7 +316,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const span = document.createElement('span');
             span.className = `testYearSpan year-${y}`;
             span.dataset.year = String(y);
-            if (excluded.has(y)) {
+            if (builder.model.assertions.length > 0 && !asserted.has(y)) {
                 span.classList.add('deleted');
                 span.title = i18n.excludedRestore.replace('%s', String(y));
                 grid.appendChild(span);
@@ -337,13 +339,15 @@ document.addEventListener('DOMContentLoaded', () => {
             span.appendChild(xmark);
             const { title, sunday } = yearDateAttrs(y);
             if (title) span.title = title;
+            // Background-color precedence: pivot > not-exists. Sunday is an
+            // additive cross overlay (background-image) that composes over any
+            // background-color instead of competing in a precedence chain.
             if (y === pivot) {
                 span.classList.add('bg-info');
             } else if (notExists.has(y)) {
                 span.classList.add('bg-warning');
-            } else if (sunday) {
-                span.classList.add('bg-light');
             }
+            if (sunday) span.classList.add('sunday');
             grid.appendChild(span);
         }
     }
@@ -357,15 +361,26 @@ document.addEventListener('DOMContentLoaded', () => {
         const pivot = (tt === TestType.ExactCorrespondenceSince || tt === TestType.ExactCorrespondenceUntil)
             ? minYear
             : null;
-        // Preserve exclusions when the event/type/slider changes; generate()
-        // skips excluded years, so without this every regeneration would
-        // silently restore them.
+        // Exclusions = assertion absence: derive excludedYears from gaps inside
+        // the asserted span so they survive event/type/slider changes. Years
+        // outside [lo, hi] are never added, so slider-widening auto-includes
+        // newly visible years.
+        const assertedYears = builder.model.assertions.map((a) => a.year);
+        const excludedYears = [];
+        if (assertedYears.length) {
+            const lo = Math.min(...assertedYears);
+            const hi = Math.max(...assertedYears);
+            const assertedSet = new Set(assertedYears);
+            for (let y = Math.max(minYear, lo); y <= Math.min(maxYear, hi); y++) {
+                if (!assertedSet.has(y)) excludedYears.push(y);
+            }
+        }
         builder.generate({
             event,
             minYear,
             maxYear,
             pivotYear: pivot,
-            excludedYears: builder.model.excludes ?? [],
+            excludedYears,
         });
         document.getElementById('testDescription').value = builder.model.description;
         document.getElementById('baseDate').value = event.month && event.day

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -190,5 +190,228 @@ document.addEventListener('DOMContentLoaded', () => {
     // Expose internals for later tasks (editor/delete wiring appended below).
     window.__adminTests = { state, fetchJson, deriveScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, ApiClient };
 
+    // ---- editor -----------------------------------------------------------
+
+    const editorModalEl = document.getElementById('testEditorModal');
+    const editorModal = bootstrap.Modal.getOrCreateInstance(editorModalEl);
+    const builder = new AssertionsBuilder({ locale: config.locale });
+    let events = [];
+
+    function selectedTestType() {
+        return document.querySelector('input[name="testType"]:checked')?.value ?? TestType.ExactCorrespondence;
+    }
+
+    function selectedScope() {
+        const type = document.getElementById('testScopeType').value;
+        if (type === 'general_roman_calendar') return null;
+        const idEl = document.getElementById('testScopeId');
+        const id = idEl ? idEl.value : '';
+        return id ? { [type]: id } : null;
+    }
+
+    function eventsPath(appliesTo) {
+        if (appliesTo && appliesTo.diocesan_calendar) return `/events/diocese/${appliesTo.diocesan_calendar}`;
+        if (appliesTo && appliesTo.national_calendar) return `/events/nation/${appliesTo.national_calendar}`;
+        return '/events';
+    }
+
+    async function loadEvents(appliesTo) {
+        const res = await fetch(apiUrl + eventsPath(appliesTo), {
+            headers: { Accept: 'application/json', 'Accept-Language': config.locale },
+            credentials: 'include',
+        });
+        const json = await res.json();
+        events = json.litcal_events ?? [];
+        const datalist = document.getElementById('testEventKeyList');
+        datalist.innerHTML = '';
+        events.forEach((e) => {
+            const opt = document.createElement('option');
+            opt.value = e.event_key;
+            opt.textContent = `${e.name} (${e.grade_lcl})`;
+            if (e.month != null) opt.dataset.month = String(e.month);
+            if (e.day != null) opt.dataset.day = String(e.day);
+            if (e.grade != null) opt.dataset.grade = String(e.grade);
+            datalist.appendChild(opt);
+        });
+    }
+
+    function sliderYears() {
+        const a = Number(document.getElementById('lowerRange').value);
+        const b = Number(document.getElementById('upperRange').value);
+        return { minYear: Math.min(a, b), maxYear: Math.max(a, b) };
+    }
+
+    function renderYearGrid() {
+        const grid = document.getElementById('yearGrid');
+        const { minYear, maxYear } = sliderYears();
+        grid.innerHTML = '';
+        for (let y = minYear; y <= maxYear; y++) {
+            const span = document.createElement('span');
+            span.className = `testYearSpan year-${y}`;
+            span.dataset.year = String(y);
+            span.textContent = String(y);
+            grid.appendChild(span);
+        }
+    }
+
+    function regenerate() {
+        const event = events.find((e) => e.event_key === document.getElementById('testEventKey').value);
+        if (!event) return;
+        const { minYear, maxYear } = sliderYears();
+        const tt = selectedTestType();
+        builder.setMeta({ test_type: tt, applies_to: selectedScope() });
+        const pivot = (tt === TestType.ExactCorrespondenceSince || tt === TestType.ExactCorrespondenceUntil)
+            ? minYear
+            : null;
+        builder.generate({ event, minYear, maxYear, pivotYear: pivot });
+        document.getElementById('testDescription').value = builder.model.description;
+        document.getElementById('baseDate').value = event.month && event.day
+            ? `${minYear}-${String(event.month).padStart(2, '0')}-${String(event.day).padStart(2, '0')}`
+            : '';
+        builder.render(document.getElementById('assertionsContainer'));
+        renderYearGrid();
+    }
+
+    document.getElementById('testEventKey').addEventListener('change', regenerate);
+    document.querySelectorAll('input[name="testType"]').forEach((el) => el.addEventListener('change', regenerate));
+    document.getElementById('lowerRange').addEventListener('change', regenerate);
+    document.getElementById('upperRange').addEventListener('change', regenerate);
+
+    // sync slider CSS custom properties as the user drags
+    ['lowerRange', 'upperRange'].forEach((id, idx) => {
+        const el = document.getElementById(id);
+        el.addEventListener('input', () => {
+            const prop = idx === 0 ? '--value-a' : '--value-b';
+            const textProp = idx === 0 ? '--text-value-a' : '--text-value-b';
+            el.parentNode.style.setProperty(prop, el.value);
+            el.parentNode.style.setProperty(textProp, `"${el.value}"`);
+        });
+    });
+
+    // per-year card interactions (event-delegated on the assertions container)
+    const assertionsContainer = document.getElementById('assertionsContainer');
+    assertionsContainer.addEventListener('click', (ev) => {
+        const card = ev.target.closest('[data-year]');
+        if (!card) return;
+        const year = Number(card.dataset.year);
+        if (ev.target.closest('.toggleAssert')) {
+            builder.toggleAssert(year);
+            builder.render(assertionsContainer);
+        } else if (ev.target.closest('.comment')) {
+            document.getElementById('commentYear').value = String(year);
+            const a = builder.model.assertions.find((x) => x.year === year);
+            document.getElementById('commentText').value = a && 'comment' in a ? a.comment : '';
+            bootstrap.Modal.getOrCreateInstance(document.getElementById('testCommentModal')).show();
+        }
+    });
+    assertionsContainer.addEventListener('change', (ev) => {
+        const card = ev.target.closest('[data-year]');
+        if (!card) return;
+        const year = Number(card.dataset.year);
+        if (ev.target.matches('.assertionText')) {
+            builder.setAssertionText(year, ev.target.value);
+        }
+    });
+    document.getElementById('saveCommentBtn').addEventListener('click', () => {
+        const year = Number(document.getElementById('commentYear').value);
+        builder.setComment(year, document.getElementById('commentText').value);
+        builder.render(assertionsContainer);
+        bootstrap.Modal.getInstance(document.getElementById('testCommentModal')).hide();
+    });
+
+    async function syncScopeIdField() {
+        const type = document.getElementById('testScopeType').value;
+        const mount = document.getElementById('testScopeIdMount');
+        mount.innerHTML = '';
+        if (type === 'national_calendar' || type === 'diocesan_calendar') {
+            const client = await ApiClient.init(apiUrl).catch(() => null);
+            if (!client) return;
+            const filter = type === 'national_calendar'
+                ? CalendarSelectFilter.NATIONAL_CALENDARS
+                : CalendarSelectFilter.DIOCESAN_CALENDARS;
+            const sel = new CalendarSelect(config.locale).filter(filter).allowNull(true).class('form-select').id('testScopeId');
+            sel.appendTo(mount);
+        }
+    }
+    document.getElementById('testScopeType').addEventListener('change', () => { syncScopeIdField(); regenerate(); });
+
+    function openEditor(test) {
+        state.editing = test ? test.name : null;
+        document.getElementById('testEditorAlerts').innerHTML = '';
+        const nameEl = document.getElementById('testName');
+        if (test) {
+            builder.load(test);
+            nameEl.value = test.name;
+            nameEl.setAttribute('readonly', '');
+            document.querySelector(`input[name="testType"][value="${test.test_type}"]`).checked = true;
+            document.getElementById('testEventKey').value = test.event_key;
+            document.getElementById('testDescription').value = test.description;
+            const scope = deriveScope(test.applies_to);
+            const typeSel = document.getElementById('testScopeType');
+            typeSel.value = scope.object_type === 'national_calendar_test' ? 'national_calendar'
+                : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
+                : 'general_roman_calendar';
+            loadEvents(test.applies_to).then(() => builder.render(assertionsContainer));
+        } else {
+            builder.load({ name: '', event_key: '', description: '', test_type: TestType.ExactCorrespondence, assertions: [] });
+            nameEl.value = '';
+            nameEl.removeAttribute('readonly');
+            document.getElementById('tt-exact').checked = true;
+            document.getElementById('testEventKey').value = '';
+            document.getElementById('testDescription').value = '';
+            document.getElementById('testScopeType').value = 'general_roman_calendar';
+            assertionsContainer.innerHTML = '';
+            loadEvents(null);
+        }
+        syncScopeIdField();
+        editorModal.show();
+    }
+
+    document.getElementById('createTestBtn').addEventListener('click', () => openEditor(null));
+    document.getElementById('testsTableBody').addEventListener('click', (ev) => {
+        const editBtn = ev.target.closest('.editTestBtn');
+        if (editBtn) {
+            const test = state.tests.find((t) => t.name === editBtn.dataset.name);
+            if (test) openEditor(test);
+        }
+    });
+
+    document.getElementById('saveTestBtn').addEventListener('click', async () => {
+        const btn = document.getElementById('saveTestBtn');
+        const nameEl = document.getElementById('testName');
+        if (!nameEl.checkValidity() || !document.getElementById('testEventKey').value) {
+            showModalAlert(editorModalEl, 'warning', i18n.requiredFields);
+            return;
+        }
+        builder.setMeta({
+            name: nameEl.value,
+            event_key: document.getElementById('testEventKey').value,
+            description: document.getElementById('testDescription').value,
+            test_type: selectedTestType(),
+            applies_to: selectedScope(),
+        });
+        const payload = builder.serialize();
+        btn.disabled = true;
+        const original = btn.textContent;
+        btn.textContent = i18n.saving;
+        try {
+            if (state.editing) {
+                await fetchJson('PATCH', `/tests/${encodeURIComponent(state.editing)}`, payload);
+            } else {
+                await fetchJson('PUT', '/tests', payload);
+            }
+            editorModal.hide();
+            await loadTests();
+        } catch (err) {
+            const msg = err.status === 403 ? i18n.denied403
+                : err.status === 409 ? i18n.conflict409
+                : (err.body && err.body.message) ? err.body.message : i18n.failedToLoad;
+            showModalAlert(editorModalEl, 'danger', msg);
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    });
+
     loadTests();
 });

--- a/docs/superpowers/HANDOFF-admin-tests-phases-2-3.md
+++ b/docs/superpowers/HANDOFF-admin-tests-phases-2-3.md
@@ -1,0 +1,94 @@
+# Handoff — admin-tests feature, phases 2 & 3
+
+Continue a multi-phase feature: porting test-definition editing into the LiturgicalCalendar admin
+frontend. **Phase 1 is done; pick up phases 2 and 3.**
+
+## Read this first (source of truth)
+
+The design spec covering all three phases lives in this repo on branch `feature/admin-tests-page`:
+
+```text
+docs/superpowers/specs/2026-06-29-admin-tests-page-design.md
+```
+
+Read it fully before doing anything — it has the locked decisions, the Editor UX section, and an
+Open items list. Also check the auto-loaded `MEMORY.md` entries, especially "Shared checkout,
+concurrent agents", "API runs in Docker", and the WebSocket gotchas.
+
+## Status
+
+- **Phase 1 (API) — DONE & MERGED.** `GET /auth/test-scopes` is live on `development`
+  (PR #678, merge commit `3e264ea6`). It returns
+  `{ is_global_admin: bool, editor: [{object_type, object_id}], admin: [{object_type, object_id}] }`
+  where `object_type` is one of `national_calendar_test`, `diocesan_calendar_test`,
+  `general_roman_calendar_test`. Use it for the frontend's exact gating: show **Edit** when
+  `is_global_admin` OR the test's scope object is in `editor`; show **Delete** when `is_global_admin`
+  OR it is in `admin`. Test-definition CRUD already exists: `GET /tests` (list), `PUT /tests`
+  (create), `PATCH /tests/{name}` (edit), `DELETE /tests/{name}` (delete); writes require the Zitadel
+  `test_editor` role plus scoped OpenFGA.
+- **Phase 2 (frontend admin-tests page)** and **Phase 3 (UnitTestInterface editor retirement)** —
+  NOT STARTED. Their implementation plans have not been written yet (only phase 1's plan existed).
+
+## What to do
+
+1. Use the `superpowers:writing-plans` skill to write the phase 2 plan from the spec, then the
+   phase 3 plan. Save under `docs/superpowers/plans/` (phase 2 → this frontend repo; phase 3 →
+   the UnitTestInterface repo). Bite-sized TDD, no placeholders, real code.
+2. Execute each via `superpowers:subagent-driven-development` **in an isolated git worktree** (the
+   user requires worktrees). Branch off `development`; copy gitignored env files if tests need them;
+   run a baseline test before starting. Use a cheap model for transcription tasks, mid-tier for
+   reviewers, the most-capable model for the final whole-branch review.
+3. Per phase: open a PR to `development`, then ask the user before merging.
+
+## Locked decisions (in the spec — do not re-litigate)
+
+- **Scope:** test-definition CRUD only; the live WebSocket test RUNNER stays in UnitTestInterface.
+- **Permission UX:** page gated to `test_editor`/admin; full unscoped list; per-row edit/delete
+  gated via `/auth/test-scopes`; the API is the backstop.
+- **Build:** a dedicated `admin-tests.php` + `assets/js/admin-tests.js` module modeled on the
+  bespoke `admin-permissions.js` (NOT the `createAdminModule` factory — that is status-workflow
+  only). Keep a clean generic/specific seam (it seeds a future coordinated admin-page factory — a
+  separate initiative; do NOT build it now).
+- **Editor:** faithfully port the UnitTestInterface editor — test-type buttons + icons, the
+  `/events` datalist (`data-month`/`data-day`/`data-grade`), base date, per-year assertion cards
+  with the `eventExists AND hasExpectedDate` ↔ `eventNotExists` toggle and color coding — with two
+  modernizations: (a) drop Isotope, use native CSS grid for the year grid; (b) state-first model
+  (`serialize()` reads the model, not the DOM); use `<textarea>` not `contenteditable`. The
+  year-range control: PORT the dual-range slider as-is from UnitTestInterface
+  (`assets/css/multi-range-slider.css`). `name` is the resource key, so render it read-only when
+  editing an existing test.
+- **Phase 3:** remove editing from UnitTestInterface `admin.php`/`admin.js`/`AssertionsBuilder.js`;
+  KEEP the runner (`index.php`/`resources.php` + WS backend); leave a redirect/notice pointing to
+  the new admin page.
+
+## Source references (gathered while writing the spec)
+
+- **Frontend pattern to mirror:** `admin-permissions.php` + `assets/js/admin-permissions.js`
+  (bespoke form-CRUD: create modal, dynamic `CalendarSelect`-by-type, `isGlobalAdmin`/
+  `isResourceAdmin` gating, `ApiClient`/`CalendarSelect` imports, `/auth/me` cookie auth). Layout:
+  `layout/head.php`, `header.php`, `footer.php`; config injected as a `window.*Config` JSON blob.
+- **Editor to port:** in the UnitTestInterface repo — `admin.php`, `assets/js/admin.js`,
+  `assets/js/AssertionsBuilder.js`, `assets/css/multi-range-slider.css`, `components/NewTestModal.php`.
+  Assertion shape: `{year:int, expected_value:RFC3339|null, assert:'eventNotExists'|'eventExists
+  AND hasExpectedDate', assertion:string, comment?:string}`. `LitCalTest` fields: `name`,
+  `event_key`, `description`, `test_type` (`exactCorrespondence`|`variableCorrespondence`),
+  `assertions`, `applies_to`/`excludes`, `year_since`/`year_until`. Schema:
+  API repo `jsondata/schemas/LitCalTest.json`.
+- **Open items from the spec to resolve during implementation:** (a) does the global `admin` role
+  satisfy `AuthorizationMiddleware::forTestEditor` (can a global admin write without the explicit
+  `test_editor` role)? (b) the exact `/events` response shape for the `event_key` datalist.
+
+## Conventions & hazards
+
+- The **API repo's main checkout is shared by other concurrent agents** — never `git checkout` or
+  commit in a shared main checkout; create your worktree FIRST and work only there (`git push` is
+  safe). Check `git worktree list` and for other agents before touching any repo. Phases 2–3 are
+  frontend + UnitTestInterface, so likely no API-repo work — but apply the same worktree discipline.
+- PR target is always `development`. Signed commits (GPG — the user may need to unlock the passphrase;
+  never disable signing). Do not skip git hooks. Lint all `.md` (markdownlint). Frontend e2e is
+  Playwright.
+- A future scope-pooling question (calendar-editor vs test-editor scopes) is tracked in org
+  Discussion #676 — out of scope.
+
+Start by reading the spec, confirm your understanding of phases 2 and 3 with the user, then write
+the phase 2 plan.

--- a/docs/superpowers/plans/2026-06-29-admin-tests-page-phase2.md
+++ b/docs/superpowers/plans/2026-06-29-admin-tests-page-phase2.md
@@ -1,0 +1,2219 @@
+# Admin Tests Page (Phase 2 — Frontend) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement
+> this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `admin-tests` page to `LiturgicalCalendarFrontend` that lets `test_editor`/admin users create, edit, delete, and view liturgical test
+definitions via the existing `/tests` API, faithfully porting the UnitTestInterface editor (state-first, native CSS grid, no Isotope).
+
+**Architecture:** A dedicated `admin-tests.php` (auth-gated page, config blob, list + two modals) plus a bespoke native-ESM module
+`assets/js/admin-tests.js` (modeled on `admin-permissions.js`, with a clean generic/specific seam) and a ported, **state-first**
+`assets/js/AssertionsBuilder.js` whose in-memory model is the single source of truth (`load()` populates it, `serialize()` reads it — never the DOM).
+Per-row Edit/Delete buttons are gated against the caller's scopes from `GET /auth/test-scopes` (live since Phase 1); the API is the hard backstop.
+
+**Tech Stack:** PHP 8.1+ (page), native ES modules (no bundler; importmap resolves `@liturgical-calendar/components-js`), Bootstrap 5 + FontAwesome 7
+(already loaded), gettext (`_()`) for i18n, Vitest (new dev-dependency) for AssertionsBuilder unit tests, Playwright for e2e (route-stubbed specs in
+`e2e/` + one real-seeded spec in `e2e/rbac/`).
+
+## Global Constraints
+
+- **Branch/PR:** work on the feature branch in an isolated git worktree; PR targets `development`, never `stable`. Commits are GPG-signed; never `--no-verify`.
+- **No bundler:** `assets/js/admin-tests.js` is loaded automatically as `<script type="module">` by `layout/footer.php` (it is NOT in the non-module
+  list `['admin-applications','admin-role-requests']`). `assets/css/admin-tests.css` is auto-loaded by `layout/head.php`. Do not edit footer/head
+  loaders for these two files.
+- **Imports:** `import { ApiClient, CalendarSelect, CalendarSelectFilter } from '@liturgical-calendar/components-js';` and `import {
+  AssertionsBuilder, TestType, AssertType } from './AssertionsBuilder.js';`.
+- **All API calls:** `credentials: 'include'`, `Accept: application/json`, and `Content-Type: application/json` on writes. Base URL from `window.AdminTestsConfig.apiUrl`.
+- **RFC 3339 dates:** `expected_value` is always `YYYY-MM-DDT00:00:00+00:00` (UTC midnight) or `null`. Compute via `new Date(Date.UTC(year, month-1,
+  day)).toISOString().split('T')[0] + 'T00:00:00+00:00'`.
+- **Test name pattern (schema):** `^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$`. `name` is the resource key for `PATCH/DELETE
+  /tests/{name}` → render it **read-only when editing**.
+- **Test types:** `exactCorrespondence`, `exactCorrespondenceSince` (requires `year_since`), `exactCorrespondenceUntil` (requires `year_until`),
+  `variableCorrespondence`. Schema: `exactCorrespondence` and `variableCorrespondence` share the base shape (no pivot year); Since/Until each require
+  their pivot year.
+- **Assert shapes (schema):** `eventNotExists` → `expected_value: null`; `eventExists AND hasExpectedDate` → `expected_value: <RFC3339 string>`.
+  Required keys per assertion: `year`, `expected_value`, `assert`, `assertion`. `comment` is optional.
+- **Slider bounds:** 1970–2050 (the ported dual-range slider).
+- **Markdown:** run `yarn lint:md` on any `.md` touched.
+- **Lint:** run `yarn lint` (eslint) on JS changes before committing.
+- **Toolchain:** this repo uses **Yarn 4 with the `node_modules` linker** (`.yarnrc.yml` sets `nodeLinker: node-modules`; it switched off PnP because
+  Vite 7.2+/Playwright crash under PnP — which is exactly why Vitest works here). Use `yarn` for everything (`yarn install`, `yarn add -D <pkg>`,
+  `yarn test:unit`, `yarn lint`, `yarn playwright test …`). Never use `npm`/`npx`/`package-lock.json`. After adding a dependency, commit `package.json`
+  and `yarn.lock` only (`node_modules/`, `.yarn/*`, `.pnp.*` are git-ignored). The lockfile enforces `npmMinimalAgeGate: "7d"` (no packages published in
+  the last 7 days) — the pinned `vitest`/`jsdom` versions below are old enough to satisfy it.
+
+---
+
+## File Structure
+
+**Create:**
+
+- `assets/js/AssertionsBuilder.js` — ported, state-first assertion model + renderer. Public API: `load()`, `generate()`, `serialize()`, `render()`, and mutators.
+- `assets/js/admin-tests.js` — page module (bootstrap, list, editor glue, CRUD).
+- `assets/css/multi-range-slider.css` — dual-range slider, ported verbatim from UnitTestInterface.
+- `assets/css/admin-tests.css` — `@import`s the slider CSS + page-specific grid styles (auto-loaded by head.php).
+- `admin-tests.php` — the page.
+- `vitest.config.js` — Vitest config (jsdom env).
+- `assets/js/__tests__/AssertionsBuilder.test.js` — unit tests.
+- `e2e/admin-tests.spec.ts` — Playwright route-stubbed specs (gating + CRUD).
+- `e2e/rbac/13-admin-tests-crud.spec.ts` — Playwright real-seeded spec (end-to-end confidence).
+
+**Modify:**
+
+- `includes/common.php:245` — add `'admin-tests'` to `$adminPages`.
+- `layout/header.php` — add the sidebar nav link.
+- `admin-dashboard.php` — add the dashboard card.
+- `package.json` — add Vitest dev-dependency + `test:unit` script.
+
+---
+
+## Interfaces (authoritative signatures used across tasks)
+
+`AssertionsBuilder` (in `assets/js/AssertionsBuilder.js`):
+
+```text
+new AssertionsBuilder({ locale = 'en' } = {})
+
+// state (single source of truth)
+.model = {
+  name, event_key, description, test_type,
+  applies_to: null | { national_calendar: id } | { diocesan_calendar: id },
+  excludes:   null | object,
+  year_since: null | number,
+  year_until: null | number,
+  assertions: Assertion[]   // {year, expected_value, assert, assertion, comment?}
+}
+.baseMonthDay = null | { month: number, day: number }
+.event        = null | { event_key, name, grade, grade_lcl, month, day }
+
+load(def): this                       // populate model from a LitCalTest object
+setMeta({name, event_key, description, test_type, applies_to, excludes}): this
+generate({ event, minYear, maxYear, pivotYear = null, excludedYears = [] }): this
+serialize(): object                   // schema-valid LitCalTest
+toggleAssert(year): this
+setExpectedDate(year, iso): this
+setAssertionText(year, text): this
+setComment(year, text /* '' clears */): this
+excludeYear(year): this
+setPivot(year): this                  // re-split eventNotExists/eventExists for Since/Until
+render(container): void               // build native-grid DOM into container
+```
+
+Enums exported: `TestType`, `AssertType`, `LitGrade`, plus `Assertion` class.
+
+`admin-tests.js` generic seam (extraction candidates for a future factory):
+
+```text
+fetchJson(method, path, body?): Promise<any>      // wraps fetch with credentials + headers, throws {status, body}
+gateByScope(scopeObj, scopes): boolean
+deriveScope(appliesTo): { object_type, object_id }
+renderTableRows(tests, scopesState): void
+showModalAlert(modalEl, type, message): void
+```
+
+---
+
+### Task 1: Vitest harness + AssertionsBuilder module scaffold
+
+**Files:**
+
+- Modify: `package.json`
+- Create: `vitest.config.js`
+- Create: `assets/js/AssertionsBuilder.js`
+- Test: `assets/js/__tests__/AssertionsBuilder.test.js`
+
+**Interfaces:**
+
+- Produces: a runnable `yarn test:unit`; the `AssertionsBuilder` module exporting `TestType`, `AssertType`, `LitGrade`, `Assertion`.
+
+- [ ] **Step 1: Add Vitest dev-dependency and script**
+
+Edit `package.json`: add to `devDependencies` (keep alphabetical where the file is) `"vitest": "^2.1.8"` and `"jsdom": "^25.0.1"`, and add to `scripts`:
+
+```json
+"test:unit": "vitest run",
+"test:unit:watch": "vitest"
+```
+
+- [ ] **Step 2: Create `vitest.config.js`**
+
+```javascript
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+        include: ['assets/js/__tests__/**/*.test.js'],
+        globals: true,
+    },
+});
+```
+
+- [ ] **Step 3: Install and write the failing test**
+
+Run: `yarn install`
+
+Create `assets/js/__tests__/AssertionsBuilder.test.js`:
+
+```javascript
+import { describe, it, expect } from 'vitest';
+import { TestType, AssertType, LitGrade, Assertion } from '../AssertionsBuilder.js';
+
+describe('enums', () => {
+    it('exposes the four test types', () => {
+        expect(TestType.ExactCorrespondence).toBe('exactCorrespondence');
+        expect(TestType.ExactCorrespondenceSince).toBe('exactCorrespondenceSince');
+        expect(TestType.ExactCorrespondenceUntil).toBe('exactCorrespondenceUntil');
+        expect(TestType.VariableCorrespondence).toBe('variableCorrespondence');
+    });
+
+    it('exposes the two assert types', () => {
+        expect(AssertType.EventNotExists).toBe('eventNotExists');
+        expect(AssertType.EventTypeExact).toBe('eventExists AND hasExpectedDate');
+    });
+
+    it('maps liturgical grades to strings', () => {
+        expect(LitGrade.toString(LitGrade.FEAST)).toBe('FEAST');
+    });
+});
+
+describe('Assertion', () => {
+    it('omits comment when not provided', () => {
+        const a = new Assertion(2024, null, AssertType.EventNotExists, 'x');
+        expect('comment' in a).toBe(false);
+        expect(a.year).toBe(2024);
+    });
+
+    it('keeps comment when provided', () => {
+        const a = new Assertion(2024, null, AssertType.EventNotExists, 'x', 'note');
+        expect(a.comment).toBe('note');
+    });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `yarn test:unit`
+Expected: FAIL — cannot resolve `../AssertionsBuilder.js` (module not created yet).
+
+- [ ] **Step 5: Create the module with enums + Assertion**
+
+Create `assets/js/AssertionsBuilder.js`:
+
+```javascript
+/**
+ * State-first Assertions Builder for the admin-tests editor.
+ * The in-memory model is the single source of truth; serialize() reads the
+ * model, never the DOM. Ported from UnitTestInterface (Isotope removed,
+ * contenteditable replaced by <textarea>).
+ * @module AssertionsBuilder
+ */
+
+export const TestType = Object.freeze({
+    ExactCorrespondence:      'exactCorrespondence',
+    ExactCorrespondenceSince: 'exactCorrespondenceSince',
+    ExactCorrespondenceUntil: 'exactCorrespondenceUntil',
+    VariableCorrespondence:   'variableCorrespondence',
+});
+
+export const AssertType = Object.freeze({
+    EventNotExists: 'eventNotExists',
+    EventTypeExact: 'eventExists AND hasExpectedDate',
+});
+
+export const LitGrade = Object.freeze({
+    WEEKDAY: 0, COMMEMORATION: 1, OPTIONAL_MEMORIAL: 2, MEMORIAL: 3,
+    FEAST: 4, FEAST_OF_THE_LORD: 5, SOLEMNITY: 6, HIGHER_SOLEMNITY: 7,
+    stringVals: ['weekday', 'commemoration', 'optional memorial', 'Memorial',
+        'FEAST', 'FEAST OF THE LORD', 'SOLEMNITY', 'HIGHER SOLEMNITY'],
+    toString: (n) => LitGrade.stringVals[parseInt(n, 10)],
+});
+
+/**
+ * A single per-year assertion. `comment` is only set when non-empty so it is
+ * omitted from serialization (matching the schema's optional `comment`).
+ */
+export class Assertion {
+    constructor(year, expected_value, assert, assertion, comment = null) {
+        this.year = year;
+        this.expected_value = expected_value;
+        this.assert = assert;
+        this.assertion = assertion;
+        if (comment !== null && comment !== '') {
+            this.comment = comment;
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `yarn test:unit`
+Expected: PASS (all three enum tests + both Assertion tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json yarn.lock vitest.config.js assets/js/AssertionsBuilder.js assets/js/__tests__/AssertionsBuilder.test.js
+git commit -m "test(admin-tests): scaffold Vitest + AssertionsBuilder enums and Assertion"
+```
+
+---
+
+### Task 2: AssertionsBuilder — `load()` / `setMeta()` / `serialize()` round-trip
+
+**Files:**
+
+- Modify: `assets/js/AssertionsBuilder.js`
+- Test: `assets/js/__tests__/AssertionsBuilder.test.js`
+
+**Interfaces:**
+
+- Consumes: `TestType`, `AssertType`, `Assertion` from Task 1.
+- Produces: `AssertionsBuilder` class with `model`, `load(def)`, `setMeta(meta)`, `serialize()`. `serialize()` returns a schema-valid `LitCalTest`:
+  always `{name, event_key, description, test_type, assertions}`; includes `year_since` only for `exactCorrespondenceSince`, `year_until` only for
+  `exactCorrespondenceUntil`, `applies_to`/`excludes` only when set; each assertion includes `comment` only when present.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `assets/js/__tests__/AssertionsBuilder.test.js`:
+
+```javascript
+import { AssertionsBuilder } from '../AssertionsBuilder.js';
+
+const sampleExact = {
+    name: 'StIgnatiusOfLoyolaTest',
+    event_key: 'StIgnatiusOfLoyola',
+    description: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+    test_type: 'exactCorrespondence',
+    applies_to: { national_calendar: 'USA' },
+    assertions: [
+        { year: 2024, expected_value: '2024-07-31T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31" },
+        { year: 2025, expected_value: '2025-07-31T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31", comment: 'note' },
+    ],
+};
+
+const sampleSince = {
+    name: 'SomeFeastTest',
+    event_key: 'SomeFeast',
+    description: "The FEAST of 'Some Feast' should fall on March 19",
+    test_type: 'exactCorrespondenceSince',
+    year_since: 2026,
+    assertions: [
+        { year: 2025, expected_value: null, assert: 'eventNotExists', assertion: "The FEAST of 'Some Feast' should not exist on March 19" },
+        { year: 2026, expected_value: '2026-03-19T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The FEAST of 'Some Feast' should fall on March 19" },
+    ],
+};
+
+describe('load + serialize round-trip', () => {
+    it('round-trips an exactCorrespondence test (applies_to + comment preserved)', () => {
+        const out = new AssertionsBuilder().load(sampleExact).serialize();
+        expect(out).toEqual(sampleExact);
+    });
+
+    it('round-trips an exactCorrespondenceSince test (year_since preserved)', () => {
+        const out = new AssertionsBuilder().load(sampleSince).serialize();
+        expect(out).toEqual(sampleSince);
+    });
+
+    it('omits year_since/year_until/applies_to/excludes when not applicable', () => {
+        const out = new AssertionsBuilder().load({
+            name: 'BareTest', event_key: 'Bare', description: 'd',
+            test_type: 'exactCorrespondence',
+            assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }],
+        }).serialize();
+        expect('year_since' in out).toBe(false);
+        expect('year_until' in out).toBe(false);
+        expect('applies_to' in out).toBe(false);
+        expect('excludes' in out).toBe(false);
+    });
+
+    it('setMeta updates name/description/event_key/test_type without touching assertions', () => {
+        const b = new AssertionsBuilder().load(sampleExact);
+        b.setMeta({ name: 'RenamedTest', description: 'new desc', test_type: 'variableCorrespondence' });
+        const out = b.serialize();
+        expect(out.name).toBe('RenamedTest');
+        expect(out.description).toBe('new desc');
+        expect(out.test_type).toBe('variableCorrespondence');
+        expect(out.assertions).toHaveLength(2);
+    });
+
+    it('derives baseMonthDay from the first eventExists assertion', () => {
+        const b = new AssertionsBuilder().load(sampleExact);
+        expect(b.baseMonthDay).toEqual({ month: 7, day: 31 });
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test:unit`
+Expected: FAIL — `AssertionsBuilder is not a constructor` / `.load is not a function`.
+
+- [ ] **Step 3: Implement the class core**
+
+Append to `assets/js/AssertionsBuilder.js`:
+
+```javascript
+const EMPTY_MODEL = () => ({
+    name: '',
+    event_key: '',
+    description: '',
+    test_type: TestType.ExactCorrespondence,
+    applies_to: null,
+    excludes: null,
+    year_since: null,
+    year_until: null,
+    assertions: [],
+});
+
+export class AssertionsBuilder {
+    constructor({ locale = 'en' } = {}) {
+        this.locale = locale;
+        this.model = EMPTY_MODEL();
+        this.baseMonthDay = null;
+        this.event = null;
+    }
+
+    /** Populate the model from an existing LitCalTest definition. */
+    load(def) {
+        this.model = EMPTY_MODEL();
+        this.model.name = def.name ?? '';
+        this.model.event_key = def.event_key ?? '';
+        this.model.description = def.description ?? '';
+        this.model.test_type = def.test_type ?? TestType.ExactCorrespondence;
+        this.model.applies_to = def.applies_to ?? null;
+        this.model.excludes = def.excludes ?? null;
+        this.model.year_since = def.year_since ?? null;
+        this.model.year_until = def.year_until ?? null;
+        this.model.assertions = (def.assertions ?? []).map(
+            (a) => new Assertion(a.year, a.expected_value, a.assert, a.assertion, a.comment ?? null)
+        );
+        this.baseMonthDay = AssertionsBuilder.#deriveBaseMonthDay(this.model.assertions);
+        return this;
+    }
+
+    /** Update editor-form metadata (never touches the assertions array). */
+    setMeta({ name, event_key, description, test_type, applies_to, excludes } = {}) {
+        if (name !== undefined) this.model.name = name;
+        if (event_key !== undefined) this.model.event_key = event_key;
+        if (description !== undefined) this.model.description = description;
+        if (test_type !== undefined) this.model.test_type = test_type;
+        if (applies_to !== undefined) this.model.applies_to = applies_to;
+        if (excludes !== undefined) this.model.excludes = excludes;
+        return this;
+    }
+
+    /** Produce a schema-valid LitCalTest object from the model. */
+    serialize() {
+        const m = this.model;
+        const out = {
+            name: m.name,
+            event_key: m.event_key,
+            description: m.description,
+            test_type: m.test_type,
+        };
+        if (m.applies_to) out.applies_to = m.applies_to;
+        if (m.excludes) out.excludes = m.excludes;
+        if (m.test_type === TestType.ExactCorrespondenceSince && m.year_since !== null) {
+            out.year_since = m.year_since;
+        }
+        if (m.test_type === TestType.ExactCorrespondenceUntil && m.year_until !== null) {
+            out.year_until = m.year_until;
+        }
+        out.assertions = m.assertions.map((a) => {
+            const item = {
+                year: a.year,
+                expected_value: a.expected_value,
+                assert: a.assert,
+                assertion: a.assertion,
+            };
+            if ('comment' in a) item.comment = a.comment;
+            return item;
+        });
+        return out;
+    }
+
+    static #deriveBaseMonthDay(assertions) {
+        const first = assertions.find((a) => a.expected_value);
+        if (!first) return null;
+        const d = new Date(first.expected_value);
+        if (Number.isNaN(d.getTime())) return null;
+        return { month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+    }
+}
+```
+
+> Note on key order: `serialize()` emits `applies_to`/`excludes` before `year_since`/`year_until`. The round-trip tests use `toEqual`
+> (order-insensitive); the sample objects above also list keys in that order for readability.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test:unit`
+Expected: PASS (round-trip, omission, setMeta, baseMonthDay).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/js/AssertionsBuilder.js assets/js/__tests__/AssertionsBuilder.test.js
+git commit -m "feat(admin-tests): AssertionsBuilder model load/setMeta/serialize round-trip"
+```
+
+---
+
+### Task 3: AssertionsBuilder — `generate()` per test type
+
+**Files:**
+
+- Modify: `assets/js/AssertionsBuilder.js`
+- Test: `assets/js/__tests__/AssertionsBuilder.test.js`
+
+**Interfaces:**
+
+- Consumes: model from Task 2.
+- Produces: `generate({ event, minYear, maxYear, pivotYear, excludedYears })` that rebuilds `model.assertions` over `[minYear, maxYear]` (skipping
+  `excludedYears`), sets `model.description`, `baseMonthDay`, and `model.year_since`/`year_until` from `pivotYear`. Rules: ExactCorrespondence → all
+  `EventTypeExact`; Since → years `< pivot` are `EventNotExists`; Until → years `> pivot` are `EventNotExists`; Variable → all `EventTypeExact`
+  (toggled later per-year). `event` shape: `{ event_key, name, grade, grade_lcl, month, day }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the test file:
+
+```javascript
+const event = { event_key: 'StIgnatiusOfLoyola', name: 'Saint Ignatius of Loyola', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 };
+
+describe('generate', () => {
+    it('exactCorrespondence: every year asserts eventExists with a UTC midnight date', () => {
+        const b = new AssertionsBuilder({ locale: 'en' });
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondence' });
+        b.generate({ event, minYear: 2023, maxYear: 2025 });
+        const out = b.serialize();
+        expect(out.assertions.map((a) => a.year)).toEqual([2023, 2024, 2025]);
+        expect(out.assertions.every((a) => a.assert === 'eventExists AND hasExpectedDate')).toBe(true);
+        expect(out.assertions[1].expected_value).toBe('2024-07-31T00:00:00+00:00');
+        expect(out.description).toBe("The Memorial of 'Saint Ignatius of Loyola' should fall on July 31");
+    });
+
+    it('exactCorrespondenceSince: years before the pivot assert eventNotExists', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondenceSince' });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2025 });
+        const out = b.serialize();
+        expect(out.year_since).toBe(2025);
+        expect(out.assertions.find((a) => a.year === 2024).assert).toBe('eventNotExists');
+        expect(out.assertions.find((a) => a.year === 2024).expected_value).toBe(null);
+        expect(out.assertions.find((a) => a.year === 2025).assert).toBe('eventExists AND hasExpectedDate');
+        expect(out.assertions.find((a) => a.year === 2024).assertion)
+            .toBe("The Memorial of 'Saint Ignatius of Loyola' should not exist on July 31");
+    });
+
+    it('exactCorrespondenceUntil: years after the pivot assert eventNotExists', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondenceUntil' });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2025 });
+        const out = b.serialize();
+        expect(out.year_until).toBe(2025);
+        expect(out.assertions.find((a) => a.year === 2026).assert).toBe('eventNotExists');
+        expect(out.assertions.find((a) => a.year === 2025).assert).toBe('eventExists AND hasExpectedDate');
+    });
+
+    it('skips excluded years', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondence' });
+        b.generate({ event, minYear: 2023, maxYear: 2025, excludedYears: [2024] });
+        expect(b.serialize().assertions.map((a) => a.year)).toEqual([2023, 2025]);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test:unit`
+Expected: FAIL — `.generate is not a function`.
+
+- [ ] **Step 3: Implement `generate()` + helpers**
+
+Add these methods inside the `AssertionsBuilder` class (before the closing brace):
+
+```javascript
+    /** Build description text from an event, e.g. "The Memorial of 'X' should fall on July 31". */
+    static #describe(event, locale) {
+        const grade = event.grade_lcl ?? '';
+        let onDate = 'the expected date';
+        if (event.month && event.day) {
+            const d = new Date(Date.UTC(1970, Number(event.month) - 1, Number(event.day)));
+            onDate = new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric', timeZone: 'UTC' }).format(d);
+        }
+        return `The ${grade} of '${event.name}' should fall on ${onDate}`;
+    }
+
+    /** RFC 3339 UTC-midnight string for an event's month/day in a given year. */
+    static #expectedValue(year, month, day) {
+        const iso = new Date(Date.UTC(year, Number(month) - 1, Number(day))).toISOString();
+        return `${iso.split('T')[0]}T00:00:00+00:00`;
+    }
+
+    /**
+     * Rebuild the assertions array from an event, a year range, and the test type.
+     * @param {{event:object, minYear:number, maxYear:number, pivotYear?:number|null, excludedYears?:number[]}} opts
+     */
+    generate({ event, minYear, maxYear, pivotYear = null, excludedYears = [] }) {
+        this.event = event;
+        this.baseMonthDay = (event.month && event.day)
+            ? { month: Number(event.month), day: Number(event.day) }
+            : null;
+        const description = AssertionsBuilder.#describe(event, this.locale);
+        this.model.description = description;
+        this.model.event_key = event.event_key;
+
+        this.model.year_since = null;
+        this.model.year_until = null;
+        if (this.model.test_type === TestType.ExactCorrespondenceSince) {
+            this.model.year_since = pivotYear;
+        } else if (this.model.test_type === TestType.ExactCorrespondenceUntil) {
+            this.model.year_until = pivotYear;
+        }
+
+        const notExistsAssertion = description.replace('should fall on', 'should not exist on');
+        const excluded = new Set(excludedYears.map(Number));
+        const assertions = [];
+        for (let year = minYear; year <= maxYear; year++) {
+            if (excluded.has(year)) continue;
+            let notExists = false;
+            if (this.model.test_type === TestType.ExactCorrespondenceSince && pivotYear !== null) {
+                notExists = year < pivotYear;
+            } else if (this.model.test_type === TestType.ExactCorrespondenceUntil && pivotYear !== null) {
+                notExists = year > pivotYear;
+            }
+            if (notExists || !this.baseMonthDay) {
+                assertions.push(new Assertion(year, null, AssertType.EventNotExists, notExistsAssertion));
+            } else {
+                const ev = AssertionsBuilder.#expectedValue(year, this.baseMonthDay.month, this.baseMonthDay.day);
+                assertions.push(new Assertion(year, ev, AssertType.EventTypeExact, description));
+            }
+        }
+        this.model.assertions = assertions;
+        return this;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test:unit`
+Expected: PASS (all four generate tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/js/AssertionsBuilder.js assets/js/__tests__/AssertionsBuilder.test.js
+git commit -m "feat(admin-tests): AssertionsBuilder.generate per-test-type assertion rules"
+```
+
+---
+
+### Task 4: AssertionsBuilder — per-year mutators
+
+**Files:**
+
+- Modify: `assets/js/AssertionsBuilder.js`
+- Test: `assets/js/__tests__/AssertionsBuilder.test.js`
+
+**Interfaces:**
+
+- Produces: `toggleAssert(year)`, `setExpectedDate(year, iso)`, `setAssertionText(year, text)`, `setComment(year, text)`, `excludeYear(year)`,
+  `setPivot(year)`. `toggleAssert` flips an assertion between `EventTypeExact` (restoring `expected_value` from `baseMonthDay`) and `EventNotExists`
+  (null + sentence swap). `setComment('')` removes the comment.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```javascript
+describe('mutators', () => {
+    const build = () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ test_type: 'variableCorrespondence' });
+        b.generate({ event, minYear: 2024, maxYear: 2026 });
+        return b;
+    };
+
+    it('toggleAssert flips eventExists -> eventNotExists and back', () => {
+        const b = build();
+        b.toggleAssert(2025);
+        let a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventNotExists');
+        expect(a.expected_value).toBe(null);
+        expect(a.assertion).toContain('should not exist on');
+        b.toggleAssert(2025);
+        a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventExists AND hasExpectedDate');
+        expect(a.expected_value).toBe('2025-07-31T00:00:00+00:00');
+        expect(a.assertion).toContain('should fall on');
+    });
+
+    it('setExpectedDate updates the RFC3339 value', () => {
+        const b = build();
+        b.setExpectedDate(2024, '2024-08-01T00:00:00+00:00');
+        expect(b.model.assertions.find((x) => x.year === 2024).expected_value).toBe('2024-08-01T00:00:00+00:00');
+    });
+
+    it('setAssertionText and setComment work; empty comment removes it', () => {
+        const b = build();
+        b.setAssertionText(2024, 'custom sentence');
+        expect(b.model.assertions.find((x) => x.year === 2024).assertion).toBe('custom sentence');
+        b.setComment(2024, 'a note');
+        expect(b.model.assertions.find((x) => x.year === 2024).comment).toBe('a note');
+        b.setComment(2024, '');
+        expect('comment' in b.model.assertions.find((x) => x.year === 2024)).toBe(false);
+    });
+
+    it('excludeYear removes the assertion', () => {
+        const b = build();
+        b.excludeYear(2025);
+        expect(b.model.assertions.map((x) => x.year)).toEqual([2024, 2026]);
+    });
+
+    it('setPivot re-splits a Since test', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ test_type: 'exactCorrespondenceSince' });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2024 });
+        b.setPivot(2026);
+        expect(b.model.year_since).toBe(2026);
+        expect(b.model.assertions.find((x) => x.year === 2024).assert).toBe('eventNotExists');
+        expect(b.model.assertions.find((x) => x.year === 2026).assert).toBe('eventExists AND hasExpectedDate');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test:unit`
+Expected: FAIL — `.toggleAssert is not a function`.
+
+- [ ] **Step 3: Implement the mutators**
+
+Add inside the class:
+
+```javascript
+    #find(year) {
+        return this.model.assertions.find((a) => a.year === year) ?? null;
+    }
+
+    toggleAssert(year) {
+        const a = this.#find(year);
+        if (!a) return this;
+        if (a.assert === AssertType.EventTypeExact) {
+            a.assert = AssertType.EventNotExists;
+            a.expected_value = null;
+            a.assertion = a.assertion.replace('should fall on', 'should not exist on');
+        } else {
+            a.assert = AssertType.EventTypeExact;
+            if (this.baseMonthDay) {
+                a.expected_value = AssertionsBuilder.#expectedValue(year, this.baseMonthDay.month, this.baseMonthDay.day);
+            }
+            a.assertion = a.assertion.replace('should not exist on', 'should fall on');
+        }
+        return this;
+    }
+
+    setExpectedDate(year, iso) {
+        const a = this.#find(year);
+        if (a) a.expected_value = iso;
+        return this;
+    }
+
+    setAssertionText(year, text) {
+        const a = this.#find(year);
+        if (a) a.assertion = text;
+        return this;
+    }
+
+    setComment(year, text) {
+        const a = this.#find(year);
+        if (!a) return this;
+        if (text === '' || text === null || text === undefined) {
+            delete a.comment;
+        } else {
+            a.comment = text;
+        }
+        return this;
+    }
+
+    excludeYear(year) {
+        this.model.assertions = this.model.assertions.filter((a) => a.year !== year);
+        return this;
+    }
+
+    setPivot(year) {
+        if (this.model.test_type === TestType.ExactCorrespondenceSince) {
+            this.model.year_since = year;
+        } else if (this.model.test_type === TestType.ExactCorrespondenceUntil) {
+            this.model.year_until = year;
+        }
+        this.model.assertions.forEach((a) => {
+            const notExists = this.model.test_type === TestType.ExactCorrespondenceSince
+                ? a.year < year
+                : a.year > year;
+            const isNot = a.assert === AssertType.EventNotExists;
+            if (notExists !== isNot) {
+                this.toggleAssert(a.year);
+            }
+        });
+        return this;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test:unit`
+Expected: PASS (all mutator tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/js/AssertionsBuilder.js assets/js/__tests__/AssertionsBuilder.test.js
+git commit -m "feat(admin-tests): AssertionsBuilder per-year mutators (toggle/date/comment/exclude/pivot)"
+```
+
+---
+
+### Task 5: AssertionsBuilder — `render()` native CSS grid
+
+**Files:**
+
+- Modify: `assets/js/AssertionsBuilder.js`
+- Test: `assets/js/__tests__/AssertionsBuilder.test.js`
+
+**Interfaces:**
+
+- Produces: `render(container)` clears `container` and appends one card per assertion. Each card carries `data-year`, a `.assert` span showing
+  `assert`, a `.toggleAssert` button (`fa-repeat`), a `.expectedValue` span with `data-value`, an `.editDate` button (`fa-pen-to-square`, `disabled`
+  when no date), a **`<textarea class="assertionText">`** (NOT contenteditable) holding the sentence, and a `.comment` button (`fa-comment-dots` when
+  a comment exists, else `fa-comment-medical`). Color classes: `bg-success text-white` (exists) / `bg-warning text-dark` (not-exists). Cards live in a
+  parent with class `assertions-grid` (native CSS grid).
+
+- [ ] **Step 1: Write the failing tests (jsdom)**
+
+Append:
+
+```javascript
+describe('render', () => {
+    it('renders one card per assertion with textarea, toggle, and color classes', () => {
+        const b = new AssertionsBuilder();
+        b.setMeta({ test_type: 'variableCorrespondence' });
+        b.generate({ event, minYear: 2024, maxYear: 2025 });
+        b.toggleAssert(2025); // make 2025 eventNotExists
+        const container = document.createElement('div');
+        b.render(container);
+
+        const cards = container.querySelectorAll('[data-year]');
+        expect(cards).toHaveLength(2);
+
+        const card2024 = container.querySelector('[data-year="2024"]');
+        expect(card2024.querySelector('.assert').textContent).toBe('eventExists AND hasExpectedDate');
+        expect(card2024.querySelector('textarea.assertionText')).not.toBeNull();
+        expect(card2024.querySelector('.toggleAssert')).not.toBeNull();
+        expect(card2024.querySelector('.expectedValue').getAttribute('data-value')).toBe('2024-07-31T00:00:00+00:00');
+
+        const card2025 = container.querySelector('[data-year="2025"]');
+        expect(card2025.querySelector('.assert').textContent).toBe('eventNotExists');
+        expect(card2025.querySelector('.editDate').classList.contains('disabled')).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test:unit`
+Expected: FAIL — `.render is not a function`.
+
+- [ ] **Step 3: Implement `render()`**
+
+Add inside the class:
+
+```javascript
+    #formatDate(iso) {
+        if (!iso) return '---';
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return '---';
+        return new Intl.DateTimeFormat(this.locale, { dateStyle: 'medium', timeZone: 'UTC' }).format(d);
+    }
+
+    render(container) {
+        container.innerHTML = '';
+        container.classList.add('assertions-grid');
+
+        this.model.assertions.forEach((a) => {
+            const notExists = a.assert === AssertType.EventNotExists;
+            const bg = notExists ? 'bg-warning' : 'bg-success';
+            const fg = notExists ? 'text-dark' : 'text-white';
+
+            const card = document.createElement('div');
+            card.className = `assertion-card d-flex flex-column border ${bg} ${fg}`;
+            card.dataset.year = String(a.year);
+
+            const yearP = document.createElement('p');
+            yearP.className = 'text-center mb-0 fw-bold testYear';
+            yearP.textContent = String(a.year);
+            card.appendChild(yearP);
+
+            // ASSERT THAT row
+            const assertRow = document.createElement('div');
+            assertRow.className = 'd-flex justify-content-between align-items-center px-1 border-bottom';
+            const assertLabel = document.createElement('span');
+            assertLabel.className = 'fw-bold small';
+            assertLabel.textContent = 'ASSERT:';
+            const assertVal = document.createElement('span');
+            assertVal.className = 'assert small text-end';
+            assertVal.textContent = a.assert;
+            const toggleBtn = document.createElement('button');
+            toggleBtn.type = 'button';
+            toggleBtn.className = 'btn btn-xs btn-danger ms-1 toggleAssert';
+            toggleBtn.innerHTML = '<i class="fas fa-repeat" aria-hidden="true"></i>';
+            assertRow.append(assertLabel, assertVal, toggleBtn);
+            card.appendChild(assertRow);
+
+            // EXPECT VALUE row
+            const dateRow = document.createElement('div');
+            dateRow.className = 'd-flex justify-content-between align-items-center px-1 border-bottom';
+            const dateLabel = document.createElement('span');
+            dateLabel.className = 'fw-bold small';
+            dateLabel.textContent = 'DATE:';
+            const dateVal = document.createElement('span');
+            dateVal.className = 'expectedValue small';
+            dateVal.setAttribute('data-value', a.expected_value ?? '');
+            dateVal.textContent = this.#formatDate(a.expected_value);
+            const editBtn = document.createElement('button');
+            editBtn.type = 'button';
+            editBtn.className = `btn btn-xs editDate ms-1${a.expected_value ? ' btn-danger' : ' btn-secondary disabled'}`;
+            editBtn.disabled = !a.expected_value;
+            editBtn.innerHTML = '<i class="fas fa-pen-to-square" aria-hidden="true"></i>';
+            dateRow.append(dateLabel, dateVal, editBtn);
+            card.appendChild(dateRow);
+
+            // ASSERTION textarea + comment button
+            const textRow = document.createElement('div');
+            textRow.className = 'd-flex flex-column p-1';
+            const textHeader = document.createElement('div');
+            textHeader.className = 'd-flex justify-content-between align-items-center';
+            const textLabel = document.createElement('span');
+            textLabel.className = 'fw-bold small';
+            textLabel.textContent = 'ASSERTION:';
+            const hasComment = 'comment' in a;
+            const commentBtn = document.createElement('button');
+            commentBtn.type = 'button';
+            commentBtn.className = `btn btn-xs comment ms-1 ${hasComment ? 'btn-dark' : 'btn-secondary'}`;
+            commentBtn.title = hasComment ? a.comment : 'add a comment';
+            commentBtn.innerHTML = hasComment
+                ? '<i class="fas fa-comment-dots" aria-hidden="true"></i>'
+                : '<i class="fas fa-comment-medical" aria-hidden="true"></i>';
+            textHeader.append(textLabel, commentBtn);
+            const textarea = document.createElement('textarea');
+            textarea.className = 'form-control form-control-sm assertionText';
+            textarea.rows = 2;
+            textarea.value = a.assertion;
+            textRow.append(textHeader, textarea);
+            card.appendChild(textRow);
+
+            container.appendChild(card);
+        });
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test:unit`
+Expected: PASS.
+
+- [ ] **Step 5: Run eslint and commit**
+
+Run: `yarn lint`
+Expected: no errors in `assets/js/AssertionsBuilder.js`.
+
+```bash
+git add assets/js/AssertionsBuilder.js assets/js/__tests__/AssertionsBuilder.test.js
+git commit -m "feat(admin-tests): AssertionsBuilder.render native CSS grid with textarea cards"
+```
+
+---
+
+### Task 6: Ported slider + page CSS
+
+**Files:**
+
+- Create: `assets/css/multi-range-slider.css`
+- Create: `assets/css/admin-tests.css`
+
+**Interfaces:**
+
+- Produces: `assets/css/admin-tests.css` (auto-loaded by `head.php` for `pageName === 'admin-tests'`), which `@import`s the slider CSS and adds the
+  `.assertions-grid` / `.year-grid` native grid styles.
+
+- [ ] **Step 1: Copy the slider CSS verbatim**
+
+Copy the file as-is:
+
+```bash
+cp ../UnitTestInterface/assets/css/multi-range-slider.css assets/css/multi-range-slider.css
+```
+
+> If the relative path differs, the source is `UnitTestInterface/assets/css/multi-range-slider.css` (314 lines, CSS-custom-property dual-range
+> slider). Copy it byte-for-byte; do not modify.
+
+- [ ] **Step 2: Create `assets/css/admin-tests.css`**
+
+```css
+@import url('multi-range-slider.css');
+
+/* Per-year assertion cards: native CSS grid (replaces Isotope fitRows). */
+.assertions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.5rem;
+}
+
+.assertion-card {
+    border-radius: 0.25rem;
+    overflow: hidden;
+}
+
+.assertion-card .assertionText {
+    resize: vertical;
+}
+
+/* Year-range overview grid (Sundays / excluded / pivot shading). */
+.year-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.year-grid .testYearSpan {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.25rem;
+    cursor: default;
+    user-select: none;
+}
+
+.year-grid .testYearSpan.deleted {
+    opacity: 0.3;
+}
+
+.btn-xs {
+    padding: 0.1rem 0.3rem;
+    font-size: 0.75rem;
+    line-height: 1.2;
+}
+```
+
+- [ ] **Step 3: Verify the import resolves**
+
+Run: `node -e "const fs=require('fs'); const c=fs.readFileSync('assets/css/admin-tests.css','utf8'); if(!/multi-range-slider\.css/.test(c))
+process.exit(1); fs.accessSync('assets/css/multi-range-slider.css'); console.log('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add assets/css/multi-range-slider.css assets/css/admin-tests.css
+git commit -m "feat(admin-tests): port dual-range slider CSS + native grid page styles"
+```
+
+---
+
+### Task 7: `admin-tests.php` page, nav registration, dashboard card
+
+**Files:**
+
+- Create: `admin-tests.php`
+- Modify: `includes/common.php:245`
+- Modify: `layout/header.php`
+- Modify: `admin-dashboard.php`
+- Test: `e2e/admin-tests.spec.ts`
+
+**Interfaces:**
+
+- Produces: a reachable, auth-gated page exposing `window.AdminTestsConfig = { apiUrl, isGlobalAdmin, hasTestEditor, locale, i18n: {...} }`, a list
+  container `#testsTableBody` with `#testsCount`, filters `#filterTestName` / `#filterTestScope` / `#refreshTestsBtn` / `#createTestBtn`, a
+  `#testEditorModal`, and a `#deleteTestModal`. Mirrors `admin-permissions.php` structure.
+
+- [ ] **Step 1: Write the failing Playwright smoke spec**
+
+Create `e2e/admin-tests.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Uses the shared authenticated storage state (e2e/.auth/user.json) from the
+// chromium project; that user is an admin in the dev environment.
+test.describe('admin-tests page', () => {
+    test('renders the page shell with list and modals', async ({ page }) => {
+        await page.goto('/admin-tests.php');
+        await expect(page.locator('#testsTableBody')).toBeVisible();
+        await expect(page.locator('#createTestBtn')).toBeVisible();
+        await expect(page.locator('#testEditorModal')).toHaveCount(1);
+        await expect(page.locator('#deleteTestModal')).toHaveCount(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium`
+Expected: FAIL — `admin-tests.php` 404s / locators not found.
+
+> Requires the frontend dev server + API running per the repo's Playwright `webServer` config. If the environment is not bootable in this worktree,
+> mark the run as "expected fail" and proceed; it will pass once the page exists and the stack is up.
+
+- [ ] **Step 3: Register the page name**
+
+Edit `includes/common.php` line 245 — add `'admin-tests'`:
+
+```php
+$adminPages = ['admin-dashboard', 'missals-editor', 'extending', 'temporale', 'decrees', 'admin-users', 'admin-role-requests', 'admin-applications', 'admin-permissions', 'admin-tests', 'developer-dashboard'];
+```
+
+- [ ] **Step 4: Create `admin-tests.php`**
+
+```php
+<?php
+
+/**
+ * Admin Tests Management Page
+ *
+ * Allows test_editor / admin users to create, edit, delete, and view
+ * liturgical test definitions via the /tests API. Per-row edit/delete are
+ * gated against the caller's scopes from GET /auth/test-scopes; the API is
+ * the hard backstop.
+ */
+
+include_once 'includes/common.php';
+include_once 'includes/messages.php';
+
+// Require authentication - redirect to home if not logged in
+if (!$authHelper->isAuthenticated) {
+    header('Location: index.php');
+    exit;
+}
+
+// This is an admin page: test editors, global admins, and resource-admins may
+// enter. Per-row gating (below, in JS) governs what each user may change.
+$isGlobalAdmin   = $authHelper->hasRole('admin');
+$hasTestEditor   = $authHelper->hasRole('test_editor');
+$isResourceAdmin = $authHelper->isResourceAdmin();
+
+if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
+    header('Location: admin-dashboard.php');
+    exit;
+}
+
+?>
+<!doctype html>
+<html lang="<?php echo htmlspecialchars($i18n->LOCALE, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+<head>
+    <title><?php
+        $testsTitle    = _('Test Definitions');
+        $calendarTitle = _('Catholic Liturgical Calendar');
+        echo htmlspecialchars($testsTitle, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        echo ' - ';
+        echo htmlspecialchars($calendarTitle, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    ?></title>
+    <?php include_once('./layout/head.php'); ?>
+</head>
+<body class="sb-nav-fixed">
+    <?php include_once('./layout/header.php'); ?>
+    <div id="layoutSidenav_content">
+        <main>
+            <div class="container-fluid px-4">
+                <h1 class="mt-4"><?php echo htmlspecialchars(_('Test Definitions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h1>
+                <p class="text-muted"><?php echo htmlspecialchars(_('Create, edit, and delete liturgical accuracy test definitions.'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></p>
+
+                <!-- Filters -->
+                <div class="card shadow mb-4">
+                    <div class="card-body">
+                        <div class="row g-2 align-items-end">
+                            <div class="col-md-4">
+                                <label class="form-label" for="filterTestName"><?php echo _('Filter by name'); ?></label>
+                                <input type="text" class="form-control" id="filterTestName" />
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label" for="filterTestScope"><?php echo _('Filter by scope'); ?></label>
+                                <input type="text" class="form-control" id="filterTestScope" placeholder="USA, diocese id, ..." />
+                            </div>
+                            <div class="col-md-4 text-end">
+                                <button type="button" class="btn btn-outline-secondary" id="refreshTestsBtn">
+                                    <i class="fas fa-rotate"></i> <?php echo _('Refresh'); ?>
+                                </button>
+                                <button type="button" class="btn btn-primary" id="createTestBtn" data-requires-auth>
+                                    <i class="fas fa-plus"></i> <?php echo _('New Test'); ?>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Tests table -->
+                <div class="card shadow mb-4">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <span><?php echo _('Tests'); ?></span>
+                        <span class="badge bg-secondary" id="testsCount">0</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-sm table-hover align-middle">
+                                <thead>
+                                    <tr>
+                                        <th><?php echo _('Name'); ?></th>
+                                        <th><?php echo _('Event'); ?></th>
+                                        <th><?php echo _('Scope'); ?></th>
+                                        <th><?php echo _('Type'); ?></th>
+                                        <th><?php echo _('Years'); ?></th>
+                                        <th class="text-end"><?php echo _('Actions'); ?></th>
+                                    </tr>
+                                </thead>
+                                <tbody id="testsTableBody"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+        <?php include_once('./layout/footer.php'); ?>
+    </div>
+
+    <!-- Editor modal -->
+    <div class="modal fade" id="testEditorModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="testEditorModalLabel"><?php echo _('Test Definition'); ?></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="testEditorAlerts"></div>
+                    <form id="testEditorForm" novalidate>
+                        <!-- Step 1: test type -->
+                        <div class="mb-3">
+                            <label class="form-label fw-bold"><?php echo _('Test type'); ?></label>
+                            <div class="btn-group d-flex flex-wrap" role="group" id="testTypeGroup">
+                                <input type="radio" class="btn-check" name="testType" id="tt-exact" value="exactCorrespondence" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-exact"><i class="fas fa-vial me-1"></i><?php echo _('Exact date'); ?></label>
+                                <input type="radio" class="btn-check" name="testType" id="tt-since" value="exactCorrespondenceSince" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-since"><i class="fas fa-right-from-bracket me-1"></i><?php echo _('Exact since year'); ?></label>
+                                <input type="radio" class="btn-check" name="testType" id="tt-until" value="exactCorrespondenceUntil" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-until"><i class="fas fa-right-to-bracket me-1"></i><?php echo _('Exact until year'); ?></label>
+                                <input type="radio" class="btn-check" name="testType" id="tt-variable" value="variableCorrespondence" autocomplete="off">
+                                <label class="btn btn-outline-primary" for="tt-variable"><i class="fas fa-square-root-variable me-1"></i><?php echo _('Variable by year'); ?></label>
+                            </div>
+                        </div>
+
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label" for="testName"><?php echo _('Name'); ?></label>
+                                <input type="text" class="form-control" id="testName" pattern="^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$" required />
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="testScopeType"><?php echo _('Scope'); ?></label>
+                                <select class="form-select" id="testScopeType">
+                                    <option value="general_roman_calendar"><?php echo _('General Roman Calendar'); ?></option>
+                                    <option value="national_calendar"><?php echo _('National Calendar'); ?></option>
+                                    <option value="diocesan_calendar"><?php echo _('Diocesan Calendar'); ?></option>
+                                </select>
+                                <div id="testScopeIdMount" class="mt-2"></div>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="testEventKey"><?php echo _('Liturgical event'); ?></label>
+                                <input type="text" class="form-control" id="testEventKey" list="testEventKeyList" required />
+                                <datalist id="testEventKeyList"></datalist>
+                            </div>
+                            <div class="col-12">
+                                <label class="form-label" for="testDescription"><?php echo _('Description'); ?></label>
+                                <textarea class="form-control" id="testDescription" rows="2" required></textarea>
+                            </div>
+                        </div>
+
+                        <!-- Step 3: year range -->
+                        <div class="mt-3">
+                            <label class="form-label fw-bold"><?php echo _('Year range'); ?></label>
+                            <div class="range-slider flat" id="yearsRangeSlider"
+                                 style="--min:1970; --max:2050; --value-a:1999; --value-b:2030; --text-value-a:'1999'; --text-value-b:'2030';">
+                                <input type="range" id="lowerRange" min="1970" max="2050" value="1999" />
+                                <output></output>
+                                <input type="range" id="upperRange" min="1970" max="2050" value="2030" />
+                                <output></output>
+                                <div class="range-slider__progress"></div>
+                            </div>
+                            <div class="year-grid mt-2" id="yearGrid"></div>
+                        </div>
+
+                        <!-- Step 4: base date -->
+                        <div class="mt-3 col-md-4">
+                            <label class="form-label" for="baseDate"><?php echo _('Base date'); ?></label>
+                            <input type="date" class="form-control" id="baseDate" min="1970-01-01" max="2050-12-31" />
+                        </div>
+
+                        <!-- Step 5: per-year assertions -->
+                        <div class="mt-3">
+                            <label class="form-label fw-bold"><?php echo _('Per-year assertions'); ?></label>
+                            <div id="assertionsContainer"></div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?php echo _('Cancel'); ?></button>
+                    <button type="button" class="btn btn-primary" id="saveTestBtn" data-requires-auth><?php echo _('Save'); ?></button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Comment modal -->
+    <div class="modal fade" id="testCommentModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><?php echo _('Assertion comment'); ?></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="commentYear" />
+                    <textarea class="form-control" id="commentText" rows="3"></textarea>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?php echo _('Cancel'); ?></button>
+                    <button type="button" class="btn btn-primary" id="saveCommentBtn"><?php echo _('Save comment'); ?></button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Delete modal -->
+    <div class="modal fade" id="deleteTestModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><?php echo _('Delete Test'); ?></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="deleteTestAlerts"></div>
+                    <p id="deleteTestConfirmText"></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?php echo _('Cancel'); ?></button>
+                    <button type="button" class="btn btn-danger" id="confirmDeleteTestBtn" data-requires-auth><?php echo _('Delete'); ?></button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        window.AdminTestsConfig = {
+            apiUrl: <?php echo json_encode($apiBaseUrl); ?>,
+            isGlobalAdmin: <?php echo json_encode($isGlobalAdmin); ?>,
+            hasTestEditor: <?php echo json_encode($hasTestEditor); ?>,
+            locale: <?php echo json_encode($i18n->LOCALE); ?>,
+            i18n: {
+                loading: <?php echo json_encode(_('Loading...')); ?>,
+                noTests: <?php echo json_encode(_('No tests found.')); ?>,
+                failedToLoad: <?php echo json_encode(_('Failed to load tests. Please try again later.')); ?>,
+                createSuccess: <?php echo json_encode(_('Test created successfully.')); ?>,
+                updateSuccess: <?php echo json_encode(_('Test updated successfully.')); ?>,
+                deleteSuccess: <?php echo json_encode(_('Test deleted successfully.')); ?>,
+                saving: <?php echo json_encode(_('Saving...')); ?>,
+                deleting: <?php echo json_encode(_('Deleting...')); ?>,
+                edit: <?php echo json_encode(_('Edit')); ?>,
+                delete: <?php echo json_encode(_('Delete')); ?>,
+                confirmDelete: <?php echo json_encode(_('Are you sure you want to delete the test "%s"?')); ?>,
+                generalRomanCalendar: <?php echo json_encode(_('General Roman Calendar')); ?>,
+                nationalCalendar: <?php echo json_encode(_('National Calendar')); ?>,
+                diocesanCalendar: <?php echo json_encode(_('Diocesan Calendar')); ?>,
+                requiredFields: <?php echo json_encode(_('Please fill in all required fields.')); ?>,
+                denied403: <?php echo json_encode(_('You do not have permission to perform this action.')); ?>,
+                conflict409: <?php echo json_encode(_('A test with that name already exists.')); ?>
+            }
+        };
+    </script>
+</body>
+</html>
+```
+
+> `$apiBaseUrl` is set by `includes/common.php` (same variable `admin-permissions.php` uses in its config blob).
+
+- [ ] **Step 5: Add the sidebar nav link**
+
+In `layout/header.php`, inside the admin sidebar block (the `if ($isAdminPage)` calendar-role section), add — directly after the existing `decrees.php` nav link:
+
+```php
+                        <?php if ($authHelper->hasRole('test_editor') || $authHelper->hasRole('admin') || $authHelper->isResourceAdmin()) : ?>
+                        <a class="nav-link<?php echo $currentPage === 'admin-tests' ? ' active' : ''; ?>" href="admin-tests.php">
+                            <i class="sb-nav-link-icon fas fa-fw fa-vial text-info"></i>
+                            <span><?php echo _('Test Definitions'); ?></span>
+                        </a>
+                        <?php endif; ?>
+```
+
+> Match the surrounding indentation in `header.php`. Place it where it reads naturally (e.g., after Decrees, or under a dedicated heading if one fits the existing structure).
+
+- [ ] **Step 6: Add the dashboard card**
+
+In `admin-dashboard.php`, inside the Administration section (the `if ($isAdmin)` row of admin cards, alongside Users/Permissions/Applications), add a
+card. Gate it on test-editor/admin:
+
+```php
+                <?php if ($isAdmin || $authHelper->hasRole('test_editor')) : ?>
+                <div class="col-xl-3 col-md-6 mb-4">
+                    <div class="card border-left-info shadow h-100 py-2">
+                        <div class="card-body">
+                            <div class="d-flex align-items-center">
+                                <i class="fas fa-vial fa-2x text-info me-3"></i>
+                                <div>
+                                    <div class="h5 mb-0 fw-bold"><?php echo _('Test Definitions'); ?></div>
+                                    <div class="small text-muted"><?php echo _('Manage liturgical accuracy tests'); ?></div>
+                                </div>
+                            </div>
+                            <a href="admin-tests.php" class="btn btn-sm btn-info mt-3"><?php echo _('Open'); ?></a>
+                        </div>
+                    </div>
+                </div>
+                <?php endif; ?>
+```
+
+> Match the exact card markup of the sibling admin cards in `admin-dashboard.php` (the snippet above is sb-admin-consistent but align
+> classes/structure to the real neighbors). Confirm `$isAdmin` is the variable used in that section; if the file uses `$isGlobalAdmin`, use that
+> instead.
+
+- [ ] **Step 7: Re-run the smoke spec**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium`
+Expected: PASS — page shell, list container, and both modals present.
+
+> If the stack cannot boot in this worktree, instead verify with PHP lint: `php -l admin-tests.php` (Expected: `No syntax errors detected`) and defer the Playwright run to CI.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add admin-tests.php includes/common.php layout/header.php admin-dashboard.php e2e/admin-tests.spec.ts
+git commit -m "feat(admin-tests): admin-tests.php page, nav link, dashboard card, smoke spec"
+```
+
+---
+
+### Task 8: `admin-tests.js` — bootstrap, list, per-row scope gating
+
+**Files:**
+
+- Create: `assets/js/admin-tests.js`
+- Test: `e2e/admin-tests.spec.ts` (extend)
+
+**Interfaces:**
+
+- Consumes: `window.AdminTestsConfig`; `GET /tests` → `{ litcal_tests: LitCalTest[] }`; `GET /auth/test-scopes` → `{ is_global_admin, editor:
+  [{object_type, object_id}], admin: [...] }`.
+- Produces: generic seam `fetchJson`, `gateByScope`, `deriveScope`, `renderTableRows`, `showModalAlert`; on load, fetches scopes + tests and renders
+  rows with per-row Edit/Delete buttons gated by scope.
+
+- [ ] **Step 1: Write the failing route-stubbed gating spec**
+
+Append to `e2e/admin-tests.spec.ts`:
+
+```typescript
+const sampleTests = {
+    litcal_tests: [
+        { name: 'GrcOnlyTest', event_key: 'StX', description: 'd', test_type: 'exactCorrespondence', assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }] },
+        { name: 'UsaNationalTest', event_key: 'StY', description: 'd', test_type: 'exactCorrespondence', applies_to: { national_calendar: 'USA' }, assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }] },
+    ],
+};
+
+async function stub(page, scopes) {
+    await page.route('**/auth/test-scopes', (r) => r.fulfill({ json: scopes }));
+    await page.route('**/auth/me', (r) => r.fulfill({ json: { authenticated: true, roles: ['test_editor'] } }));
+    await page.route('**/tests', (r) => {
+        if (r.request().method() === 'GET') return r.fulfill({ json: sampleTests });
+        return r.continue();
+    });
+}
+
+test.describe('admin-tests gating (stubbed)', () => {
+    test('scoped editor sees Edit only on the USA test, no Delete', async ({ page }) => {
+        await stub(page, { is_global_admin: false, editor: [{ object_type: 'national_calendar_test', object_id: 'USA' }], admin: [] });
+        await page.goto('/admin-tests.php');
+        const usaRow = page.locator('tr', { hasText: 'UsaNationalTest' });
+        const grcRow = page.locator('tr', { hasText: 'GrcOnlyTest' });
+        await expect(usaRow.getByRole('button', { name: 'Edit' })).toBeVisible();
+        await expect(usaRow.getByRole('button', { name: 'Delete' })).toHaveCount(0);
+        await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+    });
+
+    test('global admin sees Edit and Delete on every row', async ({ page }) => {
+        await stub(page, { is_global_admin: true, editor: [], admin: [] });
+        await page.goto('/admin-tests.php');
+        await expect(page.getByRole('button', { name: 'Edit' })).toHaveCount(2);
+        await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g gating`
+Expected: FAIL — no rows / buttons (module not created).
+
+- [ ] **Step 3: Create `assets/js/admin-tests.js` (bootstrap + list)**
+
+```javascript
+/**
+ * admin-tests page module. Bespoke (not the status-workflow factory), modeled
+ * on admin-permissions.js. Internal seam: generic CRUD plumbing vs.
+ * test-specific logic, so it can later seed a shared admin-page factory.
+ */
+import {
+    ApiClient,
+    CalendarSelect,
+    CalendarSelectFilter,
+} from '@liturgical-calendar/components-js';
+import { AssertionsBuilder, TestType } from './AssertionsBuilder.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const config = window.AdminTestsConfig;
+    if (!config) {
+        console.error('AdminTestsConfig not found');
+        return;
+    }
+    const { apiUrl, i18n } = config;
+
+    // ---- generic seam -----------------------------------------------------
+
+    async function fetchJson(method, path, body) {
+        const opts = {
+            method,
+            headers: { Accept: 'application/json' },
+            credentials: 'include',
+        };
+        if (body !== undefined) {
+            opts.headers['Content-Type'] = 'application/json';
+            opts.body = JSON.stringify(body);
+        }
+        const res = await fetch(apiUrl + path, opts);
+        const text = await res.text();
+        const data = text ? JSON.parse(text) : null;
+        if (!res.ok) {
+            throw { status: res.status, body: data };
+        }
+        return data;
+    }
+
+    /** Mirror TestScopeResolver: derive a test's scope object from applies_to. */
+    function deriveScope(appliesTo) {
+        if (appliesTo && appliesTo.diocesan_calendar) {
+            return { object_type: 'diocesan_calendar_test', object_id: appliesTo.diocesan_calendar };
+        }
+        if (appliesTo && appliesTo.national_calendar) {
+            return { object_type: 'national_calendar_test', object_id: appliesTo.national_calendar };
+        }
+        return { object_type: 'general_roman_calendar_test', object_id: 'general_roman_calendar' };
+    }
+
+    function gateByScope(scopeObj, scopes) {
+        return scopes.some((s) => s.object_type === scopeObj.object_type && s.object_id === scopeObj.object_id);
+    }
+
+    function showModalAlert(modalEl, type, message) {
+        const area = modalEl.querySelector('[id$="Alerts"]');
+        if (!area) return;
+        area.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">`
+            + `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
+    }
+
+    // ---- state ------------------------------------------------------------
+
+    const state = {
+        tests: [],
+        scopes: { is_global_admin: false, editor: [], admin: [] },
+        editing: null,
+    };
+
+    function scopeLabel(appliesTo) {
+        const s = deriveScope(appliesTo);
+        if (s.object_type === 'national_calendar_test') return `${i18n.nationalCalendar}: ${s.object_id}`;
+        if (s.object_type === 'diocesan_calendar_test') return `${i18n.diocesanCalendar}: ${s.object_id}`;
+        return i18n.generalRomanCalendar;
+    }
+
+    function yearRange(test) {
+        const years = test.assertions.map((a) => a.year);
+        return years.length ? `${Math.min(...years)}–${Math.max(...years)}` : '';
+    }
+
+    function canEdit(test) {
+        return state.scopes.is_global_admin || gateByScope(deriveScope(test.applies_to), state.scopes.editor);
+    }
+
+    function canDelete(test) {
+        return state.scopes.is_global_admin || gateByScope(deriveScope(test.applies_to), state.scopes.admin);
+    }
+
+    function renderTableRows() {
+        const tbody = document.getElementById('testsTableBody');
+        const nameFilter = document.getElementById('filterTestName').value.trim().toLowerCase();
+        const scopeFilter = document.getElementById('filterTestScope').value.trim().toLowerCase();
+        const rows = state.tests.filter((t) => {
+            const matchesName = !nameFilter || t.name.toLowerCase().includes(nameFilter);
+            const matchesScope = !scopeFilter || scopeLabel(t.applies_to).toLowerCase().includes(scopeFilter);
+            return matchesName && matchesScope;
+        });
+        document.getElementById('testsCount').textContent = String(rows.length);
+        tbody.innerHTML = '';
+        if (!rows.length) {
+            tbody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">${i18n.noTests}</td></tr>`;
+            return;
+        }
+        rows.forEach((t) => {
+            const tr = document.createElement('tr');
+            const editBtn = canEdit(t)
+                ? `<button type="button" class="btn btn-sm btn-outline-primary editTestBtn" data-name="${t.name}"><i class="fas fa-pen"></i> ${i18n.edit}</button>`
+                : '';
+            const delBtn = canDelete(t)
+                ? `<button type="button" class="btn btn-sm btn-outline-danger deleteTestBtn ms-1" data-name="${t.name}"><i class="fas fa-trash"></i> ${i18n.delete}</button>`
+                : '';
+            tr.innerHTML = `
+                <td><code>${t.name}</code></td>
+                <td>${t.event_key}</td>
+                <td>${scopeLabel(t.applies_to)}</td>
+                <td>${t.test_type}</td>
+                <td>${yearRange(t)}</td>
+                <td class="text-end">${editBtn}${delBtn}</td>`;
+            tbody.appendChild(tr);
+        });
+    }
+
+    async function loadTests() {
+        const tbody = document.getElementById('testsTableBody');
+        tbody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">${i18n.loading}</td></tr>`;
+        try {
+            const [scopes, testsResp] = await Promise.all([
+                fetchJson('GET', '/auth/test-scopes').catch(() => ({ is_global_admin: false, editor: [], admin: [] })),
+                fetchJson('GET', '/tests'),
+            ]);
+            state.scopes = scopes;
+            state.tests = testsResp.litcal_tests ?? [];
+            renderTableRows();
+        } catch (err) {
+            console.error('Failed to load tests', err);
+            tbody.innerHTML = `<tr><td colspan="6" class="text-center text-danger">${i18n.failedToLoad}</td></tr>`;
+        }
+    }
+
+    document.getElementById('refreshTestsBtn').addEventListener('click', loadTests);
+    document.getElementById('filterTestName').addEventListener('input', renderTableRows);
+    document.getElementById('filterTestScope').addEventListener('input', renderTableRows);
+
+    // Expose internals for later tasks (editor/delete wiring appended below).
+    window.__adminTests = { state, fetchJson, deriveScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, ApiClient };
+
+    loadTests();
+});
+```
+
+> `window.__adminTests` is a deliberate seam so Tasks 9–10 can append editor/delete wiring in the same file without a giant single step. When Task 10
+> is complete, this debug handle may be trimmed to only what the e2e specs rely on.
+
+- [ ] **Step 4: Run the gating spec to verify it passes**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g gating`
+Expected: PASS — scoped editor sees one Edit and no Delete; global admin sees two of each.
+
+- [ ] **Step 5: Lint and commit**
+
+Run: `yarn lint`
+
+```bash
+git add assets/js/admin-tests.js e2e/admin-tests.spec.ts
+git commit -m "feat(admin-tests): admin-tests.js bootstrap, list, per-row scope gating"
+```
+
+---
+
+### Task 9: `admin-tests.js` — editor modal (create + edit), events datalist, slider, AssertionsBuilder glue
+
+**Files:**
+
+- Modify: `assets/js/admin-tests.js`
+- Test: `e2e/admin-tests.spec.ts` (extend)
+
+**Interfaces:**
+
+- Consumes: `AssertionsBuilder` (Tasks 1–5), `CalendarSelect`/`CalendarSelectFilter`/`ApiClient`, generic seam from Task 8; `GET /events[ /nation/{id}
+  | /diocese/{id} ]` → `{ litcal_events: [{event_key, name, grade, grade_lcl, month, day}] }`; `PUT /tests` (create), `PATCH /tests/{name}` (edit).
+- Produces: a working editor that opens for create/edit, builds the datalist + slider + per-year cards from the model, and submits. `name` is read-only when editing.
+
+- [ ] **Step 1: Write the failing create/edit specs**
+
+Append to `e2e/admin-tests.spec.ts`:
+
+```typescript
+const grcEvents = {
+    litcal_events: [
+        { event_key: 'StIgnatiusOfLoyola', name: 'Saint Ignatius of Loyola', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 },
+    ],
+};
+
+async function stubEditor(page, scopes) {
+    await stub(page, scopes);
+    await page.route('**/events**', (r) => r.fulfill({ json: grcEvents }));
+}
+
+test.describe('admin-tests editor (stubbed)', () => {
+    test('create flow submits a PUT with a schema-shaped body', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        let putBody = null;
+        await page.route('**/tests', (r) => {
+            if (r.request().method() === 'PUT') {
+                putBody = r.request().postDataJSON();
+                return r.fulfill({ json: { ...putBody } });
+            }
+            return r.fulfill({ json: sampleTests });
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await page.locator('#tt-exact').check({ force: true });
+        await page.locator('#testName').fill('StIgnatiusOfLoyolaTest');
+        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('change');
+        await page.locator('#saveTestBtn').click();
+        await expect.poll(() => putBody && putBody.name).toBe('StIgnatiusOfLoyolaTest');
+        expect(putBody.test_type).toBe('exactCorrespondence');
+        expect(putBody.assertions.length).toBeGreaterThan(0);
+        expect(putBody.assertions[0].assert).toBe('eventExists AND hasExpectedDate');
+    });
+
+    test('edit flow renders name read-only and submits PATCH', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        let patched = false;
+        await page.route('**/tests/UsaNationalTest', (r) => {
+            if (r.request().method() === 'PATCH') { patched = true; return r.fulfill({ json: {} }); }
+            return r.continue();
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('tr', { hasText: 'UsaNationalTest' }).getByRole('button', { name: 'Edit' }).click();
+        await expect(page.locator('#testName')).toHaveAttribute('readonly', '');
+        await page.locator('#saveTestBtn').click();
+        await expect.poll(() => patched).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g editor`
+Expected: FAIL — clicking New/Edit does nothing yet.
+
+- [ ] **Step 3: Append editor wiring to `assets/js/admin-tests.js`**
+
+Insert the following inside the `DOMContentLoaded` callback, before the final `loadTests();` line (it reuses `fetchJson`, `state`, `i18n`, `apiUrl`,
+`config`, and the imported classes):
+
+```javascript
+    // ---- editor -----------------------------------------------------------
+
+    const editorModalEl = document.getElementById('testEditorModal');
+    const editorModal = bootstrap.Modal.getOrCreateInstance(editorModalEl);
+    const builder = new AssertionsBuilder({ locale: config.locale });
+    let events = [];
+
+    function selectedTestType() {
+        return document.querySelector('input[name="testType"]:checked')?.value ?? TestType.ExactCorrespondence;
+    }
+
+    function selectedScope() {
+        const type = document.getElementById('testScopeType').value;
+        if (type === 'general_roman_calendar') return null;
+        const idEl = document.getElementById('testScopeId');
+        const id = idEl ? idEl.value : '';
+        return id ? { [type]: id } : null;
+    }
+
+    function eventsPath(appliesTo) {
+        if (appliesTo && appliesTo.diocesan_calendar) return `/events/diocese/${appliesTo.diocesan_calendar}`;
+        if (appliesTo && appliesTo.national_calendar) return `/events/nation/${appliesTo.national_calendar}`;
+        return '/events';
+    }
+
+    async function loadEvents(appliesTo) {
+        const res = await fetch(apiUrl + eventsPath(appliesTo), {
+            headers: { Accept: 'application/json', 'Accept-Language': config.locale },
+            credentials: 'include',
+        });
+        const json = await res.json();
+        events = json.litcal_events ?? [];
+        const datalist = document.getElementById('testEventKeyList');
+        datalist.innerHTML = '';
+        events.forEach((e) => {
+            const opt = document.createElement('option');
+            opt.value = e.event_key;
+            opt.textContent = `${e.name} (${e.grade_lcl})`;
+            if (e.month != null) opt.dataset.month = String(e.month);
+            if (e.day != null) opt.dataset.day = String(e.day);
+            if (e.grade != null) opt.dataset.grade = String(e.grade);
+            datalist.appendChild(opt);
+        });
+    }
+
+    function sliderYears() {
+        const a = Number(document.getElementById('lowerRange').value);
+        const b = Number(document.getElementById('upperRange').value);
+        return { minYear: Math.min(a, b), maxYear: Math.max(a, b) };
+    }
+
+    function renderYearGrid() {
+        const grid = document.getElementById('yearGrid');
+        const { minYear, maxYear } = sliderYears();
+        grid.innerHTML = '';
+        for (let y = minYear; y <= maxYear; y++) {
+            const span = document.createElement('span');
+            span.className = `testYearSpan year-${y}`;
+            span.dataset.year = String(y);
+            span.textContent = String(y);
+            grid.appendChild(span);
+        }
+    }
+
+    function regenerate() {
+        const event = events.find((e) => e.event_key === document.getElementById('testEventKey').value);
+        if (!event) return;
+        const { minYear, maxYear } = sliderYears();
+        const tt = selectedTestType();
+        builder.setMeta({ test_type: tt, applies_to: selectedScope() });
+        const pivot = (tt === TestType.ExactCorrespondenceSince || tt === TestType.ExactCorrespondenceUntil)
+            ? minYear
+            : null;
+        builder.generate({ event, minYear, maxYear, pivotYear: pivot });
+        document.getElementById('testDescription').value = builder.model.description;
+        document.getElementById('baseDate').value = event.month && event.day
+            ? `${minYear}-${String(event.month).padStart(2, '0')}-${String(event.day).padStart(2, '0')}`
+            : '';
+        builder.render(document.getElementById('assertionsContainer'));
+        renderYearGrid();
+    }
+
+    document.getElementById('testEventKey').addEventListener('change', regenerate);
+    document.querySelectorAll('input[name="testType"]').forEach((el) => el.addEventListener('change', regenerate));
+    document.getElementById('lowerRange').addEventListener('change', regenerate);
+    document.getElementById('upperRange').addEventListener('change', regenerate);
+
+    // sync slider CSS custom properties as the user drags
+    ['lowerRange', 'upperRange'].forEach((id, idx) => {
+        const el = document.getElementById(id);
+        el.addEventListener('input', () => {
+            const prop = idx === 0 ? '--value-a' : '--value-b';
+            const textProp = idx === 0 ? '--text-value-a' : '--text-value-b';
+            el.parentNode.style.setProperty(prop, el.value);
+            el.parentNode.style.setProperty(textProp, `"${el.value}"`);
+        });
+    });
+
+    // per-year card interactions (event-delegated on the assertions container)
+    const assertionsContainer = document.getElementById('assertionsContainer');
+    assertionsContainer.addEventListener('click', (ev) => {
+        const card = ev.target.closest('[data-year]');
+        if (!card) return;
+        const year = Number(card.dataset.year);
+        if (ev.target.closest('.toggleAssert')) {
+            builder.toggleAssert(year);
+            builder.render(assertionsContainer);
+        } else if (ev.target.closest('.comment')) {
+            document.getElementById('commentYear').value = String(year);
+            const a = builder.model.assertions.find((x) => x.year === year);
+            document.getElementById('commentText').value = a && 'comment' in a ? a.comment : '';
+            bootstrap.Modal.getOrCreateInstance(document.getElementById('testCommentModal')).show();
+        }
+    });
+    assertionsContainer.addEventListener('change', (ev) => {
+        const card = ev.target.closest('[data-year]');
+        if (!card) return;
+        const year = Number(card.dataset.year);
+        if (ev.target.matches('.assertionText')) {
+            builder.setAssertionText(year, ev.target.value);
+        }
+    });
+    document.getElementById('saveCommentBtn').addEventListener('click', () => {
+        const year = Number(document.getElementById('commentYear').value);
+        builder.setComment(year, document.getElementById('commentText').value);
+        builder.render(assertionsContainer);
+        bootstrap.Modal.getInstance(document.getElementById('testCommentModal')).hide();
+    });
+
+    async function syncScopeIdField() {
+        const type = document.getElementById('testScopeType').value;
+        const mount = document.getElementById('testScopeIdMount');
+        mount.innerHTML = '';
+        if (type === 'national_calendar' || type === 'diocesan_calendar') {
+            const client = await ApiClient.init(apiUrl).catch(() => null);
+            if (!client) return;
+            const filter = type === 'national_calendar'
+                ? CalendarSelectFilter.NATIONAL_CALENDARS
+                : CalendarSelectFilter.DIOCESAN_CALENDARS;
+            const sel = new CalendarSelect(config.locale).filter(filter).allowNull(true).class('form-select').id('testScopeId');
+            sel.appendTo(mount);
+        }
+    }
+    document.getElementById('testScopeType').addEventListener('change', () => { syncScopeIdField(); regenerate(); });
+
+    function openEditor(test) {
+        state.editing = test ? test.name : null;
+        document.getElementById('testEditorAlerts').innerHTML = '';
+        const nameEl = document.getElementById('testName');
+        if (test) {
+            builder.load(test);
+            nameEl.value = test.name;
+            nameEl.setAttribute('readonly', '');
+            document.querySelector(`input[name="testType"][value="${test.test_type}"]`).checked = true;
+            document.getElementById('testEventKey').value = test.event_key;
+            document.getElementById('testDescription').value = test.description;
+            const scope = deriveScope(test.applies_to);
+            const typeSel = document.getElementById('testScopeType');
+            typeSel.value = scope.object_type === 'national_calendar_test' ? 'national_calendar'
+                : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
+                : 'general_roman_calendar';
+            loadEvents(test.applies_to).then(() => builder.render(assertionsContainer));
+        } else {
+            builder.load({ name: '', event_key: '', description: '', test_type: TestType.ExactCorrespondence, assertions: [] });
+            nameEl.value = '';
+            nameEl.removeAttribute('readonly');
+            document.getElementById('tt-exact').checked = true;
+            document.getElementById('testEventKey').value = '';
+            document.getElementById('testDescription').value = '';
+            document.getElementById('testScopeType').value = 'general_roman_calendar';
+            assertionsContainer.innerHTML = '';
+            loadEvents(null);
+        }
+        syncScopeIdField();
+        editorModal.show();
+    }
+
+    document.getElementById('createTestBtn').addEventListener('click', () => openEditor(null));
+    document.getElementById('testsTableBody').addEventListener('click', (ev) => {
+        const editBtn = ev.target.closest('.editTestBtn');
+        if (editBtn) {
+            const test = state.tests.find((t) => t.name === editBtn.dataset.name);
+            if (test) openEditor(test);
+        }
+    });
+
+    document.getElementById('saveTestBtn').addEventListener('click', async () => {
+        const btn = document.getElementById('saveTestBtn');
+        const nameEl = document.getElementById('testName');
+        if (!nameEl.checkValidity() || !document.getElementById('testEventKey').value) {
+            showModalAlert(editorModalEl, 'warning', i18n.requiredFields);
+            return;
+        }
+        builder.setMeta({
+            name: nameEl.value,
+            event_key: document.getElementById('testEventKey').value,
+            description: document.getElementById('testDescription').value,
+            test_type: selectedTestType(),
+            applies_to: selectedScope(),
+        });
+        const payload = builder.serialize();
+        btn.disabled = true;
+        const original = btn.textContent;
+        btn.textContent = i18n.saving;
+        try {
+            if (state.editing) {
+                await fetchJson('PATCH', `/tests/${encodeURIComponent(state.editing)}`, payload);
+            } else {
+                await fetchJson('PUT', '/tests', payload);
+            }
+            editorModal.hide();
+            await loadTests();
+        } catch (err) {
+            const msg = err.status === 403 ? i18n.denied403
+                : err.status === 409 ? i18n.conflict409
+                : (err.body && err.body.message) ? err.body.message : i18n.failedToLoad;
+            showModalAlert(editorModalEl, 'danger', msg);
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    });
+```
+
+- [ ] **Step 4: Run the editor specs to verify they pass**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g editor`
+Expected: PASS — PUT body is schema-shaped; edit renders `name` read-only and fires PATCH.
+
+- [ ] **Step 5: Lint and commit**
+
+Run: `yarn lint`
+
+```bash
+git add assets/js/admin-tests.js e2e/admin-tests.spec.ts
+git commit -m "feat(admin-tests): editor modal — events datalist, slider, AssertionsBuilder glue, create/edit"
+```
+
+---
+
+### Task 10: `admin-tests.js` — delete flow
+
+**Files:**
+
+- Modify: `assets/js/admin-tests.js`
+- Test: `e2e/admin-tests.spec.ts` (extend)
+
+**Interfaces:**
+
+- Consumes: generic seam; `DELETE /tests/{name}`.
+- Produces: delete-confirm modal wiring that fires `DELETE /tests/{name}` and reloads the list.
+
+- [ ] **Step 1: Write the failing delete spec**
+
+Append:
+
+```typescript
+test.describe('admin-tests delete (stubbed)', () => {
+    test('confirms and fires DELETE', async ({ page }) => {
+        await stub(page, { is_global_admin: true, editor: [], admin: [] });
+        let deleted = false;
+        await page.route('**/tests/GrcOnlyTest', (r) => {
+            if (r.request().method() === 'DELETE') { deleted = true; return r.fulfill({ json: {} }); }
+            return r.continue();
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('tr', { hasText: 'GrcOnlyTest' }).getByRole('button', { name: 'Delete' }).click();
+        await expect(page.locator('#deleteTestModal')).toBeVisible();
+        await page.locator('#confirmDeleteTestBtn').click();
+        await expect.poll(() => deleted).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g delete`
+Expected: FAIL — Delete button does nothing.
+
+- [ ] **Step 3: Append delete wiring**
+
+Insert before the final `loadTests();`:
+
+```javascript
+    // ---- delete -----------------------------------------------------------
+
+    const deleteModalEl = document.getElementById('deleteTestModal');
+    const deleteModal = bootstrap.Modal.getOrCreateInstance(deleteModalEl);
+    let deleteTarget = null;
+
+    document.getElementById('testsTableBody').addEventListener('click', (ev) => {
+        const delBtn = ev.target.closest('.deleteTestBtn');
+        if (!delBtn) return;
+        deleteTarget = delBtn.dataset.name;
+        document.getElementById('deleteTestAlerts').innerHTML = '';
+        document.getElementById('deleteTestConfirmText').textContent = i18n.confirmDelete.replace('%s', deleteTarget);
+        deleteModal.show();
+    });
+
+    document.getElementById('confirmDeleteTestBtn').addEventListener('click', async () => {
+        if (!deleteTarget) return;
+        const btn = document.getElementById('confirmDeleteTestBtn');
+        btn.disabled = true;
+        const original = btn.textContent;
+        btn.textContent = i18n.deleting;
+        try {
+            await fetchJson('DELETE', `/tests/${encodeURIComponent(deleteTarget)}`);
+            deleteModal.hide();
+            await loadTests();
+        } catch (err) {
+            const msg = err.status === 403 ? i18n.denied403 : (err.body && err.body.message) ? err.body.message : i18n.failedToLoad;
+            showModalAlert(deleteModalEl, 'danger', msg);
+        } finally {
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    });
+```
+
+- [ ] **Step 4: Run the delete spec to verify it passes**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g delete`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full stubbed suite, lint, commit**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium`
+Expected: all specs PASS.
+
+Run: `yarn lint`
+
+```bash
+git add assets/js/admin-tests.js e2e/admin-tests.spec.ts
+git commit -m "feat(admin-tests): delete-confirm flow (DELETE /tests/{name})"
+```
+
+---
+
+### Task 11: Real-seeded RBAC e2e spec
+
+**Files:**
+
+- Create: `e2e/rbac/13-admin-tests-crud.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the existing RBAC harness — `e2e/rbac/support/` (`actingAs`, `grant`, `seed`, `cleanup`) and the `rbac` Playwright project (`dependencies:
+  ['rbac-setup']`). Model on `e2e/rbac/12-test-editor-scoped-test-request.spec.ts`.
+- Produces: a real end-to-end spec where a seeded `test_editor` with a scoped FGA `editor` tuple creates/edits a test in their scope and is denied
+  outside it; a global admin deletes.
+
+- [ ] **Step 1: Read the canonical examples**
+
+Open and read for exact helper signatures and setup:
+
+```bash
+sed -n '1,80p' e2e/rbac/12-test-editor-scoped-test-request.spec.ts
+sed -n '1,60p' e2e/rbac/support/grant.ts
+sed -n '1,60p' e2e/rbac/support/actingAs.ts
+```
+
+- [ ] **Step 2: Write the spec, modeled on spec 12**
+
+Create `e2e/rbac/13-admin-tests-crud.spec.ts`. Use the same imports, `actingAs`/`grant` helpers, and seeded users that spec 12 uses. The flow:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+import { grant } from './support/grant';
+
+// Mirror spec 12's seeded users and helper signatures exactly. The user names
+// below are placeholders for the real seeded identities in support/seed.ts —
+// substitute the actual constants used by spec 12.
+
+test.describe('admin-tests CRUD (real RBAC)', () => {
+    test('scoped national test_editor can create within scope and is denied outside', async ({ page }) => {
+        await grant({ user: 'USCCB_EDITOR', relation: 'editor', object: 'national_calendar_test:USA' });
+        await actingAs(page, 'USCCB_EDITOR');
+
+        await page.goto('/admin-tests.php');
+        await expect(page.locator('#testsTableBody')).toBeVisible();
+
+        // Create within scope (national_calendar: USA)
+        await page.locator('#createTestBtn').click();
+        await page.locator('#tt-exact').check({ force: true });
+        await page.locator('#testName').fill('PlaywrightUsaScopedTest');
+        await page.locator('#testScopeType').selectOption('national_calendar');
+        // select USA in the mounted CalendarSelect (#testScopeId)
+        await page.locator('#testScopeId').selectOption('USA');
+        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('change');
+        await page.locator('#saveTestBtn').click();
+        await expect(page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' })).toBeVisible();
+
+        // A General-Roman-scoped row offers no Edit button to this scoped editor
+        const grcRow = page.locator('tr', { hasText: 'general_roman' }).first();
+        if (await grcRow.count()) {
+            await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+        }
+    });
+
+    test('global admin can delete any test', async ({ page }) => {
+        await actingAs(page, 'GLOBAL_ADMIN');
+        await page.goto('/admin-tests.php');
+        const row = page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' });
+        await row.getByRole('button', { name: 'Delete' }).click();
+        await page.locator('#confirmDeleteTestBtn').click();
+        await expect(page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' })).toHaveCount(0);
+    });
+});
+```
+
+> The `actingAs`/`grant`/user-constant names above MUST be replaced with the exact symbols spec 12 imports. Do not invent helper signatures — copy
+> spec 12's. If spec 12 seeds via a different mechanism (e.g., `seed.ts` fixtures), follow that instead. Add a `cleanup` afterAll if spec 12 does.
+
+- [ ] **Step 3: Run the rbac spec**
+
+Run: `yarn playwright test e2e/rbac/13-admin-tests-crud.spec.ts --project=rbac`
+Expected: PASS (requires the docker RBAC infra the `rbac-setup` project brings up).
+
+> If the RBAC infra is not available in this worktree, mark as deferred-to-CI and note it in the PR description; the stubbed specs (Tasks 8–10) provide the fast gate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/rbac/13-admin-tests-crud.spec.ts
+git commit -m "test(admin-tests): real-seeded RBAC e2e for scoped CRUD"
+```
+
+---
+
+### Task 12: Docs, markdownlint, and final review
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-06-29-admin-tests-page-phase2.md` (check off steps as completed)
+- Possibly create: a short `docs/` note if the repo documents admin pages (only if such an index exists)
+
+- [ ] **Step 1: Run the full unit + stubbed-e2e gates**
+
+Run: `yarn test:unit`
+Expected: all AssertionsBuilder tests PASS.
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium`
+Expected: all stubbed specs PASS.
+
+- [ ] **Step 2: Lint everything touched**
+
+Run: `yarn lint`
+Run: `yarn lint:md`
+Expected: no errors.
+
+- [ ] **Step 3: Verify no Isotope / contenteditable leaked into the port**
+
+Run: `grep -rnE "isotope|contenteditable" assets/js/AssertionsBuilder.js assets/js/admin-tests.js`
+Expected: no matches (state-first port complete).
+
+- [ ] **Step 4: Commit any doc updates**
+
+```bash
+git add docs/superpowers/plans/2026-06-29-admin-tests-page-phase2.md
+git commit -m "docs(admin-tests): mark phase 2 plan steps complete"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Dedicated `admin-tests.php` + `assets/js/admin-tests.js` modeled on `admin-permissions.js` (not the factory) → Tasks 7, 8.
+- Generic/specific seam (`fetchJson`, `gateByScope`, `deriveScope`, `renderTableRows`, `showModalAlert`) → Task 8.
+- List grouped/filterable by scope; columns name/event_key/scope/test_type/years/actions → Task 8.
+- Per-row Edit (editor scope) / Delete (admin scope) gating from `/auth/test-scopes`; API backstop (403 surfaced) → Tasks 8, 9, 10.
+- Ported editor: test-type buttons + icons (`fa-vial`/`fa-right-from-bracket`/`fa-right-to-bracket`/`fa-square-root-variable`), `/events` datalist
+  with `data-month/day/grade`, base date, dual-range slider (`multi-range-slider.css` verbatim), per-year cards with `eventExists AND hasExpectedDate
+  ↔ eventNotExists` toggle + color coding → Tasks 3, 5, 6, 9.
+- Modernizations: Isotope dropped (native CSS grid), state-first (`serialize()` reads the model), `<textarea>` not contenteditable → Tasks 2–5 (+ Task 12 grep gate).
+- `name` read-only when editing; rename = delete+recreate → Task 9.
+- Create `PUT /tests`, edit `PATCH /tests/{name}`, delete `DELETE /tests/{name}` → Tasks 9, 10.
+- Error handling (400/422/401/403/404/409, disable submit during request, required-field validation) → Tasks 9, 10.
+- Testing: Vitest unit (AssertionsBuilder), Playwright route-stubbed (gating + CRUD), one real-seeded RBAC spec → Tasks 1–5, 8–11.
+- Nav entry + dashboard card + `$adminPages` registration → Task 7.
+
+**Placeholder scan:** The two intentional "match the real neighbor" notes (header.php nav placement, admin-dashboard.php card markup, and the rbac
+helper symbol names in Task 11) are flagged explicitly because the exact surrounding markup/symbols must be read from the live files at execution
+time; the code provided is concrete and runnable, with the read-the-canonical-file step included. No `TODO`/`implement later`/empty-handler
+placeholders remain.
+
+**Type consistency:** `AssertionsBuilder` method names (`load`, `setMeta`, `generate`, `serialize`, `toggleAssert`, `setExpectedDate`,
+`setAssertionText`, `setComment`, `excludeYear`, `setPivot`, `render`) are used consistently across Tasks 2–9. `deriveScope`/`gateByScope`/`fetchJson`
+signatures match between definition (Task 8) and use (Tasks 9, 10). Assertion shape (`year`, `expected_value`, `assert`, `assertion`, optional
+`comment`) matches the schema and the serialize/round-trip tests.
+
+## Open items carried from the spec (resolve during execution)
+
+- **Global admin vs. `forTestEditor`:** the client gates Create on `isGlobalAdmin || hasTestEditor`; the API is authoritative. No client change needed
+  regardless of the answer — but confirm a global admin can actually `PUT` (if not, they'll get a 403 which the editor surfaces).
+- **`/events` shape per scope:** the datalist assumes `{ litcal_events: [{event_key, name, grade, grade_lcl, month, day}] }` from `/events`,
+  `/events/nation/{id}`, `/events/diocese/{id}`. Confirm `month`/`day` are present for fixed-date events when wiring Task 9 (the base-date prefill
+  depends on them).

--- a/docs/superpowers/plans/2026-07-05-admin-tests-year-grid-utilities.md
+++ b/docs/superpowers/plans/2026-07-05-admin-tests-year-grid-utilities.md
@@ -1,0 +1,650 @@
+# Admin-Tests Year-Grid Utilities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the UnitTestInterface year-grid affordances (hammer pivot/toggle, ⓧ exclude with striped-bar restore, Sunday highlighting) into the phase-2 admin-tests editor,
+plus a new color legend.
+
+**Architecture:** State-first — the grid is a pure projection of `builder.model` (`excludes`, `assertions`, pivot, `baseMonthDay`); clicks mutate the model via new
+`excludeYear`/`includeYear` methods (and existing `setPivot`/`toggleAssert`), then re-render grid + cards. `serialize()` already emits `excludes`; no API/schema work.
+
+**Tech Stack:** Vanilla ES6 (`assets/js/admin-tests.js`, `assets/js/AssertionsBuilder.js`), Vitest + jsdom for unit tests, Playwright (chromium project, stubbed routes) for e2e,
+PHP/gettext for markup + i18n.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md`
+
+## Global Constraints
+
+- Branch: `feat/admin-tests-phase2` (PR #379). Commit per task; **do NOT push** (CodeRabbit rate-limit convention — batch for an explicit push request).
+- Yarn 4 / node_modules linker: use `yarn …` for everything, never `npm`/`npx`; commit `package.json`+`yarn.lock` only (no `package-lock.json`).
+- Never `--no-verify`; pre-commit hooks run PHP lint + markdownlint.
+- gettext strings: numbered placeholders (`%1$s`) when more than one; wrap output in `htmlspecialchars(_('…'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')`.
+- The model is the single source of truth: `serialize()` and the grid must never read state from the DOM.
+- E2E prerequisite: the docker stack must be up (`docker compose up -d`) — the chromium project uses the shared auth storage state; the tests below stub every API route they touch.
+
+---
+
+### Task 1: `excludeYear` / `includeYear` model methods
+
+**Files:**
+
+- Modify: `assets/js/AssertionsBuilder.js` (insert after `setPivot`, which ends near line 257)
+- Test: `assets/js/__tests__/AssertionsBuilder.test.js` (append a new `describe` at the end)
+
+**Interfaces:**
+
+- Consumes: existing `AssertionsBuilder` internals — `this.model` (`excludes`, `assertions`, `test_type`, `year_since`, `year_until`, `description`), `this.baseMonthDay`,
+  `Assertion`, `AssertType`, `TestType`, static `#expectedValue(year, month, day)`.
+- Produces: `excludeYear(year: number): this` and `includeYear(year: number): this` — chainable, used by Task 3's click handler.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `assets/js/__tests__/AssertionsBuilder.test.js` (the `event` fixture — `{ event_key: 'StIgnatiusOfLoyola', …, month: 7, day: 31 }` — is already defined at module level):
+
+```javascript
+describe("excludeYear / includeYear", () => {
+  const build = () => {
+    const b = new AssertionsBuilder({ locale: "en" });
+    b.setMeta({ event_key: event.event_key, test_type: "exactCorrespondence" });
+    b.generate({ event, minYear: 2024, maxYear: 2026 });
+    return b;
+  };
+
+  it("excludeYear removes the assertion and records the exclusion (sorted, deduped)", () => {
+    const b = build();
+    b.excludeYear(2025).excludeYear(2024).excludeYear(2025);
+    expect(b.model.excludes).toEqual([2024, 2025]);
+    expect(b.model.assertions.map((a) => a.year)).toEqual([2026]);
+  });
+
+  it("excludeYear is a no-op for years without an assertion", () => {
+    const b = build();
+    b.excludeYear(1999);
+    expect(b.model.excludes).toBe(null);
+    expect(b.model.assertions).toHaveLength(3);
+  });
+
+  it("includeYear restores an exact assertion with expected_value from baseMonthDay", () => {
+    const b = build();
+    b.excludeYear(2025).includeYear(2025);
+    expect(b.model.excludes).toBe(null);
+    const a = b.model.assertions.find((x) => x.year === 2025);
+    expect(a.assert).toBe("eventExists AND hasExpectedDate");
+    expect(a.expected_value).toBe("2025-07-31T00:00:00+00:00");
+    expect(b.model.assertions.map((x) => x.year)).toEqual([2024, 2025, 2026]);
+  });
+
+  it("includeYear respects the since-pivot (restores eventNotExists before it)", () => {
+    const b = new AssertionsBuilder({ locale: "en" });
+    b.setMeta({
+      event_key: event.event_key,
+      test_type: "exactCorrespondenceSince",
+    });
+    b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2026 });
+    b.excludeYear(2024).includeYear(2024);
+    const a = b.model.assertions.find((x) => x.year === 2024);
+    expect(a.assert).toBe("eventNotExists");
+    expect(a.assertion).toContain("should not exist on");
+  });
+
+  it("serialize emits excludes while excluded and drops the key after restore", () => {
+    const b = build();
+    b.excludeYear(2026);
+    expect(b.serialize().excludes).toEqual([2026]);
+    b.includeYear(2026);
+    expect("excludes" in b.serialize()).toBe(false);
+  });
+
+  it("includeYear is a no-op when the year is not excluded", () => {
+    const b = build();
+    b.includeYear(2025);
+    expect(b.model.excludes).toBe(null);
+    expect(b.model.assertions).toHaveLength(3);
+  });
+
+  it("generate skips excludedYears so regeneration preserves exclusions", () => {
+    // model-level guarantee behind the regenerate() wiring in admin-tests.js
+    const b = build();
+    b.excludeYear(2025);
+    b.generate({
+      event,
+      minYear: 2024,
+      maxYear: 2026,
+      excludedYears: b.model.excludes ?? [],
+    });
+    expect(b.model.assertions.map((a) => a.year)).toEqual([2024, 2026]);
+    expect(b.model.excludes).toEqual([2025]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test:unit`
+Expected: 7 new tests FAIL with `b.excludeYear is not a function`; the pre-existing 28 still pass.
+
+- [ ] **Step 3: Implement the two methods**
+
+In `assets/js/AssertionsBuilder.js`, insert immediately AFTER the closing brace of `setPivot(year)` (and before `#formatDate`):
+
+```javascript
+    /**
+     * Exclude a year from the test: record it in model.excludes (sorted,
+     * deduped) and drop its assertion. No-op if the year has no assertion.
+     */
+    excludeYear(year) {
+        const y = Number(year);
+        if (!this.model.assertions.some((a) => a.year === y)) return this;
+        const current = this.model.excludes ?? [];
+        if (!current.includes(y)) {
+            this.model.excludes = [...current, y].sort((a, b) => a - b);
+        }
+        this.model.assertions = this.model.assertions.filter((a) => a.year !== y);
+        return this;
+    }
+
+    /**
+     * Restore a previously excluded year, re-creating its assertion with the
+     * same rules generate() uses (pivot- and baseMonthDay-aware). excludes
+     * returns to null when the last exclusion is removed, so serialize()
+     * drops the key. No-op if the year is not excluded.
+     */
+    includeYear(year) {
+        const y = Number(year);
+        const current = this.model.excludes ?? [];
+        if (!current.includes(y)) return this;
+        const remaining = current.filter((x) => x !== y);
+        this.model.excludes = remaining.length ? remaining : null;
+
+        let notExists = false;
+        if (this.model.test_type === TestType.ExactCorrespondenceSince && this.model.year_since !== null) {
+            notExists = y < this.model.year_since;
+        } else if (this.model.test_type === TestType.ExactCorrespondenceUntil && this.model.year_until !== null) {
+            notExists = y > this.model.year_until;
+        }
+        const description = this.model.description;
+        if (notExists || !this.baseMonthDay) {
+            this.model.assertions.push(
+                new Assertion(y, null, AssertType.EventNotExists, description.replace('should fall on', 'should not exist on'))
+            );
+        } else {
+            this.model.assertions.push(
+                new Assertion(
+                    y,
+                    AssertionsBuilder.#expectedValue(y, this.baseMonthDay.month, this.baseMonthDay.day),
+                    AssertType.EventTypeExact,
+                    description
+                )
+            );
+        }
+        this.model.assertions.sort((a, b) => a.year - b.year);
+        return this;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test:unit`
+Expected: all 35 tests PASS (28 pre-existing + 7 new).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+yarn lint
+node --check assets/js/AssertionsBuilder.js
+git add assets/js/AssertionsBuilder.js assets/js/__tests__/AssertionsBuilder.test.js
+git commit -m "feat(admin-tests): AssertionsBuilder excludeYear/includeYear (state-first year exclusion)"
+```
+
+---
+
+### Task 2: Grid rendering — icons, Sunday highlighting, striped exclusion bar
+
+**Files:**
+
+- Modify: `assets/js/admin-tests.js` — replace `renderYearGrid()` (currently ~lines 246-271) and add a `yearDateAttrs()` helper above it
+- Modify: `assets/css/admin-tests.css` — replace the `.testYearSpan.deleted { opacity: 0.3 }` placeholder with the striped bar; add icon hover rules
+- Modify: `admin-tests.php` — add 4 keys to the `i18n:` block (after `conflict409`, ~line 323)
+- Test: `e2e/admin-tests.spec.ts` (append a new `test.describe`)
+
+**Interfaces:**
+
+- Consumes: `builder.model` / `builder.baseMonthDay`, `AssertType`, `TestType`, `sliderYears()`, `config.locale`, `i18n` (all already in scope in `admin-tests.js`).
+- Produces: grid spans with classes/`data-year` that Task 3's click handler targets: `.testYearSpan` (always), `.deleted` (excluded), child icons `.hammerYear` / `.removeYear`.
+  Same `renderYearGrid()` name — call sites unchanged.
+
+- [ ] **Step 1: Add the i18n keys**
+
+In `admin-tests.php`, the `i18n:` object currently ends with:
+
+```php
+                conflict409:         <?php echo json_encode(_('A test with that name already exists.')); ?>
+```
+
+Change that to (comma added, four keys appended):
+
+```php
+                conflict409:         <?php echo json_encode(_('A test with that name already exists.')); ?>,
+                setYear:             <?php echo json_encode(_('set year')); ?>,
+                removeYear:          <?php echo json_encode(_('remove')); ?>,
+                sundayInYear:        <?php echo json_encode(_('In the year %1$s, %2$s falls on a Sunday')); ?>,
+                excludedRestore:     <?php echo json_encode(_('%s excluded — click to restore')); ?>
+```
+
+- [ ] **Step 2: Replace the placeholder CSS**
+
+In `assets/css/admin-tests.css`, replace:
+
+```css
+.year-grid .testYearSpan.deleted {
+  opacity: 0.3;
+}
+```
+
+with (striped-bar values ported verbatim from `UnitTestInterface/assets/css/admin.css`; the selector is deliberately NOT ID-scoped so Task 4's legend chips can share it):
+
+```css
+.year-grid .testYearSpan.deleted,
+.legend-chip.deleted {
+  background: repeating-linear-gradient(
+    45deg,
+    red,
+    red 5px,
+    white 8px,
+    white 12px
+  );
+  cursor: not-allowed;
+}
+
+/* The base .testYearSpan padding stays in effect, so the clickable area is
+   ~19px wide even though the visible stripe content is 3px (same as the
+   original, where the 3px width sat inside the span's 3px/5px padding). */
+.year-grid .testYearSpan.deleted {
+  width: 3px;
+  height: 32px;
+}
+
+.year-grid .testYearSpan .hammerYear,
+.year-grid .testYearSpan .removeYear {
+  cursor: pointer;
+}
+
+.year-grid .testYearSpan .hammerYear:hover,
+.year-grid .testYearSpan .removeYear:hover {
+  opacity: 1 !important;
+}
+```
+
+- [ ] **Step 3: Rewrite `renderYearGrid()`**
+
+In `assets/js/admin-tests.js`, replace the whole current `renderYearGrid()` function with the following two functions (`yearDateAttrs` is new — the port of the old UI's
+`computeYearDateAttrs`):
+
+```javascript
+/**
+ * Port of UnitTestInterface's computeYearDateAttrs: title + Sunday flag
+ * for the event's fixed date in the given year (empty when the event has
+ * no fixed month/day).
+ */
+function yearDateAttrs(year) {
+  if (!builder.baseMonthDay) return { title: "", sunday: false };
+  const d = new Date(
+    Date.UTC(year, builder.baseMonthDay.month - 1, builder.baseMonthDay.day),
+  );
+  const sunday = d.getUTCDay() === 0;
+  const fmt = new Intl.DateTimeFormat(config.locale, {
+    dateStyle: "long",
+    timeZone: "UTC",
+  });
+  const title = sunday
+    ? i18n.sundayInYear
+        .replace("%1$s", String(year))
+        .replace("%2$s", fmt.format(d))
+    : fmt.format(d);
+  return { title, sunday };
+}
+
+function renderYearGrid() {
+  const grid = document.getElementById("yearGrid");
+  const { minYear, maxYear } = sliderYears();
+  const tt = builder.model.test_type;
+  const excluded = new Set(builder.model.excludes ?? []);
+  const notExists = new Set(
+    builder.model.assertions
+      .filter((a) => a.assert === AssertType.EventNotExists)
+      .map((a) => a.year),
+  );
+  const pivot =
+    tt === TestType.ExactCorrespondenceSince
+      ? builder.model.year_since
+      : tt === TestType.ExactCorrespondenceUntil
+        ? builder.model.year_until
+        : null;
+  const showHammer = tt !== TestType.ExactCorrespondence;
+  grid.innerHTML = "";
+  for (let y = minYear; y <= maxYear; y++) {
+    const span = document.createElement("span");
+    span.className = `testYearSpan year-${y}`;
+    span.dataset.year = String(y);
+    if (excluded.has(y)) {
+      span.classList.add("deleted");
+      span.title = i18n.excludedRestore.replace("%s", String(y));
+      grid.appendChild(span);
+      continue;
+    }
+    if (showHammer) {
+      const hammer = document.createElement("i");
+      hammer.className = "fas fa-hammer me-1 opacity-50 hammerYear";
+      hammer.setAttribute("role", "button");
+      hammer.setAttribute("aria-hidden", "true");
+      hammer.title = i18n.setYear;
+      span.appendChild(hammer);
+    }
+    span.appendChild(document.createTextNode(String(y)));
+    const xmark = document.createElement("i");
+    xmark.className = "fas fa-circle-xmark ms-1 opacity-50 removeYear";
+    xmark.setAttribute("role", "button");
+    xmark.setAttribute("aria-hidden", "true");
+    xmark.title = i18n.removeYear;
+    span.appendChild(xmark);
+    const { title, sunday } = yearDateAttrs(y);
+    if (title) span.title = title;
+    if (y === pivot) {
+      span.classList.add("bg-info");
+    } else if (notExists.has(y)) {
+      span.classList.add("bg-warning");
+    } else if (sunday) {
+      span.classList.add("bg-light");
+    }
+    grid.appendChild(span);
+  }
+}
+```
+
+Background precedence (pivot > not-exists > Sunday) matches the old UI, where pivot/warning classes replaced `bg-light`.
+
+- [ ] **Step 4: Add the failing e2e test**
+
+Append to `e2e/admin-tests.spec.ts` (reuses the existing `stubEditor` helper and `grcEvents` fixture — StIgnatiusOfLoyola, July 31; note 2005-07-31 IS a Sunday):
+
+```typescript
+test.describe("admin-tests year grid (stubbed)", () => {
+  test("spans carry icons, Sunday highlighting, and exclude/restore round-trips", async ({
+    page,
+  }) => {
+    await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+    await page.goto("/admin-tests.php");
+    await page.locator("#createTestBtn").click();
+    await page.locator("#tt-variable").check({ force: true });
+    await page.locator("#testEventKey").fill("StIgnatiusOfLoyola");
+    await page.locator("#testEventKey").dispatchEvent("change");
+
+    const span2005 = page.locator("#yearGrid .testYearSpan.year-2005");
+    await expect(span2005).toBeVisible();
+    // variable type → hammer present; x always present; 2005-07-31 is a Sunday
+    await expect(span2005.locator(".hammerYear")).toHaveCount(1);
+    await expect(span2005.locator(".removeYear")).toHaveCount(1);
+    await expect(span2005).toHaveClass(/bg-light/);
+
+    // exclude: card disappears, span collapses to the striped bar
+    await span2005.locator(".removeYear").click();
+    await expect(span2005).toHaveClass(/deleted/);
+    await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
+      0,
+    );
+
+    // restore: card returns, stripes gone
+    await span2005.click();
+    await expect(span2005).not.toHaveClass(/deleted/);
+    await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
+      1,
+    );
+  });
+});
+```
+
+- [ ] **Step 5: Run the e2e test to verify current failure mode**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g "year grid"`
+Expected: FAIL — `.hammerYear` count is 0 (icons not rendered yet by the running container if not yet synced, or exclusion does nothing because Task 3's handler is not written).
+Rendering assertions (icons, `bg-light`) should PASS after this task; the exclude/restore section FAILS until Task 3. That is the expected intermediate state — do not try to make
+the whole test pass in this task.
+
+- [ ] **Step 6: Syntax-check, lint, commit**
+
+```bash
+node --check assets/js/admin-tests.js
+yarn lint
+yarn typecheck
+php -l admin-tests.php
+git add assets/js/admin-tests.js assets/css/admin-tests.css admin-tests.php e2e/admin-tests.spec.ts
+git commit -m "feat(admin-tests): year-grid icons, Sunday highlighting, striped exclusion styling"
+```
+
+---
+
+### Task 3: Grid interactions + `regenerate()` exclusion preservation
+
+**Files:**
+
+- Modify: `assets/js/admin-tests.js` — replace the existing `#yearGrid` click handler (the block starting with the comment `// For Since/Until types, clicking a year in the
+  overview grid sets the pivot`), and one line in `regenerate()`
+
+**Interfaces:**
+
+- Consumes: `builder.excludeYear/includeYear` (Task 1), grid classes `.deleted`/`.hammerYear`/`.removeYear` + `data-year` (Task 2), existing
+  `builder.setPivot/toggleAssert/render`, `selectedTestType()`, `assertionsContainer`, `renderYearGrid()`.
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Replace the grid click handler**
+
+In `assets/js/admin-tests.js`, replace this entire existing block:
+
+```javascript
+// For Since/Until types, clicking a year in the overview grid sets the pivot
+// (year_since / year_until) and re-splits the assertions around it.
+document.getElementById("yearGrid").addEventListener("click", (ev) => {
+  const span = ev.target.closest(".testYearSpan");
+  if (!span) return;
+  const tt = selectedTestType();
+  if (
+    tt !== TestType.ExactCorrespondenceSince &&
+    tt !== TestType.ExactCorrespondenceUntil
+  )
+    return;
+  builder.setPivot(Number(span.dataset.year));
+  builder.render(assertionsContainer);
+  renderYearGrid();
+});
+```
+
+with:
+
+```javascript
+// Year-grid interactions (ported from UnitTestInterface, state-first):
+//   hammer  → Since/Until: set the pivot; Variable: toggle that year
+//   x-mark  → exclude the year (collapses to the striped bar)
+//   striped bar → restore the year
+//   span body   → no action (the icons are the affordances)
+document.getElementById("yearGrid").addEventListener("click", (ev) => {
+  const span = ev.target.closest(".testYearSpan");
+  if (!span) return;
+  const year = Number(span.dataset.year);
+  if (span.classList.contains("deleted")) {
+    builder.includeYear(year);
+  } else if (ev.target.closest(".removeYear")) {
+    builder.excludeYear(year);
+  } else if (ev.target.closest(".hammerYear")) {
+    const tt = selectedTestType();
+    if (
+      tt === TestType.ExactCorrespondenceSince ||
+      tt === TestType.ExactCorrespondenceUntil
+    ) {
+      builder.setPivot(year);
+    } else if (tt === TestType.VariableCorrespondence) {
+      builder.toggleAssert(year);
+    }
+  } else {
+    return;
+  }
+  builder.render(assertionsContainer);
+  renderYearGrid();
+});
+```
+
+- [ ] **Step 2: Preserve exclusions across regeneration**
+
+In `regenerate()`, change:
+
+```javascript
+builder.generate({ event, minYear, maxYear, pivotYear: pivot });
+```
+
+to:
+
+```javascript
+// Preserve exclusions when the event/type/slider changes; generate()
+// skips excluded years, so without this every regeneration would
+// silently restore them.
+builder.generate({
+  event,
+  minYear,
+  maxYear,
+  pivotYear: pivot,
+  excludedYears: builder.model.excludes ?? [],
+});
+```
+
+- [ ] **Step 3: Run the Task 2 e2e test to verify it now fully passes**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g "year grid"`
+Expected: PASS (icons + Sunday class from Task 2, exclude/restore now wired).
+
+- [ ] **Step 4: Run the full stubbed e2e file (regression: pivot flow, editor, delete)**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium`
+Expected: all tests PASS. If a pre-existing test clicked a span body to set the pivot, update it to click `.hammerYear` instead — the whole-span pivot click is intentionally
+removed.
+
+- [ ] **Step 5: Syntax-check, lint, unit tests, commit**
+
+```bash
+node --check assets/js/admin-tests.js
+yarn lint
+yarn test:unit
+git add assets/js/admin-tests.js e2e/admin-tests.spec.ts
+git commit -m "feat(admin-tests): year-grid hammer/exclude interactions; preserve excludes on regenerate"
+```
+
+---
+
+### Task 4: Legend chip row
+
+**Files:**
+
+- Modify: `admin-tests.php` — insert the legend row right after `<div class="year-grid mt-2" id="yearGrid"></div>` (~line 211)
+- Modify: `assets/css/admin-tests.css` — append `.legend-chip` sizing rules
+- Test: `e2e/admin-tests.spec.ts` — extend the year-grid describe with a legend test
+
+**Interfaces:**
+
+- Consumes: the shared `.deleted` striped CSS from Task 2 (selector already matches `.legend-chip.deleted`).
+- Produces: `#yearGridLegend` element.
+
+- [ ] **Step 1: Add the legend markup**
+
+In `admin-tests.php`, immediately after the `#yearGrid` div, insert:
+
+```php
+                            <div class="d-flex flex-wrap align-items-center column-gap-3 row-gap-1 small text-muted mt-2" id="yearGridLegend">
+                                <span><span class="legend-chip me-1"></span><?php echo htmlspecialchars(_('included'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip bg-light me-1"></span><?php echo htmlspecialchars(_('falls on a Sunday'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip bg-info me-1"></span><?php echo htmlspecialchars(_('pivot year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip bg-warning me-1"></span><?php echo htmlspecialchars(_('event not expected'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                                <span><span class="legend-chip deleted me-1"></span><?php echo htmlspecialchars(_('excluded — click to restore'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                            </div>
+```
+
+- [ ] **Step 2: Add the chip sizing CSS**
+
+Append to `assets/css/admin-tests.css` (AFTER the shared `.deleted` rule from Task 2, so the size override wins):
+
+```css
+/* Legend chips reuse the exact grid classes so legend and grid cannot drift. */
+.legend-chip {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.25rem;
+  vertical-align: text-bottom;
+}
+
+.legend-chip.deleted {
+  width: 5px;
+  height: 1.25rem;
+  border: none;
+}
+```
+
+- [ ] **Step 3: Add the failing e2e assertion**
+
+Inside the `test.describe('admin-tests year grid (stubbed)', …)` block from Task 2, add:
+
+```typescript
+test("legend row is visible with all five chips", async ({ page }) => {
+  await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+  await page.goto("/admin-tests.php");
+  await page.locator("#createTestBtn").click();
+  const legend = page.locator("#yearGridLegend");
+  await expect(legend).toBeVisible();
+  await expect(legend.locator(".legend-chip")).toHaveCount(5);
+  await expect(legend.locator(".legend-chip.deleted")).toHaveCount(1);
+});
+```
+
+- [ ] **Step 4: Run the e2e tests**
+
+Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g "year grid"`
+Expected: both tests PASS. (If the container serves a stale `admin-tests.php`, remember the bind-mount is per-file and live — but a rebuilt container is only needed if the file
+was newly created; here it exists, edits propagate.)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+php -l admin-tests.php
+composer lint
+git add admin-tests.php assets/css/admin-tests.css e2e/admin-tests.spec.ts
+git commit -m "feat(admin-tests): color legend chip row under the year grid"
+```
+
+---
+
+### Task 5: Full validation sweep
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Run every quality gate**
+
+```bash
+yarn test:unit
+yarn lint
+yarn typecheck
+composer parallel-lint
+composer lint
+composer analyse
+yarn playwright test e2e/admin-tests.spec.ts --project=chromium
+```
+
+Expected: everything green (35 unit tests; all stubbed e2e specs).
+
+- [ ] **Step 2: Manual smoke in the running docker stack**
+
+Open `http://localhost:3000/admin-tests.php` (logged in as an admin), create-test flow: pick the Since type → hammer a year → confirm blue pivot + amber pre-pivot years and cards
+flip to "should not exist"; ⓧ a year → striped bar + card gone; click the bar → both return; legend visible. Confirm a PATCH round-trip on an existing test preserves `excludes`
+(Network tab).
+
+- [ ] **Step 3: Report completion**
+
+Do NOT push — summarize the commits and wait for an explicit push request (the push updates PR #379 and triggers CodeRabbit).

--- a/docs/superpowers/plans/2026-07-05-admin-tests-year-grid-utilities.md
+++ b/docs/superpowers/plans/2026-07-05-admin-tests-year-grid-utilities.md
@@ -364,13 +364,14 @@ function renderYearGrid() {
 
 Background precedence (pivot > not-exists > Sunday) matches the old UI, where pivot/warning classes replaced `bg-light`.
 
-- [ ] **Step 4: Add the failing e2e test**
+- [ ] **Step 4: Add the rendering e2e test**
 
-Append to `e2e/admin-tests.spec.ts` (reuses the existing `stubEditor` helper and `grcEvents` fixture — StIgnatiusOfLoyola, July 31; note 2005-07-31 IS a Sunday):
+Append to `e2e/admin-tests.spec.ts` (reuses the existing `stubEditor` helper and `grcEvents` fixture — StIgnatiusOfLoyola, July 31; note 2005-07-31 IS a Sunday). This test covers
+ONLY rendering; the exclude/restore interaction test is added in Task 3, where the click handler exists — every commit stays green.
 
 ```typescript
 test.describe("admin-tests year grid (stubbed)", () => {
-  test("spans carry icons, Sunday highlighting, and exclude/restore round-trips", async ({
+  test("spans carry hammer/x icons and Sunday highlighting", async ({
     page,
   }) => {
     await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
@@ -386,30 +387,18 @@ test.describe("admin-tests year grid (stubbed)", () => {
     await expect(span2005.locator(".hammerYear")).toHaveCount(1);
     await expect(span2005.locator(".removeYear")).toHaveCount(1);
     await expect(span2005).toHaveClass(/bg-light/);
-
-    // exclude: card disappears, span collapses to the striped bar
-    await span2005.locator(".removeYear").click();
-    await expect(span2005).toHaveClass(/deleted/);
-    await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
-      0,
-    );
-
-    // restore: card returns, stripes gone
-    await span2005.click();
-    await expect(span2005).not.toHaveClass(/deleted/);
-    await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
-      1,
-    );
+    // exactCorrespondence type → hammer absent
+    await page.locator("#tt-exact").check({ force: true });
+    await expect(span2005.locator(".hammerYear")).toHaveCount(0);
+    await expect(span2005.locator(".removeYear")).toHaveCount(1);
   });
 });
 ```
 
-- [ ] **Step 5: Run the e2e test to verify current failure mode**
+- [ ] **Step 5: Run the e2e test to verify it passes**
 
 Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g "year grid"`
-Expected: FAIL — `.hammerYear` count is 0 (icons not rendered yet by the running container if not yet synced, or exclusion does nothing because Task 3's handler is not written).
-Rendering assertions (icons, `bg-light`) should PASS after this task; the exclude/restore section FAILS until Task 3. That is the expected intermediate state — do not try to make
-the whole test pass in this task.
+Expected: PASS (rendering only — no interaction is exercised yet).
 
 - [ ] **Step 6: Syntax-check, lint, commit**
 
@@ -516,10 +505,44 @@ builder.generate({
 });
 ```
 
-- [ ] **Step 3: Run the Task 2 e2e test to verify it now fully passes**
+- [ ] **Step 3: Add the failing exclude/restore e2e test**
+
+Inside the `test.describe("admin-tests year grid (stubbed)", …)` block added in Task 2, add:
+
+```typescript
+  test("exclude collapses to the striped bar and restore brings the card back", async ({
+    page,
+  }) => {
+    await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+    await page.goto("/admin-tests.php");
+    await page.locator("#createTestBtn").click();
+    await page.locator("#tt-variable").check({ force: true });
+    await page.locator("#testEventKey").fill("StIgnatiusOfLoyola");
+    await page.locator("#testEventKey").dispatchEvent("change");
+
+    const span2005 = page.locator("#yearGrid .testYearSpan.year-2005");
+    await expect(span2005).toBeVisible();
+
+    // exclude: card disappears, span collapses to the striped bar
+    await span2005.locator(".removeYear").click();
+    await expect(span2005).toHaveClass(/deleted/);
+    await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
+      0,
+    );
+
+    // restore: card returns, stripes gone
+    await span2005.click();
+    await expect(span2005).not.toHaveClass(/deleted/);
+    await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
+      1,
+    );
+  });
+```
 
 Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g "year grid"`
-Expected: PASS (icons + Sunday class from Task 2, exclude/restore now wired).
+Expected: the new test FAILS before Steps 1-2 are applied (no click handler → span never gains `deleted`); after applying Steps 1-2 it PASSES. If you already applied Steps 1-2,
+verify the failure by `git stash`-ing the `admin-tests.js` change, running, then `git stash pop`.
+Final state: both year-grid tests PASS.
 
 - [ ] **Step 4: Run the full stubbed e2e file (regression: pivot flow, editor, delete)**
 

--- a/docs/superpowers/specs/2026-06-29-admin-tests-page-design.md
+++ b/docs/superpowers/specs/2026-06-29-admin-tests-page-design.md
@@ -1,0 +1,241 @@
+# Admin Tests Page — Design
+
+**Date:** 2026-06-29
+**Status:** Draft (awaiting review)
+**Repos touched:** `LiturgicalCalendarFrontend` (primary), `LiturgicalCalendarAPI`, `UnitTestInterface`
+
+## Summary
+
+Add an `admin-tests` page to the administration area of `LiturgicalCalendarFrontend` so that
+holders of the `test_editor` role can **create, edit, delete, and view liturgical test
+definitions** directly from the website, without leaving it for the standalone UnitTestInterface
+site. The editing UI currently living in `UnitTestInterface/admin.php` is retired; that site keeps
+only the live test **runner**.
+
+### Goals
+
+- Full CRUD over test definitions from the main admin area, reusing the existing `/tests` API.
+- Permissions reflected exactly in the UI (which tests a user may edit / delete), backed by the
+  server's calendar-scoped authorization.
+- Single source of truth for test-definition editing.
+
+### Non-goals
+
+- Porting the live test **runner** (WebSocket / `Health` backend). It stays in UnitTestInterface
+  for now. (Revisit separately.)
+- Building a generalized admin-page factory. Tracked as separate future work (see below).
+
+## Background — current state
+
+- **API already supports test CRUD.** `GET/POST/PUT /tests` and `GET/PATCH/DELETE /tests/{testId}`
+  (`Router.php:486–513`, `TestsHandler.php:334–393`), validated against
+  `jsondata/schemas/LitCalTest.json`. Test files live in `jsondata/tests/{Name}.json`.
+- **Authorization is already calendar-scoped.** Writes require the Zitadel `test_editor` role
+  (`AuthorizationMiddleware::forTestEditor`, `Router.php:699`) **and** an OpenFGA relation on the
+  test's scope object (`OpenFgaAuthorizationMiddleware::forTestScopes` + `TestScopeResolver`,
+  `Router.php:704`): `PUT/PATCH → editor`, `DELETE → admin`. Global admins bypass the FGA checks.
+  Scope is derived from the test's `applies_to` (`TestScopeResolver`): diocesan →
+  `diocesan_calendar_test:<id>`, national → `national_calendar_test:<id>`, otherwise
+  `general_roman_calendar_test:general_roman_calendar`.
+- **An editor already exists** in `UnitTestInterface/admin.php` + `assets/js/admin.js`
+  (`AccuracyTestDefinition`, save via `PUT /tests` create / `PATCH /tests/{name}` update) +
+  `assets/js/AssertionsBuilder.js` (the per-year assertion grid). No DELETE in that UI today.
+- **Frontend admin conventions.** The closest analog to a form-CRUD admin page is the *bespoke*
+  `admin-permissions.js` (create via `POST`, delete via `DELETE`, dynamic `CalendarSelect`-by-type
+  fields, scope gating via an `isGlobalAdmin` config flag + the resource-admin distinction). The
+  `createAdminModule` factory (`admin-module-base.js`) is **status-workflow-specific**
+  (pending/approved/rejected/revoked, approve/reject actions) and is **not** suitable here. No
+  existing page implements a true entity EDIT (PATCH) yet — this page introduces the first.
+- There are **no** `admin-decrees/missals/calendars.php` form-CRUD pages today; what exists is
+  `missals-editor.php` (inline table) and `decrees.php` (read-only). They are incomplete/piecemeal.
+
+## Decisions
+
+1. **Scope:** CRUD of test *definitions* only; the runner stays in UnitTestInterface.
+2. **Permission UX:** Hybrid — list/view all tests for any authenticated user; gate edit/delete
+   buttons per-row using the caller's exact scopes; API is the hard backstop.
+3. **Old editor:** Retire the editing UI in `UnitTestInterface/admin.php` (single source of truth).
+4. **Build approach:** A dedicated `admin-tests` module modeled on `admin-permissions.js` (NOT the
+   status-workflow factory), with a clean internal seam between generic CRUD plumbing and
+   test-specific logic so it can later seed a shared factory cheaply.
+5. **Exact gating:** Add a sibling API endpoint `GET /auth/test-scopes` exposing the caller's
+   `editor` and `admin` scopes for the `*_test` object types, so the UI gates precisely for every
+   user (including scoped editors who are not admins).
+
+## Architecture
+
+### A. API — `GET /auth/test-scopes` (LiturgicalCalendarAPI)
+
+A new read-only, authenticated endpoint returning the caller's own test scopes. Chosen as a
+**sibling** to `/auth/admin-scopes` rather than extending it, so the applications/permissions admin
+pages (which call `/auth/admin-scopes`) don't incur the extra OpenFGA `listObjects` calls.
+
+- **Handler:** `src/Handlers/Auth/TestScopesHandler.php` (mirrors `AdminScopesHandler`: derive
+  `is_global_admin` from the Zitadel `admin` role; compute scopes via `ResourceAdminService`;
+  fail closed to empty arrays when the FGA client is unavailable).
+- **Service:** extend `ResourceAdminService` with
+  `resolveTestScopes(string $sub): array{editor: list<Scope>, admin: list<Scope>}`, looping the
+  three test object types `['national_calendar_test','diocesan_calendar_test',
+  'general_roman_calendar_test']` and calling the existing
+  `OpenFgaClient::listObjects($fgaUser, 'editor'|'admin', $type)` (`OpenFgaClient.php:299–328`).
+  `editor` ⊇ `admin` because the model defines `editor = this ∪ computedUserset(admin)`.
+- **Route:** add `GET /auth/test-scopes` behind the same JWT/OIDC auth middleware as
+  `/auth/admin-scopes` (authenticated; returns the caller's scopes only — no elevation).
+- **Response:**
+
+  ```json
+  {
+    "is_global_admin": false,
+    "editor": [{ "object_type": "national_calendar_test", "object_id": "USA" }],
+    "admin":  [{ "object_type": "diocesan_calendar_test", "object_id": "..." }]
+  }
+  ```
+
+- **Grounding:** test scopes are **independent** of calendar scopes in the current OpenFGA model
+  (`scripts/openfga-model.json` test types use only `this` + same-type `computedUserset`; no
+  `tupleToUserset` back to calendar objects). See Future work for possible pooling.
+
+### B. Frontend — `admin-tests` page (LiturgicalCalendarFrontend)
+
+- **`admin-tests.php`** — follows the admin-page convention: auth gate
+  (`$authHelper->isAuthenticated` + a test-editor/admin/resource-admin check → redirect otherwise);
+  renders an `AdminTestsConfig` JSON blob (`apiUrl`, `i18n`, and the page reads scopes at runtime
+  from `/auth/test-scopes`); `head.php`/`header.php`/`footer.php` includes; markup for the list
+  container and two modals — `#testEditorModal` (create/edit form) and `#deleteTestModal`
+  (confirm). A nav entry is added to the admin dashboard/header.
+- **`assets/js/admin-tests.js`** — bespoke module (initialized on `DOMContentLoaded`), importing
+  `ApiClient` / `CalendarSelect` / `CalendarSelectFilter` like `admin-permissions.js`. Internally
+  organized as:
+  - **Generic seam** (extraction candidates for the future factory): `fetchJson(method, path,
+    body)`, `renderTable(rows, columns)`, `showModalAlert(...)`, `gateByScope(...)`,
+    auth/scope bootstrap (`/auth/me` + `/auth/test-scopes`).
+  - **Test-specific:** scope grouping for the list, the editor form, and `AssertionsBuilder` glue.
+- **`assets/js/AssertionsBuilder.js`** — ported from UnitTestInterface with a tight interface:
+  `load(testDefinition)` to populate, `serialize()` to produce the assertions array. The per-year
+  assertion grid keyed by `test_type` (exact/variable correspondence) is preserved.
+- **List:** `GET /tests` → rows grouped by derived scope (General Roman / `national:<id>` /
+  `diocesan:<id>`), columns: name, event_key, description, scope, test_type, year range, actions.
+  A client-side name/scope filter keeps the list usable as it grows.
+- **Editor form fields:** `name`, `event_key` (datalist sourced from `GET /events`), `description`,
+  `test_type`, **scope** (`applies_to`) via the dynamic `CalendarSelect`-by-type approach from
+  `admin-permissions.js`, `year_since`/`year_until`, and the assertions grid. Create uses
+  `PUT /tests`; edit uses `PATCH /tests/{name}`.
+- **Delete:** `#deleteTestModal` → `DELETE /tests/{name}`.
+- All requests: `credentials: 'include'`, `Accept`/`Content-Type: application/json`.
+
+#### Editor UX (port the UnitTestInterface editor, modernized)
+
+The editor reproduces the existing UnitTestInterface editing experience so editors keep a familiar
+workflow, presented as a stepped modal:
+
+1. **Test type** — four choices with their existing FontAwesome icons: Exact date (`fa-vial`,
+   `exactCorrespondence`), Exact date since year (`fa-right-from-bracket`,
+   `exactCorrespondenceSince`), Exact date until year (`fa-right-to-bracket`,
+   `exactCorrespondenceUntil`), Variable existence by year (`fa-square-root-variable`,
+   `variableCorrespondence`). The choice drives the rest of the form.
+2. **Liturgical event** — an `<input list>` datalist populated from `GET /events` for the selected
+   calendar/locale; options carry `data-month`/`data-day`/`data-grade`. Selecting an event
+   auto-fills the description and feeds the base date + Sunday highlighting.
+3. **Year range** — the dual-range slider ported as-is from UnitTestInterface
+   (`assets/css/multi-range-slider.css`), bounded 1970–2050, feeding `year_since`/`year_until` (for
+   the *Since*/*Until* types) and the set of years to assert on.
+4. **Base date** — `<input type=date>` pre-filled from the event's fixed `month`/`day` (or Jan 1 of
+   the first year); expands to per-year `expected_value` (RFC 3339,
+   `YYYY-MM-DDT00:00:00+00:00`).
+5. **Per-year assertion cards** — one card per year, each with: the year; the calendar scope; an
+   **assertion-type toggle** between `eventExists AND hasExpectedDate` (green) and `eventNotExists`
+   (amber) via `fa-repeat`; an editable **expected date** (`fa-pen-to-square`, hidden when
+   `eventNotExists`); an editable **assertion sentence**; and an optional **comment**
+   (`fa-comment-medical` / `fa-comment-dots`). Per-type behavior: exact = uniform across years;
+   since/until = years before/after the pivot forced to `eventNotExists`; variable = each year
+   toggled independently. A **year-grid overview** shades Sundays / excluded / pivot years and
+   supports click-to-exclude.
+
+**Modernizations vs. the original (preserve the look, reduce risk):**
+
+- **Drop the Isotope dependency** — the year grid is a plain CSS grid (`fitRows` is native
+  `grid` / `flex-wrap`); same visual, one fewer third-party library.
+- **State-first** — one in-memory test model is the source of truth; the UI renders from it and
+  `AssertionsBuilder.serialize()` reads the model (not the DOM, as the original does), matching the
+  `load()` / `serialize()` interface. The assertion sentence uses a `<textarea>` rather than
+  `contenteditable` for accessibility.
+
+Reuses Bootstrap 5 + FontAwesome (already present in the frontend).
+
+### C. UnitTestInterface — retire the editor
+
+- Remove the test-definition editing UI: `admin.php` editing surfaces and the create/edit/save
+  paths in `assets/js/admin.js`; the `AssertionsBuilder.js` there is superseded by the ported copy
+  in the frontend. Keep the live runner (`index.php`/`resources.php` + WebSocket backend) intact.
+- Replace the old admin entry point with a short notice/redirect pointing editors to the admin
+  area page, so existing bookmarks aren't dead ends.
+- The `test_editor` role and `/tests` API are unchanged, so the runner is unaffected.
+
+## Permission model & UX
+
+- **Page access** requires the `test_editor` role or admin/resource-admin — it is an admin page.
+  Reads are not scope-filtered, so anyone who can reach the page sees **all** tests; the per-row
+  gating below governs what they may change.
+- **Bootstrap on load:** `GET /auth/me` (for the `test_editor` role) + `GET /auth/test-scopes`
+  (`is_global_admin`, `editor[]`, `admin[]`).
+- **Per-row gating:** derive each test's scope object from its `applies_to`; show **Edit** when
+  `is_global_admin` or the object is in `editor[]`; show **Delete** when `is_global_admin` or the
+  object is in `admin[]`.
+- **Create:** enabled when the user has the `test_editor` role (or is global admin). The scope
+  picker is constrained to scopes the user may edit (`editor[]`), except global admins who may pick
+  any scope.
+- **Backstop:** the API enforces role + scope regardless; any `403` is surfaced in the modal.
+
+## Error handling
+
+- Client-side: required-field validation before submit; disable the submit button during the
+  request; validate assertion rows (year present, expected_value shape) before serialize.
+- API responses surfaced in the modal alert area: `400/422` (schema/validation — show the message),
+  `401` (open the login modal), `403` (scope/role denied — explain), `404`, `409` (name conflict on
+  create). On success, close the modal and reload the list.
+
+## Testing
+
+- **Frontend (Playwright, the repo's e2e stack):** load the page; list renders grouped by scope;
+  create → appears; edit → persists; delete → removed; scope-gating hides Edit/Delete for
+  out-of-scope rows (drive via a stubbed `/auth/test-scopes` / `/auth/me`). Gate behind the e2e
+  path filters already used for `package.json`/JS changes.
+- **API:** unit/route tests for `TestScopesHandler` (global admin, scoped editor, scoped admin,
+  unauthenticated, FGA-unavailable → empty). Existing `TestsHandler` write tests already cover the
+  CRUD authorization.
+- **AssertionsBuilder:** unit test for `serialize()`/`load()` round-trip if a JS unit runner is
+  available; otherwise covered via the Playwright editor flow.
+
+## Rollout / sequencing
+
+1. API: add `GET /auth/test-scopes` (+ `ResourceAdminService::resolveTestScopes`) and tests; deploy.
+2. Frontend: build `admin-tests` page + ported `AssertionsBuilder`; e2e; ship behind the admin nav.
+3. UnitTestInterface: retire the editor, leave a redirect/notice to the admin page.
+
+## Future work
+
+- **Coordinated admin-page form-CRUD factory.** decrees/missals/calendars admin are piecemeal and
+  incomplete; `admin-tests` is built with a clean generic/specific seam so it can serve as a clean
+  reference example. A unified factory (covering form-CRUD *and* the existing status-workflow
+  pattern) is a separate initiative with its own spec, studying all real pages — not designed from
+  this one example.
+- **Pooling calendar-editor and test-editor scopes.** Test-editor scopes are independent of
+  calendar scopes today, which is why `/auth/test-scopes` is a dedicated sibling endpoint. Over
+  time, calendar-editor and test-editor scopes may be pooled — possibly absorbing test-editor
+  scopes into calendar-editor scopes. If that happens, the endpoint/semantics (and the FGA model)
+  would be revisited. To be discussed in a GitHub Discussion on the API repo.
+
+## Open items / risks
+
+- Confirm during implementation whether the global `admin` role satisfies
+  `AuthorizationMiddleware::forTestEditor` (i.e., whether a global admin without the explicit
+  `test_editor` role may write). The client gates on `is_global_admin || has test_editor role`; the
+  API is authoritative either way.
+- `event_key` datalist depends on `GET /events` returning the event catalog for the chosen scope;
+  confirm the shape/locale handling when wiring the field.
+- Renaming a test is not an in-place edit — `name` is the resource key for `PATCH/DELETE
+  /tests/{name}`, so a rename is delete + recreate. The editor must render `name` read-only when
+  editing an existing test.
+- (Resolved) Year-range control: port the original custom dual-range slider
+  (`multi-range-slider.css`) as-is to preserve the familiar feel — carried over verbatim alongside
+  the ported assertion editor.

--- a/docs/superpowers/specs/2026-06-29-admin-tests-page-design.md
+++ b/docs/superpowers/specs/2026-06-29-admin-tests-page-design.md
@@ -114,7 +114,8 @@ pages (which call `/auth/admin-scopes`) don't incur the extra OpenFGA `listObjec
   `load(testDefinition)` to populate, `serialize()` to produce the assertions array. The per-year
   assertion grid keyed by `test_type` (exact/variable correspondence) is preserved.
 - **List:** `GET /tests` → rows grouped by derived scope (General Roman / `national:<id>` /
-  `diocesan:<id>`), columns: name, event_key, description, scope, test_type, year range, actions.
+  `diocesan:<id>`), columns: name, event_key, scope, test_type, year range, actions (the
+  description is shown in the editor rather than as a table column, keeping rows scannable).
   A client-side name/scope filter keeps the list usable as it grows.
 - **Editor form fields:** `name`, `event_key` (datalist sourced from `GET /events`), `description`,
   `test_type`, **scope** (`applies_to`) via the dynamic `CalendarSelect`-by-type approach from
@@ -148,8 +149,10 @@ workflow, presented as a stepped modal:
    `eventNotExists`); an editable **assertion sentence**; and an optional **comment**
    (`fa-comment-medical` / `fa-comment-dots`). Per-type behavior: exact = uniform across years;
    since/until = years before/after the pivot forced to `eventNotExists`; variable = each year
-   toggled independently. A **year-grid overview** shades Sundays / excluded / pivot years and
-   supports click-to-exclude.
+   toggled independently. A **year-grid overview** shades the pivot year and the years it forces
+   to `eventNotExists`; for the *Since*/*Until* types, clicking a year sets the pivot.
+   (Click-to-exclude — editing the `excludes` list from the grid — is deferred to a follow-up;
+   the model and `generate()` already accept `excludedYears`.)
 
 **Modernizations vs. the original (preserve the look, reduce risk):**
 

--- a/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
+++ b/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
@@ -197,3 +197,26 @@ UnitTestInterface shows June 24). The base date's lifecycle is now defined expli
   month/day, or leaves it empty for movable feasts (the user sets it manually).
 - **Precedence:** on edit, the loaded assertions' dates are authoritative over the event
   catalog's month/day (definitions may deliberately differ, and the catalog fetch is async).
+
+### R3.1 Correction (2026-07-06): base date derives from the CATALOG, not the assertions
+
+R3's "first dated assertion" rule was wrong in intent. The base date's purpose (user-clarified) is
+a **Sunday-coincidence assist on the canonical date** — "in which of these years does the event's
+canonical date fall on a Sunday" — plus a pre-fill helper for the assertion cards. The assertions
+hold _resolved_ dates (possibly transferred, e.g. NativityJohnBaptistTest asserts June 23 in
+anticipation years), so deriving the base from them inverts input and output. The old UI reads the
+event catalog's `data-month`/`data-day` (June 24) for exactly this reason.
+
+Rule:
+
+- **Edit path:** once the events fetch resolves, `#baseDate` = `minAssertedYear-MM-DD` from the
+  catalog entry for the test's `event_key`. Fallback when the event is absent from the catalog or
+  has no fixed date: the **mode** (most frequent month/day) of the dated assertions,
+  earliest-year tiebreak — strictly better than the old UI's `-01-01` fallback. Empty only when
+  neither source yields a date. `builder.baseMonthDay` is set to the same value **without**
+  firing the field's change handler (which would rewrite every assertion's date).
+- **Model:** `load()`'s internal fallback derivation upgrades from "first dated assertion" to the
+  same mode rule.
+- The field **remains editable** as the escape hatch for custom pre-fill dates (and for
+  all-transfer tests, where restoring toggled years at the transferred date requires setting it
+  manually — old-UI-equivalent behavior, now documented).

--- a/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
+++ b/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
@@ -243,3 +243,13 @@ follows the model, so re-saving a grouped legacy definition normalizes it — an
 - **Legend spacing:** the legend used `column-gap-3 row-gap-1`, which do not exist in the
   Bootstrap 5.2.x bundled by startbootstrap-sb-admin@7.0.7 (they arrived in 5.3) — the chips
   rendered clumped. Replaced with `gap-3`, which the bundle provides for flex containers.
+
+## Revision 6 (2026-07-06) — pivot hammer revealed on hover
+
+The hammer's action is per-year ("make this year the pivot") but the state it sets is exclusive —
+one pivot per test — so rendering a permanent hammer on every span implies thirty independent
+states. The pivot hammer (`fa-hammer`, Since/Until only) is now invisible (`opacity: 0`) until the
+year span is hovered (`0.5`, then `1` on the icon itself). The variable-type `fa-repeat` icon
+stays always visible: toggling IS per-year state, matching the always-visible card toggle. Opacity
+(not `display`) preserves span geometry (no grid reflow on hover) and keeps the icon a functional
+tap target on touch devices; `!important` is required to beat Bootstrap's `opacity-50` utility.

--- a/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
+++ b/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
@@ -130,3 +130,50 @@ year are no-ops.
 - Any API/schema change (none needed).
 - Isotope-style animated grid relayout (the old fade/relayout was an Isotope artifact; phase 2
   uses native CSS grid).
+
+## Revision 2 (2026-07-06) — field-test findings
+
+Manual smoke testing against real test definitions surfaced three changes (user-approved):
+
+### R2.1 Year exclusion is implicit — assertion absence is the source of truth
+
+Source test definitions encode year exclusion **implicitly**: e.g. `NativityJohnBaptistTest.json`
+(exactCorrespondence) asserts only 2022/2033/2044 — every other year in the span is excluded by
+omission. No definition in the corpus has an `excludes` field, the old UnitTestInterface never
+emitted one, and — decisively — the schema types `excludes` as `AppliesToOrExcludes` (the same
+shape as `applies_to`): it is **calendar-scope** exclusion metadata, not a year list. The original
+Task 1 design misused `model.excludes` as a year list, which `serialize()` would have emitted as a
+schema-invalid PATCH body (stubbed e2e never hit real validation).
+
+Fix — assertion absence becomes the single source of truth for year exclusion:
+
+- `excludeYear(y)`: removes the year's assertion; never touches `model.excludes`.
+- `includeYear(y)`: creates the assertion (pivot- and `baseMonthDay`-aware, `generate()` rules)
+  for any year lacking one; no `excludes` bookkeeping.
+- `renderYearGrid()`: a year renders striped iff it has no assertion.
+- `regenerate()`: derives `excludedYears` as the gaps inside the asserted span
+  (`[min(assertedYears), max(assertedYears)]` minus asserted years; empty when there are no
+  assertions yet, so the create flow is unaffected) — exclusions survive event/type/slider changes,
+  and slider-widening still auto-includes the newly visible years.
+- `model.excludes` reverts to schema semantics (calendar scope): loaded and serialized verbatim,
+  never mutated by year interactions.
+- Task 1's unit tests are rewritten to these semantics.
+
+This also fixes the reported "x only works in Since type": `excludeYear` guarded on assertion
+presence, so on sparse loaded tests the gap years' controls silently no-opped — not a type
+dependency.
+
+### R2.2 Sunday hint: additive cross overlay replaces bg-light
+
+`bg-light` sat at the bottom of a mutually-exclusive precedence (pivot > not-exists > Sunday), so
+the hint vanished exactly where most informative, and was nearly invisible anyway. Replaced by an
+**additive overlay**: spans (and the legend chip) get a `sunday` class whose `background-image`
+draws a centered upright cross (two linear-gradient bars) in semi-transparent liturgical red
+(`rgba(220, 53, 69, 0.30)`). Because `background-image` layers over `background-color`, the cross
+composes with beige/`bg-info`/`bg-warning` instead of competing. The background-color precedence
+reduces to pivot > not-exists. Tooltip unchanged. Excluded (striped) years carry no Sunday overlay.
+
+### R2.3 Legend
+
+The Sunday legend chip now demonstrates the cross overlay (`legend-chip sunday`) instead of
+`bg-light`; label unchanged.

--- a/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
+++ b/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
@@ -220,3 +220,14 @@ Rule:
 - The field **remains editable** as the escape hatch for custom pre-fill dates (and for
   all-transfer tests, where restoring toggled years at the transferred date requires setting it
   manually — old-UI-equivalent behavior, now documented).
+
+## Revision 4 (2026-07-06) — assertions normalized to year order at load
+
+Field finding: per-year cards appeared grouped by assert type. Cause: the corpus does not
+guarantee assertion order — e.g. `StJaneFrancesDeChantalTest` stores all `eventExists` assertions
+first, then the `eventNotExists` block — and `load()` preserved definition order (the old UI's
+Isotope layout masked this). Rule: `load()` sorts assertions by year, establishing the model
+invariant _assertions are always year-ordered_ (`generate()` already produces sorted output and
+`includeYear()` maintains it). This also repairs the R3.1 mode-derivation tiebreak, whose
+"earliest seen = earliest year" assumption was false on unsorted input. Serialization order
+follows the model, so re-saving a grouped legacy definition normalizes it — an intended cleanup.

--- a/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
+++ b/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
@@ -1,0 +1,132 @@
+# Admin-Tests Year-Grid Utilities — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (brainstorming session)
+**Lands in:** PR #379 (`feat/admin-tests-phase2`), extending the phase-2 admin-tests page
+**Reference implementation:** `UnitTestInterface/assets/js/admin.js` (`generateYearSpanHtml`,
+`computeYearDateAttrs`, the `fa-circle-xmark` / `fa-hammer` / `.deleted` click handlers) and
+`UnitTestInterface/assets/css/admin.css` (`.testYearSpan.deleted` striped bar)
+
+## Problem
+
+Acceptance testing of the phase-2 test editor against the old UnitTestInterface editor found the
+year-grid overview incomplete:
+
+- no per-year **exclude** affordance (the ⓧ icon that collapses a year to a red/white striped bar,
+  click-to-restore);
+- no **hammer** affordance (pivot/toggle, with behavior that varies by test type);
+- no **Sunday highlighting** (`bg-light` + explanatory tooltip when the event's fixed date falls on
+  a Sunday in that year);
+- no explanation of what the background colors mean (the old UI never had one either — a legend is
+  a new addition).
+
+The model layer needs no schema work: `AssertionsBuilder` already round-trips `excludes`
+(`load()` → `setMeta()` → `serialize()`), `generate({ excludedYears })` skips excluded years, and
+the API's `LitCalTest` schema defines the `excludes` field.
+
+## Approach
+
+**State-first port** (approach A of the brainstorm). The grid remains a pure projection of
+`builder.model`; clicks mutate the model and re-render. The old UI's direct-DOM mutation approach
+was rejected because `serialize()` never reads the DOM in phase 2 — DOM-held exclusion state would
+silently not serialize, the same class of desync CodeRabbit review round 2 eliminated from
+`toggleAssert`.
+
+## Design
+
+### 1. Model layer — `AssertionsBuilder` additions
+
+- `excludeYear(year)` — adds `year` to `model.excludes` (kept sorted, deduped; array created if
+  `null`), removes that year's entry from `model.assertions`. Chainable, no-op for unknown years.
+- `includeYear(year)` — removes `year` from `model.excludes` (field returns to `null` when the
+  array empties), re-creates that year's assertion using the same rules as `generate()`:
+  `eventNotExists` when outside the pivot (`year_since`/`year_until`) or when `baseMonthDay` is
+  null, otherwise the exact-correspondence assertion with `expected_value` computed from
+  `baseMonthDay`. Assertions stay sorted by year. Chainable, no-op if the year is not excluded.
+- **Folded-in bug fix:** `regenerate()` in `admin-tests.js` currently calls `generate()` without
+  `excludedYears`, so any exclusions would be wiped whenever the event, test type, or slider
+  changes. It will pass `excludedYears: builder.model.excludes ?? []`.
+
+### 2. Grid rendering — `renderYearGrid()` extended
+
+Span anatomy: `[🔨?] YEAR [ⓧ]`.
+
+- Hammer (`fa-hammer me-1 opacity-50`, `title="set year"`): omitted for `exactCorrespondence`
+  (nothing to pivot or toggle), present for the other three types.
+- X-mark (`fa-circle-xmark ms-1 opacity-50`, `title="remove"`): always present on included years.
+- Excluded years render as `<span class="testYearSpan year-YYYY deleted">` — no text, no icons.
+  CSS ported to `assets/css/admin-tests.css`: red/white 45° `repeating-linear-gradient`, 3px wide,
+  32px tall, `cursor: not-allowed` (visually identical to the old UI; a `title` attribute such as
+  "2026 excluded — click to restore" is added as an accessibility improvement over the original).
+
+Background classes, all derived from state (never from sibling-sweeping the DOM):
+
+| Class / style        | Meaning                                                 | Derived from                                            |
+| -------------------- | ------------------------------------------------------- | ------------------------------------------------------- |
+| default (beige)      | year included, event asserted on its date               | assertion present, `assert = eventExists…`              |
+| `bg-light` + tooltip | event's fixed month/day falls on a **Sunday** that year | `builder.baseMonthDay` (port of `computeYearDateAttrs`) |
+| `bg-info`            | pivot year                                              | `model.year_since` / `model.year_until`                 |
+| `bg-warning`         | year asserted `eventNotExists`                          | that year's `assertion.assert`                          |
+| red/white stripes    | year excluded from the test                             | `model.excludes`                                        |
+
+`bg-warning` derivation from assertions replaces the old UI's previous/next-sibling class sweep —
+same visual result, single source of truth.
+
+### 3. Interactions — one delegated click handler on `#yearGrid`
+
+Replaces the current whole-span pivot click (ambiguous once spans contain two other targets):
+
+| Click target | Test type     | Action                                  |
+| ------------ | ------------- | --------------------------------------- |
+| 🔨 hammer    | Since / Until | `builder.setPivot(year)` (existing)     |
+| 🔨 hammer    | Variable      | `builder.toggleAssert(year)` (existing) |
+| ⓧ x-mark     | any           | `builder.excludeYear(year)`             |
+| striped bar  | any           | `builder.includeYear(year)`             |
+| span body    | any           | no action                               |
+
+Deliberate improvement over the original: the variable-type hammer is **two-way** (delegates to
+`toggleAssert`, which flips both directions), consistent with the per-card toggle buttons. The old
+UI's hammer only set `bg-warning` one-way.
+
+After every mutation both the grid **and** the assertion cards re-render
+(`builder.render(assertionsContainer)` + `renderYearGrid()`): an excluded year must have no card,
+and a restored year's card must reappear.
+
+### 4. Legend — chip row under the grid
+
+Static HTML in `admin-tests.php`, directly beneath `#yearGrid`; five entries, labels
+gettext-wrapped with `htmlspecialchars` escaping like the rest of the page:
+
+```text
+■ included   □ falls on Sunday   ■ pivot year   ■ event not expected   ┃ excluded (click to restore)
+```
+
+Swatches are small chips (`<span class="legend-chip …">`) that reuse the exact classes the grid
+spans use (`bg-light`, `bg-info`, `bg-warning`, `deleted`) so legend and grid cannot drift apart.
+To make that sharing possible, the ported striped-bar CSS must NOT be ID-scoped the way the
+original was (`#yearsToTestGrid > .testYearSpan.deleted`): `admin-tests.css` styles `.deleted` via
+a selector that matches both grid spans and legend chips (e.g. `.testYearSpan.deleted,
+.legend-chip.deleted`). Chip sizing lives in `admin-tests.css`.
+
+### 5. Error handling
+
+All interactions are pure client-side state changes — nothing network-touching. Guards: clicks
+resolving to a year with no matching assertion/exclusion are no-ops (same convention as
+`toggleAssert`); `excludeYear` on an already-excluded year and `includeYear` on a non-excluded
+year are no-ops.
+
+### 6. Testing
+
+- **Unit (Vitest):** `excludeYear`/`includeYear` round-trip (assertion removed and re-created with
+  pivot- and `baseMonthDay`-aware rules); `serialize()` emits `excludes` and drops the key when
+  empty; `generate()` + `regenerate()` wiring preserves exclusions across event/type/slider
+  changes; `render()`/grid derivation of `bg-warning` from assertions.
+- **E2E (chromium smoke spec):** exclude a year → its assertion card disappears and the span
+  becomes the striped bar → click the bar → card and full span return; legend row is visible.
+
+## Out of scope
+
+- Retiring the old UnitTestInterface editor (phase 3, separate repo).
+- Any API/schema change (none needed).
+- Isotope-style animated grid relayout (the old fade/relayout was an Isotope artifact; phase 2
+  uses native CSS grid).

--- a/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
+++ b/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
@@ -177,3 +177,23 @@ reduces to pivot > not-exists. Tooltip unchanged. Excluded (striped) years carry
 
 The Sunday legend chip now demonstrates the cross overlay (`legend-chip sunday`) instead of
 `bg-light`; label unchanged.
+
+## Revision 3 (2026-07-06) — base date derivation / storage / restoration
+
+Field finding: loading `NativityJohnBaptistTest` left the **Base date** field empty (the old
+UnitTestInterface shows June 24). The base date's lifecycle is now defined explicitly:
+
+- **Stored:** nowhere as a dedicated field. The base date is implicit in the assertions'
+  `expected_value` dates — every exact assertion shares the same month/day with a per-year year.
+- **Derived (model):** `load()` sets `builder.baseMonthDay` to the month/day of the first
+  assertion carrying an `expected_value` (existing `#deriveBaseMonthDay`); `null` when no
+  assertion has a date. `generate()` sets it from the event catalog's fixed `month`/`day`.
+- **Restored (UI):** `openEditor(test)` must populate `#baseDate` with
+  `${minAssertedYear}-MM-DD` from `builder.baseMonthDay` — the year component is presentational
+  only (the field's change handler expands month/day across every asserted year); empty when
+  `baseMonthDay` is `null`. This mirrors UnitTestInterface `admin.js:1070`
+  (`#baseDate.value = firstYear + monthDay`).
+- **Create flow:** unchanged — `regenerate()` seeds `#baseDate` from the selected event's fixed
+  month/day, or leaves it empty for movable feasts (the user sets it manually).
+- **Precedence:** on edit, the loaded assertions' dates are authoritative over the event
+  catalog's month/day (definitions may deliberately differ, and the catalog fetch is async).

--- a/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
+++ b/docs/superpowers/specs/2026-07-05-admin-tests-year-grid-utilities-design.md
@@ -231,3 +231,15 @@ invariant _assertions are always year-ordered_ (`generate()` already produces so
 `includeYear()` maintains it). This also repairs the R3.1 mode-derivation tiebreak, whose
 "earliest seen = earliest year" assumption was false on unsorted input. Serialization order
 follows the model, so re-saving a grouped legacy definition normalizes it — an intended cleanup.
+
+## Revision 5 (2026-07-06) — icon semantics per test type; legend spacing
+
+- **Grid action icon by test type:** the hammer's meaning is _set the pivot year_ — it only
+  applies to `exactCorrespondenceSince`/`Until`. For `variableCorrespondence` the action is
+  _toggle the assertion_, which the per-year cards already express with `fa-repeat` — the grid
+  now uses `fa-repeat` there too (new i18n title `toggleAssertion`), deviating deliberately from
+  the old UI (hammer everywhere) to preserve semantic consistency. The behavioral hook class
+  (`hammerYear`) and the click handler are unchanged — only the visual icon and title vary.
+- **Legend spacing:** the legend used `column-gap-3 row-gap-1`, which do not exist in the
+  Bootstrap 5.2.x bundled by startbootstrap-sb-admin@7.0.7 (they arrived in 5.3) — the chips
+  rendered clumped. Replaced with `gap-3`, which the bundle provides for flex containers.

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -121,3 +121,27 @@ test.describe('admin-tests delete (stubbed)', () => {
         await expect.poll(() => deleted).toBe(true);
     });
 });
+
+test.describe('admin-tests year grid (stubbed)', () => {
+    test('spans carry hammer/x icons and Sunday highlighting', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        // btn-check inputs use pointer-events:none; click the label, not the input
+        await page.locator('label[for="tt-variable"]').click();
+        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('change');
+
+        const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
+        await expect(span2005).toBeVisible();
+        // variable type → hammer present; x always present; 2005-07-31 is a Sunday
+        await expect(span2005.locator('.hammerYear')).toHaveCount(1);
+        await expect(span2005.locator('.removeYear')).toHaveCount(1);
+        await expect(span2005).toHaveClass(/bg-light/);
+        // exactCorrespondence type → hammer absent
+        await page.locator('label[for="tt-exact"]').click();
+        await expect(span2005.locator('.hammerYear')).toHaveCount(0);
+        await expect(span2005.locator('.removeYear')).toHaveCount(1);
+    });
+});

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+// Uses the shared authenticated storage state (e2e/.auth/user.json) from the
+// chromium project; that user is an admin in the dev environment.
+test.describe('admin-tests page', () => {
+    test('renders the page shell with list and modals', async ({ page }) => {
+        await page.goto('/admin-tests.php');
+        await expect(page.locator('#testsTableBody')).toBeVisible();
+        await expect(page.locator('#createTestBtn')).toBeVisible();
+        await expect(page.locator('#testEditorModal')).toHaveCount(1);
+        await expect(page.locator('#deleteTestModal')).toHaveCount(1);
+    });
+});

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page, type Route } from '@playwright/test';
 
 // Uses the shared authenticated storage state (e2e/.auth/user.json) from the
 // chromium project; that user is an admin in the dev environment.
@@ -9,5 +9,42 @@ test.describe('admin-tests page', () => {
         await expect(page.locator('#createTestBtn')).toBeVisible();
         await expect(page.locator('#testEditorModal')).toHaveCount(1);
         await expect(page.locator('#deleteTestModal')).toHaveCount(1);
+    });
+});
+
+const sampleTests = {
+    litcal_tests: [
+        { name: 'GrcOnlyTest', event_key: 'StX', description: 'd', test_type: 'exactCorrespondence', assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }] },
+        { name: 'UsaNationalTest', event_key: 'StY', description: 'd', test_type: 'exactCorrespondence', applies_to: { national_calendar: 'USA' }, assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }] },
+    ],
+};
+
+type TestScopes = { is_global_admin: boolean; editor: { object_type: string; object_id: string }[]; admin: { object_type: string; object_id: string }[] };
+
+async function stub(page: Page, scopes: TestScopes): Promise<void> {
+    await page.route('**/auth/test-scopes', (r: Route) => r.fulfill({ json: scopes }));
+    await page.route('**/auth/me', (r: Route) => r.fulfill({ json: { authenticated: true, roles: ['test_editor'] } }));
+    await page.route('**/tests', (r: Route) => {
+        if (r.request().method() === 'GET') return r.fulfill({ json: sampleTests });
+        return r.continue();
+    });
+}
+
+test.describe('admin-tests gating (stubbed)', () => {
+    test('scoped editor sees Edit only on the USA test, no Delete', async ({ page }) => {
+        await stub(page, { is_global_admin: false, editor: [{ object_type: 'national_calendar_test', object_id: 'USA' }], admin: [] });
+        await page.goto('/admin-tests.php');
+        const usaRow = page.locator('tr', { hasText: 'UsaNationalTest' });
+        const grcRow = page.locator('tr', { hasText: 'GrcOnlyTest' });
+        await expect(usaRow.getByRole('button', { name: 'Edit' })).toBeVisible();
+        await expect(usaRow.getByRole('button', { name: 'Delete' })).toHaveCount(0);
+        await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+    });
+
+    test('global admin sees Edit and Delete on every row', async ({ page }) => {
+        await stub(page, { is_global_admin: true, editor: [], admin: [] });
+        await page.goto('/admin-tests.php');
+        await expect(page.getByRole('button', { name: 'Edit' })).toHaveCount(2);
+        await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(2);
     });
 });

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -122,16 +122,25 @@ test.describe('admin-tests delete (stubbed)', () => {
     });
 });
 
+/**
+ * Shared create-modal boilerplate for the year-grid tests: stub routes as a
+ * global admin, open the editor, pick the variable test type, and select an
+ * event so the grid regenerates.
+ */
+async function openVariableEditor(page: Page, eventKey: string): Promise<void> {
+    await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+    await page.goto('/admin-tests.php');
+    await page.locator('#createTestBtn').click();
+    await expect(page.locator('#testEditorModal')).toBeVisible();
+    // btn-check inputs use pointer-events:none; click the label, not the input
+    await page.locator('label[for="tt-variable"]').click();
+    await page.locator('#testEventKey').fill(eventKey);
+    await page.locator('#testEventKey').dispatchEvent('change');
+}
+
 test.describe('admin-tests year grid (stubbed)', () => {
     test('spans carry hammer/x icons and Sunday highlighting', async ({ page }) => {
-        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
-        await page.goto('/admin-tests.php');
-        await page.locator('#createTestBtn').click();
-        await expect(page.locator('#testEditorModal')).toBeVisible();
-        // btn-check inputs use pointer-events:none; click the label, not the input
-        await page.locator('label[for="tt-variable"]').click();
-        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
-        await page.locator('#testEventKey').dispatchEvent('change');
+        await openVariableEditor(page, 'StIgnatiusOfLoyola');
 
         const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
         await expect(span2005).toBeVisible();
@@ -158,14 +167,7 @@ test.describe('admin-tests year grid (stubbed)', () => {
     });
 
     test('exclude collapses to the striped bar and restore brings the card back', async ({ page }) => {
-        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
-        await page.goto('/admin-tests.php');
-        await page.locator('#createTestBtn').click();
-        await expect(page.locator('#testEditorModal')).toBeVisible();
-        // btn-check inputs use pointer-events:none; click the label, not the input
-        await page.locator('label[for="tt-variable"]').click();
-        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
-        await page.locator('#testEventKey').dispatchEvent('change');
+        await openVariableEditor(page, 'StIgnatiusOfLoyola');
 
         const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
         await expect(span2005).toBeVisible();

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -193,6 +193,9 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await page.goto('/admin-tests.php');
         await page.locator('.editTestBtn[data-name="SparseTest"]').click();
         await expect(page.locator('#testEditorModal')).toBeVisible();
+        // base date restored from the loaded assertions (minAssertedYear-MM-DD,
+        // spec R3): first dated assertion is 2022-07-31
+        await expect(page.locator('#baseDate')).toHaveValue('2022-07-31');
         // gap year renders striped, asserted year renders normally
         await expect(page.locator('#yearGrid .testYearSpan.year-2025')).toHaveClass(/deleted/);
         const span2033 = page.locator('#yearGrid .testYearSpan.year-2033');

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -99,3 +99,19 @@ test.describe('admin-tests editor (stubbed)', () => {
         await expect.poll(() => patched).toBe(true);
     });
 });
+
+test.describe('admin-tests delete (stubbed)', () => {
+    test('confirms and fires DELETE', async ({ page }) => {
+        await stub(page, { is_global_admin: true, editor: [], admin: [] });
+        let deleted = false;
+        await page.route('**/tests/GrcOnlyTest', (r) => {
+            if (r.request().method() === 'DELETE') { deleted = true; return r.fulfill({ json: {} }); }
+            return r.continue();
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('tr', { hasText: 'GrcOnlyTest' }).getByRole('button', { name: 'Delete' }).click();
+        await expect(page.locator('#deleteTestModal')).toBeVisible();
+        await page.locator('#confirmDeleteTestBtn').click();
+        await expect.poll(() => deleted).toBe(true);
+    });
+});

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -143,10 +143,14 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCount(0);
         await expect(span2005.locator('.removeYear')).toHaveCount(1);
         await expect(span2005).toHaveClass(/sunday/);
-        // since type → the icon is the pivot hammer (spec R5)
+        // since type → the icon is the pivot hammer (spec R5), hidden until
+        // the span is hovered (spec R6: pivot is an exclusive state)
         await page.locator('label[for="tt-since"]').click();
         await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCount(1);
         await expect(span2005.locator('.hammerYear.fa-repeat')).toHaveCount(0);
+        await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCSS('opacity', '0');
+        await span2005.hover();
+        await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCSS('opacity', '0.5');
         // exactCorrespondence type → no action icon at all
         await page.locator('label[for="tt-exact"]').click();
         await expect(span2005.locator('.hammerYear')).toHaveCount(0);

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -172,4 +172,15 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(span2005).not.toHaveClass(/deleted/);
         await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(1);
     });
+
+    test('legend row is visible with all five chips', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        const legend = page.locator('#yearGridLegend');
+        await expect(legend).toBeVisible();
+        await expect(legend.locator('.legend-chip')).toHaveCount(5);
+        await expect(legend.locator('.legend-chip.deleted')).toHaveCount(1);
+    });
 });

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -49,3 +49,53 @@ test.describe('admin-tests gating (stubbed)', () => {
         await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(2);
     });
 });
+
+const grcEvents = {
+    litcal_events: [
+        { event_key: 'StIgnatiusOfLoyola', name: 'Saint Ignatius of Loyola', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 },
+    ],
+};
+
+async function stubEditor(page: Page, scopes: TestScopes): Promise<void> {
+    await stub(page, scopes);
+    await page.route('**/events**', (r: Route) => r.fulfill({ json: grcEvents }));
+}
+
+test.describe('admin-tests editor (stubbed)', () => {
+    test('create flow submits a PUT with a schema-shaped body', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        let putBody: Record<string, unknown> | null = null;
+        await page.route('**/tests', (r: Route) => {
+            if (r.request().method() === 'PUT') {
+                putBody = r.request().postDataJSON() as Record<string, unknown>;
+                return r.fulfill({ json: { ...putBody } });
+            }
+            return r.fulfill({ json: sampleTests });
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await page.locator('#tt-exact').check({ force: true });
+        await page.locator('#testName').fill('StIgnatiusOfLoyolaTest');
+        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('change');
+        await page.locator('#saveTestBtn').click();
+        await expect.poll(() => putBody && putBody['name']).toBe('StIgnatiusOfLoyolaTest');
+        expect(putBody!['test_type']).toBe('exactCorrespondence');
+        expect((putBody!['assertions'] as unknown[]).length).toBeGreaterThan(0);
+        expect((putBody!['assertions'] as Array<{ assert: string }>)[0].assert).toBe('eventExists AND hasExpectedDate');
+    });
+
+    test('edit flow renders name read-only and submits PATCH', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        let patched = false;
+        await page.route('**/tests/UsaNationalTest', (r: Route) => {
+            if (r.request().method() === 'PATCH') { patched = true; return r.fulfill({ json: {} }); }
+            return r.continue();
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('tr', { hasText: 'UsaNationalTest' }).getByRole('button', { name: 'Edit' }).click();
+        await expect(page.locator('#testName')).toHaveAttribute('readonly', '');
+        await page.locator('#saveTestBtn').click();
+        await expect.poll(() => patched).toBe(true);
+    });
+});

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -39,6 +39,7 @@ test.describe('admin-tests gating (stubbed)', () => {
         await expect(usaRow.getByRole('button', { name: 'Edit' })).toBeVisible();
         await expect(usaRow.getByRole('button', { name: 'Delete' })).toHaveCount(0);
         await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+        await expect(grcRow.getByRole('button', { name: 'Delete' })).toHaveCount(0);
     });
 
     test('global admin sees Edit and Delete on every row', async ({ page }) => {

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -179,8 +179,11 @@ test.describe('admin-tests year grid (stubbed)', () => {
                 name: 'SparseTest', event_key: 'StIgnatiusOfLoyola',
                 description: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
                 test_type: 'exactCorrespondence',
+                // deliberately transferred dates (July 30) that DISAGREE with the
+                // catalog's canonical July 31 — the base date must show the catalog
+                // value (spec R3.1: catalog wins over assertions-mode fallback)
                 assertions: [2022, 2033, 2044].map((year) => ({
-                    year, expected_value: `${year}-07-31T00:00:00+00:00`,
+                    year, expected_value: `${year}-07-30T00:00:00+00:00`,
                     assert: 'eventExists AND hasExpectedDate',
                     assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
                 })),
@@ -193,8 +196,8 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await page.goto('/admin-tests.php');
         await page.locator('.editTestBtn[data-name="SparseTest"]').click();
         await expect(page.locator('#testEditorModal')).toBeVisible();
-        // base date restored from the loaded assertions (minAssertedYear-MM-DD,
-        // spec R3): first dated assertion is 2022-07-31
+        // base date restored as minAssertedYear + the CATALOG's canonical
+        // month/day (spec R3.1) — July 31 wins over the assertions' July 30
         await expect(page.locator('#baseDate')).toHaveValue('2022-07-31');
         // gap year renders striped, asserted year renders normally
         await expect(page.locator('#yearGrid .testYearSpan.year-2025')).toHaveClass(/deleted/);

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -138,7 +138,7 @@ test.describe('admin-tests year grid (stubbed)', () => {
         // variable type → hammer present; x always present; 2005-07-31 is a Sunday
         await expect(span2005.locator('.hammerYear')).toHaveCount(1);
         await expect(span2005.locator('.removeYear')).toHaveCount(1);
-        await expect(span2005).toHaveClass(/bg-light/);
+        await expect(span2005).toHaveClass(/sunday/);
         // exactCorrespondence type → hammer absent
         await page.locator('label[for="tt-exact"]').click();
         await expect(span2005.locator('.hammerYear')).toHaveCount(0);
@@ -173,6 +173,40 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(1);
     });
 
+    test('sparse loaded test renders gap years striped and x works on asserted years', async ({ page }) => {
+        const sparse = {
+            litcal_tests: [{
+                name: 'SparseTest', event_key: 'StIgnatiusOfLoyola',
+                description: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+                test_type: 'exactCorrespondence',
+                assertions: [2022, 2033, 2044].map((year) => ({
+                    year, expected_value: `${year}-07-31T00:00:00+00:00`,
+                    assert: 'eventExists AND hasExpectedDate',
+                    assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+                })),
+            }],
+        };
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        // Register the sparse override AFTER stubEditor so it takes precedence
+        // (Playwright uses last-registered-first-matched for route handlers).
+        await page.route('**/tests', (r) => (r.request().method() === 'GET' ? r.fulfill({ json: sparse }) : r.continue()));
+        await page.goto('/admin-tests.php');
+        await page.locator('.editTestBtn[data-name="SparseTest"]').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        // gap year renders striped, asserted year renders normally
+        await expect(page.locator('#yearGrid .testYearSpan.year-2025')).toHaveClass(/deleted/);
+        const span2033 = page.locator('#yearGrid .testYearSpan.year-2033');
+        await expect(span2033).not.toHaveClass(/deleted/);
+        // x-mark on an asserted year collapses it to the striped bar
+        await span2033.locator('.removeYear').dispatchEvent('click');
+        await expect(span2033).toHaveClass(/deleted/);
+        await expect(page.locator('.assertion-card[data-year="2033"]')).toHaveCount(0);
+        // clicking the striped gap year restores it
+        await page.locator('#yearGrid .testYearSpan.year-2025').dispatchEvent('click');
+        await expect(page.locator('#yearGrid .testYearSpan.year-2025')).not.toHaveClass(/deleted/);
+        await expect(page.locator('.assertion-card[data-year="2025"]')).toHaveCount(1);
+    });
+
     test('legend row is visible with all five chips', async ({ page }) => {
         await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
         await page.goto('/admin-tests.php');
@@ -182,5 +216,6 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(legend).toBeVisible();
         await expect(legend.locator('.legend-chip')).toHaveCount(5);
         await expect(legend.locator('.legend-chip.deleted')).toHaveCount(1);
+        await expect(legend.locator('.legend-chip.sunday')).toHaveCount(1);
     });
 });

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -144,4 +144,32 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(span2005.locator('.hammerYear')).toHaveCount(0);
         await expect(span2005.locator('.removeYear')).toHaveCount(1);
     });
+
+    test('exclude collapses to the striped bar and restore brings the card back', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        // btn-check inputs use pointer-events:none; click the label, not the input
+        await page.locator('label[for="tt-variable"]').click();
+        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('change');
+
+        const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
+        await expect(span2005).toBeVisible();
+
+        // exclude: card disappears, span collapses to the striped bar
+        // dispatchEvent is used because Playwright's physical click on <i> inside a
+        // scrollable modal does not synthesize a click event (mousedown+mouseup fire
+        // but the browser cancels click due to scroll-container interaction).
+        await span2005.locator('.removeYear').dispatchEvent('click');
+        await expect(span2005).toHaveClass(/deleted/);
+        await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(0);
+
+        // restore: deleted span collapses to 3px width — dispatchEvent is more
+        // reliable than a physical click on such a small hit area inside a modal.
+        await span2005.dispatchEvent('click');
+        await expect(span2005).not.toHaveClass(/deleted/);
+        await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(1);
+    });
 });

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -88,8 +88,13 @@ test.describe('admin-tests editor (stubbed)', () => {
     test('edit flow renders name read-only and submits PATCH', async ({ page }) => {
         await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
         let patched = false;
+        let patchBody: Record<string, unknown> | null = null;
         await page.route('**/tests/UsaNationalTest', (r: Route) => {
-            if (r.request().method() === 'PATCH') { patched = true; return r.fulfill({ json: {} }); }
+            if (r.request().method() === 'PATCH') {
+                patchBody = r.request().postDataJSON() as Record<string, unknown>;
+                patched = true;
+                return r.fulfill({ json: {} });
+            }
             return r.continue();
         });
         await page.goto('/admin-tests.php');
@@ -97,6 +102,7 @@ test.describe('admin-tests editor (stubbed)', () => {
         await expect(page.locator('#testName')).toHaveAttribute('readonly', '');
         await page.locator('#saveTestBtn').click();
         await expect.poll(() => patched).toBe(true);
+        expect(patchBody!.applies_to).toEqual({ national_calendar: 'USA' });
     });
 });
 

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -135,11 +135,19 @@ test.describe('admin-tests year grid (stubbed)', () => {
 
         const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
         await expect(span2005).toBeVisible();
-        // variable type → hammer present; x always present; 2005-07-31 is a Sunday
+        // variable type → action icon present as fa-repeat ("toggle assertion",
+        // same semantic as the card toggle — spec R5); x always present;
+        // 2005-07-31 is a Sunday
         await expect(span2005.locator('.hammerYear')).toHaveCount(1);
+        await expect(span2005.locator('.hammerYear.fa-repeat')).toHaveCount(1);
+        await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCount(0);
         await expect(span2005.locator('.removeYear')).toHaveCount(1);
         await expect(span2005).toHaveClass(/sunday/);
-        // exactCorrespondence type → hammer absent
+        // since type → the icon is the pivot hammer (spec R5)
+        await page.locator('label[for="tt-since"]').click();
+        await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCount(1);
+        await expect(span2005.locator('.hammerYear.fa-repeat')).toHaveCount(0);
+        // exactCorrespondence type → no action icon at all
         await page.locator('label[for="tt-exact"]').click();
         await expect(span2005.locator('.hammerYear')).toHaveCount(0);
         await expect(span2005.locator('.removeYear')).toHaveCount(1);

--- a/e2e/rbac/13-admin-tests-crud.spec.ts
+++ b/e2e/rbac/13-admin-tests-crud.spec.ts
@@ -63,7 +63,9 @@ const API_BASE = `${process.env.API_PROTOCOL || 'http'}://${process.env.API_HOST
 let editorZitadelId: string | null = null;
 
 /** Path where actingAs(browser, EDITOR_USER_ID) expects the auth state file. */
-const authFilePath = path.join(__dirname, '..', '..', '.auth', `${EDITOR_USER_ID}.json`);
+// NB: this spec lives in e2e/rbac/ (one level above support/), so the shared
+// e2e/.auth/ directory that actingAs() reads from is '../.auth' — NOT '../../.auth'.
+const authFilePath = path.join(__dirname, '..', '.auth', `${EDITOR_USER_ID}.json`);
 
 // ── Spec ──────────────────────────────────────────────────────────────────────
 
@@ -217,7 +219,7 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
             // session; a 404 (already deleted by Test 2) is a successful no-op.
             (async () => {
                 const api = await request.newContext({
-                    storageState: path.join(__dirname, '..', '..', '.auth', `${GLOBAL_ADMIN_ID}.json`),
+                    storageState: path.join(__dirname, '..', '.auth', `${GLOBAL_ADMIN_ID}.json`),
                 });
                 try {
                     await api.delete(`${API_BASE}/tests/${encodeURIComponent(TEST_NAME)}`);

--- a/e2e/rbac/13-admin-tests-crud.spec.ts
+++ b/e2e/rbac/13-admin-tests-crud.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * Scenario 13 — admin-tests CRUD (real RBAC)
+ *
+ * Proves that:
+ *   - A national test_editor scoped to IT can create a test within scope and
+ *     is denied an Edit button on out-of-scope (general_roman) rows.
+ *   - A global admin (super-admin) can delete any test.
+ *
+ * The `test_editor` Zitadel role is not pre-seeded by rbac-setup (it is
+ * earned through the access-request workflow, as spec 12 demonstrates). To
+ * exercise real CRUD, `beforeAll` provisions an ephemeral user
+ * (`test-editor-it`) with that role + an FGA `editor` tuple on
+ * `national_calendar_test:IT`, then logs in headlessly and writes
+ * `e2e/.auth/test-editor-it.json` so `actingAs` can load the session.
+ *
+ * `afterAll` tears everything down:
+ *   - Deletes the ephemeral Zitadel user + FGA tuple.
+ *   - Truncates audit_log rows created by the API write operations.
+ *   - Removes the transient auth state file.
+ *
+ * Preconditions (seeded by rbac-setup):
+ *   - super-admin: Zitadel `admin` role; `.auth/super-admin.json` pre-written.
+ *   - login-client: Zitadel machine user with IAM PAT-issuance rights.
+ */
+
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+import { actingAs } from './support/actingAs';
+import { truncateAppTables, settleCleanup } from './support/cleanup';
+import { Fga } from './support/fga';
+import { ZitadelAdmin } from './support/zitadel';
+import { oidcLogin } from './support/seed';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** National calendar whose test scope is exercised. IT is used because spec 12
+ *  already references `national_calendar_test:IT`, keeping harness coverage consistent. */
+const NATION          = 'IT';
+
+/** Test name satisfying the API schema: `^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$` */
+const TEST_NAME       = 'PlaywrightScopedNationalTest';
+
+/** Event key present in the General Roman Calendar (and therefore in every national
+ *  calendar that extends it). Avoids having to seed national-specific events. */
+const EVENT_KEY       = 'StIgnatiusOfLoyola';
+
+/** Key used for `.auth/${id}.json` lookup by `actingAs`. Must be unique across
+ *  all seeded users so it does not collide with rbac-setup-provisioned files. */
+const EDITOR_USER_ID  = 'test-editor-it';
+const EDITOR_EMAIL    = `${EDITOR_USER_ID}+e2e@litcal.test`;
+const EDITOR_PASSWORD = 'E2e-Test-Passw0rd!'; // shared test password (mirrors other e2e users)
+
+/** Pre-seeded by rbac-setup; Zitadel `admin` role bypasses all API role checks. */
+const GLOBAL_ADMIN_ID = 'super-admin';
+
+// Resolved in beforeAll; used in afterAll cleanup even if a test partially fails.
+let editorZitadelId: string | null = null;
+
+/** Path where actingAs(browser, EDITOR_USER_ID) expects the auth state file. */
+const authFilePath = path.join(__dirname, '..', '..', '.auth', `${EDITOR_USER_ID}.json`);
+
+// ── Spec ──────────────────────────────────────────────────────────────────────
+
+test.describe('admin-tests CRUD (real RBAC)', () => {
+
+    // ── Provisioning ──────────────────────────────────────────────────────────
+
+    test.beforeAll(async () => {
+        // Extend timeout: Zitadel user creation + OIDC headless login can take ~30 s.
+        test.setTimeout(120_000);
+
+        const z = new ZitadelAdmin();
+        const f = new Fga();
+
+        // Mint an ephemeral session-capable PAT for the login-client machine user
+        // (required by the OIDC headless session flow — mirrors rbac.setup.ts pattern).
+        const loginClientUserId = await z.findUserIdByUsername('login-client');
+        if (!loginClientUserId) {
+            throw new Error('scenario 13 beforeAll: login-client machine user not found in Zitadel');
+        }
+        const { tokenId: patId, token: loginClientToken } = await z.mintPat(loginClientUserId);
+
+        try {
+            // Idempotent teardown: remove any stale test-editor-it user left by a
+            // previous failed run so re-runs start from a clean slate.
+            const staleId = await z.findUserIdByEmail(EDITOR_EMAIL);
+            if (staleId) {
+                await f.delete(`user:${staleId}`, 'editor', `national_calendar_test:${NATION}`)
+                    .catch(() => {}); // tolerate already-absent tuple
+                await z.deleteUser(staleId);
+            }
+
+            // 1. Create Zitadel user with the `test_editor` project role.
+            //    grantProjectRole accepts any role string; `test_editor` is the
+            //    role checked by AuthorizationMiddleware::forTestEditor() in the API.
+            editorZitadelId = await z.createVerifiedUser({
+                email: EDITOR_EMAIL,
+                password: EDITOR_PASSWORD,
+                firstName: EDITOR_USER_ID,
+                lastName: 'E2E',
+            });
+            await z.grantProjectRole(editorZitadelId, 'test_editor');
+
+            // 2. Write the FGA `editor` tuple on national_calendar_test:IT.
+            //    Mirrors the tuple that the access-request approval flow would write
+            //    after a `test_editor` request is reviewed (see spec 12 for that flow).
+            await f.write(`user:${editorZitadelId}`, 'editor', `national_calendar_test:${NATION}`);
+
+            // 3. Headless OIDC login → write .auth/test-editor-it.json.
+            //    Mirrors the logic in loginAndSaveState() from support/seed.ts.
+            //    The `test_editor` role is baked into the token because the role was
+            //    granted to the user BEFORE this login call.
+            const { accessToken, idToken } = await oidcLogin(
+                EDITOR_EMAIL,
+                EDITOR_PASSWORD,
+                loginClientToken,
+                editorZitadelId,
+            );
+            const cookieBase = {
+                domain: 'localhost', path: '/', expires: -1,
+                httpOnly: true, secure: false, sameSite: 'Lax' as const,
+            };
+            const cookies = [{ name: 'litcal_access_token', value: accessToken, ...cookieBase }];
+            if (idToken) cookies.push({ name: 'litcal_id_token', value: idToken, ...cookieBase });
+            fs.mkdirSync(path.dirname(authFilePath), { recursive: true });
+            fs.writeFileSync(authFilePath, JSON.stringify({ cookies, origins: [] }, null, 2));
+        } finally {
+            // Always revoke the ephemeral login-client PAT.
+            await z.deletePat(loginClientUserId, patId).catch((e) =>
+                console.warn(
+                    'scenario 13 beforeAll: PAT revocation failed (token may persist):',
+                    String(e),
+                ),
+            );
+        }
+    });
+
+    // ── Test 1: scoped editor creates a test within scope ──────────────────────
+
+    test('scoped national test_editor creates within scope and is denied Edit outside', async ({ browser }) => {
+        const tei = await actingAs(browser, EDITOR_USER_ID);
+        try {
+            await tei.page.goto('/admin-tests.php');
+            await expect(tei.page.locator('#testsTableBody')).toBeVisible();
+
+            // Open the create modal.
+            await tei.page.locator('#createTestBtn').click();
+            await tei.page.locator('#tt-exact').check({ force: true });
+            await tei.page.locator('#testName').fill(TEST_NAME);
+
+            // Select national_calendar scope. syncScopeIdField() asynchronously mounts
+            // a CalendarSelect with id="testScopeId" — wait for it before selecting.
+            await tei.page.locator('#testScopeType').selectOption('national_calendar');
+            await expect(tei.page.locator('#testScopeId')).toBeVisible();
+            await tei.page.locator('#testScopeId').selectOption(NATION);
+
+            // Fill the event key and dispatch the change event (triggers datalist reload).
+            await tei.page.locator('#testEventKey').fill(EVENT_KEY);
+            await tei.page.locator('#testEventKey').dispatchEvent('change');
+
+            // Save → expect the new row to appear in the table.
+            await tei.page.locator('#saveTestBtn').click();
+            await expect(tei.page.locator('tr', { hasText: TEST_NAME })).toBeVisible();
+
+            // Out-of-scope gating (client-side FGA gate from GET /auth/test-scopes):
+            // any existing general-roman-scoped row must NOT show an Edit button to
+            // this nationally-scoped editor.
+            const grcRow = tei.page.locator('tr', { hasText: 'general_roman' }).first();
+            if (await grcRow.count()) {
+                await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+            }
+        } finally {
+            await tei.context.close();
+        }
+    });
+
+    // ── Test 2: global admin deletes the test created above ───────────────────
+
+    test('global admin can delete any test', async ({ browser }) => {
+        const adm = await actingAs(browser, GLOBAL_ADMIN_ID);
+        try {
+            await adm.page.goto('/admin-tests.php');
+            const row = adm.page.locator('tr', { hasText: TEST_NAME });
+            await row.getByRole('button', { name: 'Delete' }).click();
+            await adm.page.locator('#confirmDeleteTestBtn').click();
+            await expect(adm.page.locator('tr', { hasText: TEST_NAME })).toHaveCount(0);
+        } finally {
+            await adm.context.close();
+        }
+    });
+
+    // ── Cleanup ───────────────────────────────────────────────────────────────
+
+    test.afterAll(async () => {
+        const z = new ZitadelAdmin();
+        const f = new Fga();
+
+        const cleanupOps: Array<Promise<unknown>> = [
+            // Purge audit_log rows written by the PUT /tests and DELETE /tests calls.
+            truncateAppTables(),
+        ];
+
+        // Remove the ephemeral test_editor user + FGA tuple.
+        // Fall back to email lookup if beforeAll failed before assigning editorZitadelId.
+        const uid = editorZitadelId ?? await z.findUserIdByEmail(EDITOR_EMAIL).catch(() => null);
+        if (uid) {
+            // Fga.delete tolerates "not found" — safe if test 2 already deleted the tuple.
+            cleanupOps.push(
+                f.delete(`user:${uid}`, 'editor', `national_calendar_test:${NATION}`),
+            );
+            // ZitadelAdmin.deleteUser tolerates 404 — safe on re-runs where the user is absent.
+            cleanupOps.push(z.deleteUser(uid));
+        }
+
+        await settleCleanup('scenario 13 afterAll', cleanupOps);
+
+        // Remove the transient auth state file written by beforeAll.
+        // Best-effort: a missing file on a first/failed run is not an error.
+        try { fs.unlinkSync(authFilePath); } catch { /* absent — nothing to remove */ }
+    });
+});

--- a/e2e/rbac/13-admin-tests-crud.spec.ts
+++ b/e2e/rbac/13-admin-tests-crud.spec.ts
@@ -23,7 +23,7 @@
  *   - login-client: Zitadel machine user with IAM PAT-issuance rights.
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, request } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
 import { actingAs } from './support/actingAs';
@@ -53,6 +53,11 @@ const EDITOR_PASSWORD = 'E2e-Test-Passw0rd!'; // shared test password (mirrors o
 
 /** Pre-seeded by rbac-setup; Zitadel `admin` role bypasses all API role checks. */
 const GLOBAL_ADMIN_ID = 'super-admin';
+
+/** API base URL — same env convention as spec 08; domain=localhost cookies in a
+ *  storageState are sent to the API port, so an authenticated request context
+ *  built from `.auth/super-admin.json` can call protected API routes directly. */
+const API_BASE = `${process.env.API_PROTOCOL || 'http'}://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || '8000'}`;
 
 // Resolved in beforeAll; used in afterAll cleanup even if a test partially fails.
 let editorZitadelId: string | null = null;
@@ -165,11 +170,14 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
 
             // Out-of-scope gating (client-side FGA gate from GET /auth/test-scopes):
             // any existing general-roman-scoped row must NOT show an Edit button to
-            // this nationally-scoped editor.
-            const grcRow = tei.page.locator('tr', { hasText: 'general_roman' }).first();
-            if (await grcRow.count()) {
-                await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
-            }
+            // this nationally-scoped editor. The scope column renders the i18n label
+            // "General Roman Calendar" (not the object_type literal), and the API
+            // repo ships GRC-scoped definitions in jsondata/tests, so at least one
+            // such row must exist — assert it, so this gating check can never be
+            // silently skipped.
+            const grcRow = tei.page.locator('tr', { hasText: 'General Roman' }).first();
+            await expect(grcRow).toBeVisible();
+            await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
         } finally {
             await tei.context.close();
         }
@@ -182,6 +190,8 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
         try {
             await adm.page.goto('/admin-tests.php');
             const row = adm.page.locator('tr', { hasText: TEST_NAME });
+            // Fail with a clear message if Test 1 did not create the row.
+            await expect(row).toBeVisible();
             await row.getByRole('button', { name: 'Delete' }).click();
             await adm.page.locator('#confirmDeleteTestBtn').click();
             await expect(adm.page.locator('tr', { hasText: TEST_NAME })).toHaveCount(0);
@@ -199,6 +209,22 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
         const cleanupOps: Array<Promise<unknown>> = [
             // Purge audit_log rows written by the PUT /tests and DELETE /tests calls.
             truncateAppTables(),
+            // Best-effort removal of the created test definition via the API, so a
+            // failed Test 2 cannot orphan it. Test definitions are files under the
+            // API's jsondata/tests/ (not DB rows), so truncateAppTables cannot reach
+            // them — and a leftover file reds every subsequent run with a
+            // duplicate-name conflict on PUT /tests. Uses the pre-seeded super-admin
+            // session; a 404 (already deleted by Test 2) is a successful no-op.
+            (async () => {
+                const api = await request.newContext({
+                    storageState: path.join(__dirname, '..', '..', '.auth', `${GLOBAL_ADMIN_ID}.json`),
+                });
+                try {
+                    await api.delete(`${API_BASE}/tests/${encodeURIComponent(TEST_NAME)}`);
+                } finally {
+                    await api.dispose();
+                }
+            })(),
         ];
 
         // Remove the ephemeral test_editor user + FGA tuple.

--- a/e2e/rbac/13-admin-tests-crud.spec.ts
+++ b/e2e/rbac/13-admin-tests-crud.spec.ts
@@ -42,8 +42,11 @@ const NATION          = 'IT';
 const TEST_NAME       = 'PlaywrightScopedNationalTest';
 
 /** Event key present in the General Roman Calendar (and therefore in every national
- *  calendar that extends it). Avoids having to seed national-specific events. */
-const EVENT_KEY       = 'StIgnatiusOfLoyola';
+ *  calendar that extends it). Avoids having to seed national-specific events.
+ *  NB: the API's real key is `StIgnatiusLoyola` (no "Of") — see
+ *  jsondata/sourcedata/missals/propriumdesanctis_1970. An unmatched key makes the
+ *  editor silently skip generation and the API reject the empty payload with 400. */
+const EVENT_KEY       = 'StIgnatiusLoyola';
 
 /** Key used for `.auth/${id}.json` lookup by `actingAs`. Must be unique across
  *  all seeded users so it does not collide with rbac-setup-provisioned files. */
@@ -165,6 +168,11 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
             // Fill the event key and dispatch the change event (triggers datalist reload).
             await tei.page.locator('#testEventKey').fill(EVENT_KEY);
             await tei.page.locator('#testEventKey').dispatchEvent('change');
+
+            // The editor auto-fills the description once the event key matches the
+            // loaded /events catalog — assert it BEFORE saving so a key/catalog
+            // mismatch fails here (the true cause) rather than at the row check.
+            await expect(tei.page.locator('#testDescription')).not.toHaveValue('');
 
             // Save → expect the new row to appear in the table.
             await tei.page.locator('#saveTestBtn').click();

--- a/includes/admin-tests-card.php
+++ b/includes/admin-tests-card.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * "Test Definitions" dashboard card.
+ * Rendered from admin-dashboard.php for both global admins (inside the admin
+ * blocks grid) and scoped test_editors (in their own Administration section),
+ * so the markup lives here once instead of being duplicated per branch.
+ */
+
+?>
+<div class="col-12 col-md-6 col-lg-4 mb-4">
+    <div class="card admin-block shadow h-100 border-dark">
+        <div class="card-body text-center d-flex flex-column">
+            <div class="admin-block-icon mb-3">
+                <i class="fas fa-vial fa-3x text-info"></i>
+            </div>
+            <h5 class="card-title"><?php echo htmlspecialchars(_('Test Definitions'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></h5>
+            <p class="card-text text-muted small flex-grow-1">
+                <?php echo htmlspecialchars(_('Manage liturgical accuracy tests'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+            </p>
+            <div class="admin-block-actions mt-auto">
+                <a href="admin-tests.php" class="btn btn-dark btn-sm">
+                    <i class="fas fa-tasks me-1"></i><?php echo htmlspecialchars(_('Manage'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/includes/common.php
+++ b/includes/common.php
@@ -242,7 +242,19 @@ $i18n = new I18n();
 // Exposed to JavaScript as AdminPages global via layout/footer.php.
 // ============================================================================
 
-$adminPages = ['admin-dashboard', 'missals-editor', 'extending', 'temporale', 'decrees', 'admin-users', 'admin-role-requests', 'admin-applications', 'admin-permissions', 'developer-dashboard'];
+$adminPages = [
+    'admin-dashboard',
+    'missals-editor',
+    'extending',
+    'temporale',
+    'decrees',
+    'admin-users',
+    'admin-role-requests',
+    'admin-applications',
+    'admin-permissions',
+    'admin-tests',
+    'developer-dashboard',
+];
 
 // ============================================================================
 // Setup PSR-Compliant HTTP Client with Production Features

--- a/layout/header.php
+++ b/layout/header.php
@@ -290,6 +290,16 @@ asort($langsAssoc);
                             </a>
                         <?php endif; // end $sidebarHasCalendarRole ?>
 
+                        <?php if ($authHelper->hasRole('test_editor') || $authHelper->hasRole('admin') || $authHelper->isResourceAdmin()) : ?>
+                        <div class="sb-sidenav-menu-heading text-white-50">
+                            <?php echo _('Accuracy Tests'); ?>
+                        </div>
+                        <a class="nav-link<?php echo $currentPage === 'admin-tests' ? ' active' : ''; ?>" href="admin-tests.php">
+                            <i class="sb-nav-link-icon fas fa-fw fa-vial text-info"></i>
+                            <span><?php echo _('Test Definitions'); ?></span>
+                        </a>
+                        <?php endif; ?>
+
                         <hr class="sidebar-divider my-2">
                         <a class="nav-link" href="/">
                             <i class="sb-nav-link-icon fas fa-fw fa-arrow-left"></i>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "lint": "eslint .",
     "test": "playwright test",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
     "test:chromium": "playwright test --project=chromium",
@@ -29,9 +31,11 @@
     "dotenv": "^17.4.2",
     "eslint": "^10.5.0",
     "globals": "^17.7.0",
+    "jsdom": "^25.0.1",
     "markdownlint-cli2": "^0.22.1",
     "prettier": "^3.8.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^2.1.8"
   },
   "resolutions": {
     "js-yaml": "^4.2.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -52,6 +52,7 @@
     </rule>
     <file>./</file> <!-- directory you want to analyze -->
     <exclude-pattern>/vendor/</exclude-pattern>
+    <exclude-pattern>/node_modules/</exclude-pattern>
     <exclude-pattern>/examples</exclude-pattern>
     <exclude-pattern>*Test.php</exclude-pattern>
     <exclude-pattern>allowedOrigins.php</exclude-pattern>

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+        include: ['assets/js/__tests__/**/*.test.js'],
+        globals: true,
+    },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,226 @@ __metadata:
   version: 10
   cacheKey: 10c0
 
+"@asamuzakjp/css-color@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@asamuzakjp/css-color@npm:3.2.0"
+  dependencies:
+    "@csstools/css-calc": "npm:^2.1.3"
+    "@csstools/css-color-parser": "npm:^3.0.9"
+    "@csstools/css-parser-algorithms": "npm:^3.0.4"
+    "@csstools/css-tokenizer": "npm:^3.0.3"
+    lru-cache: "npm:^10.4.3"
+  checksum: 10c0/a4bf1c831751b1fae46b437e37e8a38c0b5bd58d23230157ae210bd1e905fe509b89b7c243e63d1522d852668a6292ed730a160e21342772b4e5b7b8ea14c092
+  languageName: node
+  linkType: hard
+
+"@csstools/color-helpers@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@csstools/color-helpers@npm:5.1.0"
+  checksum: 10c0/b7f99d2e455cf1c9b41a67a5327d5d02888cd5c8802a68b1887dffef537d9d4bc66b3c10c1e62b40bbed638b6c1d60b85a232f904ed7b39809c4029cb36567db
+  languageName: node
+  linkType: hard
+
+"@csstools/css-calc@npm:^2.1.3, @csstools/css-calc@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@csstools/css-calc@npm:2.1.4"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/42ce5793e55ec4d772083808a11e9fb2dfe36db3ec168713069a276b4c3882205b3507c4680224c28a5d35fe0bc2d308c77f8f2c39c7c09aad8747708eb8ddd8
+  languageName: node
+  linkType: hard
+
+"@csstools/css-color-parser@npm:^3.0.9":
+  version: 3.1.0
+  resolution: "@csstools/css-color-parser@npm:3.1.0"
+  dependencies:
+    "@csstools/color-helpers": "npm:^5.1.0"
+    "@csstools/css-calc": "npm:^2.1.4"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/0e0c670ad54ec8ec4d9b07568b80defd83b9482191f5e8ca84ab546b7be6db5d7cc2ba7ac9fae54488b129a4be235d6183d3aab4416fec5e89351f73af4222c5
+  languageName: node
+  linkType: hard
+
+"@csstools/css-parser-algorithms@npm:^3.0.4":
+  version: 3.0.5
+  resolution: "@csstools/css-parser-algorithms@npm:3.0.5"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/d9a1c888bd43849ae3437ca39251d5c95d2c8fd6b5ccdb7c45491dfd2c1cbdc3075645e80901d120e4d2c1993db9a5b2d83793b779dbbabcfb132adb142eb7f7
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^3.0.3":
+  version: 3.0.4
+  resolution: "@csstools/css-tokenizer@npm:3.0.4"
+  checksum: 10c0/3b589f8e9942075a642213b389bab75a2d50d05d203727fcdac6827648a5572674caff07907eff3f9a2389d86a4ee47308fafe4f8588f4a77b7167c588d2559f
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/aix-ppc64@npm:0.21.5"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm64@npm:0.21.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm@npm:0.21.5"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-x64@npm:0.21.5"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-arm64@npm:0.21.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-x64@npm:0.21.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-arm64@npm:0.21.5"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-x64@npm:0.21.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm64@npm:0.21.5"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm@npm:0.21.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ia32@npm:0.21.5"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-loong64@npm:0.21.5"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-mips64el@npm:0.21.5"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ppc64@npm:0.21.5"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-riscv64@npm:0.21.5"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-s390x@npm:0.21.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-x64@npm:0.21.5"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/netbsd-x64@npm:0.21.5"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/openbsd-x64@npm:0.21.5"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/sunos-x64@npm:0.21.5"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-arm64@npm:0.21.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-ia32@npm:0.21.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-x64@npm:0.21.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.8.0":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
@@ -128,6 +348,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -188,6 +415,181 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.62.2"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-android-arm64@npm:4.62.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.62.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-darwin-x64@npm:4.62.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.62.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.62.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.62.2"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.62.2"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.62.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.62.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.62.2"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.62.2"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.62.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.62.2"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.62.2"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.62.2"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.62.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.62.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.62.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.62.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.62.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.62.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.62.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.62.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.62.2":
+  version: 4.62.2
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.62.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@sindresorhus/merge-streams@npm:^4.0.0":
   version: 4.0.0
   resolution: "@sindresorhus/merge-streams@npm:4.0.0"
@@ -211,17 +613,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/estree@npm:1.0.9, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.8":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:^1.0.6":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:^1.0.8":
-  version: 1.0.9
-  resolution: "@types/estree@npm:1.0.9"
-  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 
@@ -259,6 +661,87 @@ __metadata:
   version: 2.0.11
   resolution: "@types/unist@npm:2.0.11"
   checksum: 10c0/24dcdf25a168f453bb70298145eb043cfdbb82472db0bc0b56d6d51cd2e484b9ed8271d4ac93000a80da568f2402e9339723db262d0869e2bf13bc58e081768d
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/expect@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/98d1cf02917316bebef9e4720723e38298a1c12b3c8f3a81f259bb822de4288edf594e69ff64f0b88afbda6d04d7a4f0c2f720f3fec16b4c45f5e2669f09fdbb
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/mocker@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": "npm:2.1.9"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.12"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/f734490d8d1206a7f44dfdfca459282f5921d73efa72935bb1dc45307578defd38a4131b14853316373ec364cbe910dbc74594ed4137e0da35aa4d9bb716f190
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:2.1.9, @vitest/pretty-format@npm:^2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/pretty-format@npm:2.1.9"
+  dependencies:
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/155f9ede5090eabed2a73361094bb35ed4ec6769ae3546d2a2af139166569aec41bb80e031c25ff2da22b71dd4ed51e5468e66a05e6aeda5f14b32e30bc18f00
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/runner@npm:2.1.9"
+  dependencies:
+    "@vitest/utils": "npm:2.1.9"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/e81f176badb12a815cbbd9bd97e19f7437a0b64e8934d680024b0f768d8670d59cad698ef0e3dada5241b6731d77a7bb3cd2c7cb29f751fd4dd35eb11c42963a
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/snapshot@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+  checksum: 10c0/394974b3a1fe96186a3c87f933b2f7f1f7b7cc42f9c781d80271dbb4c987809bf035fecd7398b8a3a2d54169e3ecb49655e38a0131d0e7fea5ce88960613b526
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/spy@npm:2.1.9"
+  dependencies:
+    tinyspy: "npm:^3.0.2"
+  checksum: 10c0/12a59b5095e20188b819a1d797e0a513d991b4e6a57db679927c43b362a3eff52d823b34e855a6dd9e73c9fa138dcc5ef52210841a93db5cbf047957a60ca83c
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/utils@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": "npm:2.1.9"
+    loupe: "npm:^3.1.2"
+    tinyrainbow: "npm:^1.2.0"
+  checksum: 10c0/81a346cd72b47941f55411f5df4cc230e5f740d1e97e0d3f771b27f007266fc1f28d0438582f6409ea571bc0030ed37f684c64c58d1947d6298d770c21026fdf
   languageName: node
   linkType: hard
 
@@ -320,6 +803,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
+"async-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-function@npm:1.0.0"
+  checksum: 10c0/669a32c2cb7e45091330c680e92eaeb791bc1d4132d827591e499cd1f776ff5a873e77e5f92d0ce795a8d60f10761dec9ddfe7225a5de680f5d357f67b1aac73
+  languageName: node
+  linkType: hard
+
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
+  languageName: node
+  linkType: hard
+
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -345,6 +856,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^20.0.1":
   version: 20.0.3
   resolution: "cacache@npm:20.0.3"
@@ -361,6 +879,29 @@ __metadata:
     ssri: "npm:^13.0.0"
     unique-filename: "npm:^5.0.0"
   checksum: 10c0/c7da1ca694d20e8f8aedabd21dc11518f809a7d2b59aa76a1fc655db5a9e62379e465c157ddd2afe34b19230808882288effa6911b2de26a088a6d5645123462
+  languageName: node
+  linkType: hard
+
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
+  languageName: node
+  linkType: hard
+
+"chai@npm:^5.1.2":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10c0/b360fd4d38861622e5010c2f709736988b05c7f31042305fa3f4e9911f6adb80ccfb4e302068bf8ed10e835c2e2520cba0f5edc13d878b886987e5aa62483f53
   languageName: node
   linkType: hard
 
@@ -385,10 +926,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10c0/878e99038fb6476316b74668cd6a498c7e66df3efe48158fa40db80a06ba4258742ac3ee2229c4a2a98c5e73f5dff84eb3e50ceb6b65bbd8f831eafc8338607d
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^3.0.0":
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
+  languageName: node
+  linkType: hard
+
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: "npm:~1.0.0"
+  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
   languageName: node
   linkType: hard
 
@@ -410,7 +967,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"cssstyle@npm:^4.1.0":
+  version: 4.6.0
+  resolution: "cssstyle@npm:4.6.0"
+  dependencies:
+    "@asamuzakjp/css-color": "npm:^3.2.0"
+    rrweb-cssom: "npm:^0.8.0"
+  checksum: 10c0/71add1b0ffafa1bedbef6855db6189b9523d3320e015a0bf3fbd504760efb9a81e1f1a225228d5fa892ee58e56d06994ca372e7f4e461cda7c4c9985fe075f65
+  languageName: node
+  linkType: hard
+
+"data-urls@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "data-urls@npm:5.0.0"
+  dependencies:
+    whatwg-mimetype: "npm:^4.0.0"
+    whatwg-url: "npm:^14.0.0"
+  checksum: 10c0/1b894d7d41c861f3a4ed2ae9b1c3f0909d4575ada02e36d3d3bc584bdd84278e20709070c79c3b3bff7ac98598cb191eb3e86a89a79ea4ee1ef360e1694f92ad
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -419,6 +996,13 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.4.3":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 10c0/07d69fbcc54167a340d2d97de95f546f9ff1f69d2b45a02fd7a5292412df3cd9eb7e23065e532a318f5474a2e1bccf8392fdf0443ef467f97f3bf8cb0477e5aa
   languageName: node
   linkType: hard
 
@@ -431,10 +1015,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: 10c0/7f0ee496e0dff14a573dc6127f14c95061b448b87b995fc96c017ce0a1e66af1675e73f1d6064407975bc4ea6ab679497a29fff7b5b9c4e99cb10797c1ad0b4c
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
   languageName: node
   linkType: hard
 
@@ -461,6 +1059,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.2.0"
+  checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -477,6 +1086,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "entities@npm:6.0.1"
+  checksum: 10c0/ed836ddac5acb34341094eb495185d527bd70e8632b6c0d59548cbfa23defdbae70b96f9a405c82904efa421230b5b3fd2283752447d737beffd3f3e6ee74414
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -488,6 +1104,128 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: 10c0/b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
+  languageName: node
+  linkType: hard
+
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^1.5.4":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "es-object-atoms@npm:1.1.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10c0/1772861f094f739d6f41b579cfb9a18579daffeb434552a370a5fbef50a32d22227e27b63fdbb757b7ddd429d1b42fe52ccae7966d9302a2ec221b6f1b41bbc4
+  languageName: node
+  linkType: hard
+
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.21.3":
+  version: 0.21.5
+  resolution: "esbuild@npm:0.21.5"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.21.5"
+    "@esbuild/android-arm": "npm:0.21.5"
+    "@esbuild/android-arm64": "npm:0.21.5"
+    "@esbuild/android-x64": "npm:0.21.5"
+    "@esbuild/darwin-arm64": "npm:0.21.5"
+    "@esbuild/darwin-x64": "npm:0.21.5"
+    "@esbuild/freebsd-arm64": "npm:0.21.5"
+    "@esbuild/freebsd-x64": "npm:0.21.5"
+    "@esbuild/linux-arm": "npm:0.21.5"
+    "@esbuild/linux-arm64": "npm:0.21.5"
+    "@esbuild/linux-ia32": "npm:0.21.5"
+    "@esbuild/linux-loong64": "npm:0.21.5"
+    "@esbuild/linux-mips64el": "npm:0.21.5"
+    "@esbuild/linux-ppc64": "npm:0.21.5"
+    "@esbuild/linux-riscv64": "npm:0.21.5"
+    "@esbuild/linux-s390x": "npm:0.21.5"
+    "@esbuild/linux-x64": "npm:0.21.5"
+    "@esbuild/netbsd-x64": "npm:0.21.5"
+    "@esbuild/openbsd-x64": "npm:0.21.5"
+    "@esbuild/sunos-x64": "npm:0.21.5"
+    "@esbuild/win32-arm64": "npm:0.21.5"
+    "@esbuild/win32-ia32": "npm:0.21.5"
+    "@esbuild/win32-x64": "npm:0.21.5"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
   languageName: node
   linkType: hard
 
@@ -605,10 +1343,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -719,6 +1473,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^4.0.0":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^3.0.0":
   version: 3.0.3
   resolution: "fs-minipass@npm:3.0.3"
@@ -738,6 +1505,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
@@ -747,10 +1524,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
+  languageName: node
+  linkType: hard
+
+"generator-function@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "generator-function@npm:2.0.1"
+  checksum: 10c0/8a9f59df0f01cfefafdb3b451b80555e5cf6d76487095db91ac461a0e682e4ff7a9dbce15f4ecec191e53586d59eece01949e05a4b4492879600bbbe8e28d6b8
+  languageName: node
+  linkType: hard
+
 "get-east-asian-width@npm:^1.3.0":
   version: 1.6.0
   resolution: "get-east-asian-width@npm:1.6.0"
   checksum: 10c0/7e72e9550fd49ca5b246f9af6bb2afc129c96412845ff6556b3274fd44817a381702ca17028efe9866b261a3d44254cbf21e6c90cf05b4b61675630af776d431
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.2.6":
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
+  dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: "npm:^1.0.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
   languageName: node
   linkType: hard
 
@@ -804,10 +1635,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: "npm:^1.0.3"
+  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.2, hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
+  languageName: node
+  linkType: hard
+
+"html-encoding-sniffer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "html-encoding-sniffer@npm:4.0.0"
+  dependencies:
+    whatwg-encoding: "npm:^3.1.1"
+  checksum: 10c0/523398055dc61ac9b34718a719cb4aa691e4166f29187e211e1607de63dc25ac7af52ca7c9aead0c4b3c0415ffecb17326396e1202e2e86ff4bca4c0ee4c6140
   languageName: node
   linkType: hard
 
@@ -818,7 +1690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0":
+"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.2":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -828,7 +1700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -838,7 +1710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -936,6 +1808,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-potential-custom-element-name@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-potential-custom-element-name@npm:1.0.1"
+  checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^2.0.0":
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
@@ -958,6 +1837,40 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:^25.0.1":
+  version: 25.0.1
+  resolution: "jsdom@npm:25.0.1"
+  dependencies:
+    cssstyle: "npm:^4.1.0"
+    data-urls: "npm:^5.0.0"
+    decimal.js: "npm:^10.4.3"
+    form-data: "npm:^4.0.0"
+    html-encoding-sniffer: "npm:^4.0.0"
+    http-proxy-agent: "npm:^7.0.2"
+    https-proxy-agent: "npm:^7.0.5"
+    is-potential-custom-element-name: "npm:^1.0.1"
+    nwsapi: "npm:^2.2.12"
+    parse5: "npm:^7.1.2"
+    rrweb-cssom: "npm:^0.7.1"
+    saxes: "npm:^6.0.0"
+    symbol-tree: "npm:^3.2.4"
+    tough-cookie: "npm:^5.0.0"
+    w3c-xmlserializer: "npm:^5.0.0"
+    webidl-conversions: "npm:^7.0.0"
+    whatwg-encoding: "npm:^3.1.1"
+    whatwg-mimetype: "npm:^4.0.0"
+    whatwg-url: "npm:^14.0.0"
+    ws: "npm:^8.18.0"
+    xml-name-validator: "npm:^5.0.0"
+  peerDependencies:
+    canvas: ^2.11.2
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 10c0/6bda32a6dfe4e37a30568bf51136bdb3ba9c0b72aadd6356280404275a34c9e097c8c25b5eb3c742e602623741e172da977ff456684befd77c9042ed9bf8c2b4
   languageName: node
   linkType: hard
 
@@ -1045,9 +1958,11 @@ __metadata:
     dotenv: "npm:^17.4.2"
     eslint: "npm:^10.5.0"
     globals: "npm:^17.7.0"
+    jsdom: "npm:^25.0.1"
     markdownlint-cli2: "npm:^0.22.1"
     prettier: "npm:^3.8.4"
     typescript: "npm:^6.0.3"
+    vitest: "npm:^2.1.8"
   languageName: unknown
   linkType: soft
 
@@ -1060,10 +1975,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^3.1.0, loupe@npm:^3.1.2":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10c0/910c872cba291309664c2d094368d31a68907b6f5913e989d301b5c25f30e97d76d77f23ab3bf3b46d0f601ff0b6af8810c10c31b91d2c6b2f132809ca2cc705
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^10.4.3":
+  version: 10.4.3
+  resolution: "lru-cache@npm:10.4.3"
+  checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
   version: 11.2.2
   resolution: "lru-cache@npm:11.2.2"
   checksum: 10c0/72d7831bbebc85e2bdefe01047ee5584db69d641c48d7a509e86f66f6ee111b30af7ec3bd68a967d47b69a4b1fa8bbf3872630bd06a63b6735e6f0a5f1c8e83d
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.12":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
   languageName: node
   linkType: hard
 
@@ -1144,6 +2082,13 @@ __metadata:
     micromark-util-types: "npm:2.0.2"
     string-width: "npm:8.1.0"
   checksum: 10c0/1543fcf4a433bc54e0e565cb1c8111e5e3d0df3742df0cc840d470bced21a1e3b5593e4e380ad0d8d5e490d9b399699d48aeabed33719f3fbdc6d00128138f20
+  languageName: node
+  linkType: hard
+
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
   languageName: node
   linkType: hard
 
@@ -1466,6 +2411,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.35":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
@@ -1565,6 +2526,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.12":
+  version: 3.3.15
+  resolution: "nanoid@npm:3.3.15"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/e0b12e3a1d361f74150fa4b25631d0ae29f7162dab01a12f0f1be1f53b7a2a219f9b729504e474d4821207d0fe349bd3c97569ab5cf7ec2fff6aa94711956c93
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -1607,6 +2577,13 @@ __metadata:
   bin:
     nopt: bin/nopt.js
   checksum: 10c0/1822eb6f9b020ef6f7a7516d7b64a8036e09666ea55ac40416c36e4b2b343122c3cff0e2f085675f53de1d2db99a2a89a60ccea1d120bcd6a5347bf6ceb4a7fd
+  languageName: node
+  linkType: hard
+
+"nwsapi@npm:^2.2.12":
+  version: 2.2.24
+  resolution: "nwsapi@npm:2.2.24"
+  checksum: 10c0/9bc04ee9c7698f1b5506778d36f7382962f71667205d441d6a50f6180ee92328e770b76be78b907817ee103241b29984d3a17ae387e4723aebe0aeaed7a7c3a1
   languageName: node
   linkType: hard
 
@@ -1664,6 +2641,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^7.1.2":
+  version: 7.3.0
+  resolution: "parse5@npm:7.3.0"
+  dependencies:
+    entities: "npm:^6.0.0"
+  checksum: 10c0/7fd2e4e247e85241d6f2a464d0085eed599a26d7b0a5233790c49f53473232eb85350e8133344d9b3fd58b89339e7ad7270fe1f89d28abe50674ec97b87f80b5
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
@@ -1685,6 +2671,27 @@ __metadata:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
   checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
+  languageName: node
+  linkType: hard
+
+"pathe@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "pathe@npm:1.1.2"
+  checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10c0/460f4709479fbf2c45903a65655fc8f0a5f6d808f989173aeef5fdea4ff4f303dc13f7870303999add60ec49d4c14733895c0a869392e9866f1091fa64fd7581
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
   languageName: node
   linkType: hard
 
@@ -1723,6 +2730,17 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/079dceebe8b745fa6062a3af928024d0c508177fbf15d61dba09ba173f277465ad3746fdc1b31788ade65428f4d3f92fc8083b44c07381b088721eaa2ea06513
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.43":
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
+  dependencies:
+    nanoid: "npm:^3.3.12"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
   languageName: node
   linkType: hard
 
@@ -1766,7 +2784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0":
+"punycode@npm:^2.1.0, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
@@ -1794,6 +2812,110 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.20.0":
+  version: 4.62.2
+  resolution: "rollup@npm:4.62.2"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.62.2"
+    "@rollup/rollup-android-arm64": "npm:4.62.2"
+    "@rollup/rollup-darwin-arm64": "npm:4.62.2"
+    "@rollup/rollup-darwin-x64": "npm:4.62.2"
+    "@rollup/rollup-freebsd-arm64": "npm:4.62.2"
+    "@rollup/rollup-freebsd-x64": "npm:4.62.2"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.62.2"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.62.2"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.62.2"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.62.2"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.62.2"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.62.2"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.62.2"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.62.2"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.62.2"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.62.2"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.62.2"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.62.2"
+    "@rollup/rollup-linux-x64-musl": "npm:4.62.2"
+    "@rollup/rollup-openbsd-x64": "npm:4.62.2"
+    "@rollup/rollup-openharmony-arm64": "npm:4.62.2"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.62.2"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.62.2"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.62.2"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.62.2"
+    "@types/estree": "npm:1.0.9"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/83ff5f4a1fea3fa05db2ef56beceee8c33d4a72b818e19c562f1e85c41076fe5b12aadc44048bb73e60b83336df82154b017fa6bf0186f3141643e6f215fbdcb
+  languageName: node
+  linkType: hard
+
+"rrweb-cssom@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "rrweb-cssom@npm:0.7.1"
+  checksum: 10c0/127b8ca6c8aac45e2755abbae6138d4a813b1bedc2caabf79466ae83ab3cfc84b5bfab513b7033f0aa4561c7753edf787d0dd01163ceacdee2e8eb1b6bf7237e
+  languageName: node
+  linkType: hard
+
+"rrweb-cssom@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "rrweb-cssom@npm:0.8.0"
+  checksum: 10c0/56f2bfd56733adb92c0b56e274c43f864b8dd48784d6fe946ef5ff8d438234015e59ad837fc2ad54714b6421384141c1add4eb569e72054e350d1f8a50b8ac7b
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -1807,6 +2929,15 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
+  languageName: node
+  linkType: hard
+
+"saxes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "saxes@npm:6.0.0"
+  dependencies:
+    xmlchars: "npm:^2.2.0"
+  checksum: 10c0/3847b839f060ef3476eb8623d099aa502ad658f5c40fd60c105ebce86d244389b0d76fcae30f4d0c728d7705ceb2f7e9b34bb54717b6a7dbedaf5dad2d9a4b74
   languageName: node
   linkType: hard
 
@@ -1832,6 +2963,13 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
   languageName: node
   linkType: hard
 
@@ -1877,12 +3015,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^13.0.0":
   version: 13.0.0
   resolution: "ssri@npm:13.0.0"
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/405f3a531cd98b013cecb355d63555dca42fd12c7bc6671738aaa9a82882ff41cdf0ef9a2b734ca4f9a760338f114c29d01d9238a65db3ccac27929bd6e6d4b2
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.8.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
   languageName: node
   linkType: hard
 
@@ -1905,6 +3064,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"symbol-tree@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "symbol-tree@npm:3.2.4"
+  checksum: 10c0/dfbe201ae09ac6053d163578778c53aa860a784147ecf95705de0cd23f42c851e1be7889241495e95c37cabb058edb1052f141387bef68f705afc8f9dd358509
+  languageName: node
+  linkType: hard
+
 "tar@npm:^7.5.2":
   version: 7.5.16
   resolution: "tar@npm:7.5.16"
@@ -1918,6 +3084,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.12":
   version: 0.2.16
   resolution: "tinyglobby@npm:0.2.16"
@@ -1928,12 +3108,69 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinypool@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "tinyrainbow@npm:1.2.0"
+  checksum: 10c0/7f78a4b997e5ba0f5ecb75e7ed786f30bab9063716e7dff24dd84013fb338802e43d176cb21ed12480561f5649a82184cf31efb296601a29d38145b1cdb4c192
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "tinyspy@npm:3.0.2"
+  checksum: 10c0/55ffad24e346622b59292e097c2ee30a63919d5acb7ceca87fc0d1c223090089890587b426e20054733f97a58f20af2c349fb7cc193697203868ab7ba00bcea0
+  languageName: node
+  linkType: hard
+
+"tldts-core@npm:^6.1.86":
+  version: 6.1.86
+  resolution: "tldts-core@npm:6.1.86"
+  checksum: 10c0/8133c29375f3f99f88fce5f4d62f6ecb9532b106f31e5423b27c1eb1b6e711bd41875184a456819ceaed5c8b94f43911b1ad57e25c6eb86e1fc201228ff7e2af
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^6.1.32":
+  version: 6.1.86
+  resolution: "tldts@npm:6.1.86"
+  dependencies:
+    tldts-core: "npm:^6.1.86"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/27ae7526d9d78cb97b2de3f4d102e0b4321d1ccff0648a7bb0e039ed54acbce86bacdcd9cd3c14310e519b457854e7bafbef1f529f58a1e217a737ced63f0940
+  languageName: node
+  linkType: hard
+
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^5.0.0":
+  version: 5.1.2
+  resolution: "tough-cookie@npm:5.1.2"
+  dependencies:
+    tldts: "npm:^6.1.32"
+  checksum: 10c0/5f95023a47de0f30a902bba951664b359725597d8adeabc66a0b93a931c3af801e1e697dae4b8c21a012056c0ea88bd2bf4dfe66b2adcf8e2f42cd9796fe0626
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "tr46@npm:5.1.1"
+  dependencies:
+    punycode: "npm:^2.3.1"
+  checksum: 10c0/ae270e194d52ec67ebd695c1a42876e0f19b96e4aca2ab464ab1d9d17dc3acd3e18764f5034c93897db73421563be27c70c98359c4501136a497e46deda5d5ec
   languageName: node
   linkType: hard
 
@@ -2014,6 +3251,156 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:2.1.9":
+  version: 2.1.9
+  resolution: "vite-node@npm:2.1.9"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.3.7"
+    es-module-lexer: "npm:^1.5.4"
+    pathe: "npm:^1.1.2"
+    vite: "npm:^5.0.0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10c0/0d3589f9f4e9cff696b5b49681fdb75d1638c75053728be52b4013f70792f38cb0120a9c15e3a4b22bdd6b795ad7c2da13bcaf47242d439f0906049e73bdd756
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0":
+  version: 5.4.21
+  resolution: "vite@npm:5.4.21"
+  dependencies:
+    esbuild: "npm:^0.21.3"
+    fsevents: "npm:~2.3.3"
+    postcss: "npm:^8.4.43"
+    rollup: "npm:^4.20.0"
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^2.1.8":
+  version: 2.1.9
+  resolution: "vitest@npm:2.1.9"
+  dependencies:
+    "@vitest/expect": "npm:2.1.9"
+    "@vitest/mocker": "npm:2.1.9"
+    "@vitest/pretty-format": "npm:^2.1.9"
+    "@vitest/runner": "npm:2.1.9"
+    "@vitest/snapshot": "npm:2.1.9"
+    "@vitest/spy": "npm:2.1.9"
+    "@vitest/utils": "npm:2.1.9"
+    chai: "npm:^5.1.2"
+    debug: "npm:^4.3.7"
+    expect-type: "npm:^1.1.0"
+    magic-string: "npm:^0.30.12"
+    pathe: "npm:^1.1.2"
+    std-env: "npm:^3.8.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.1"
+    tinypool: "npm:^1.0.1"
+    tinyrainbow: "npm:^1.2.0"
+    vite: "npm:^5.0.0"
+    vite-node: "npm:2.1.9"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/node": ^18.0.0 || >=20.0.0
+    "@vitest/browser": 2.1.9
+    "@vitest/ui": 2.1.9
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/e339e16dccacf4589ff43cb1f38c7b4d14427956ae8ef48702af6820a9842347c2b6c77356aeddb040329759ca508a3cb2b104ddf78103ea5bc98ab8f2c3a54e
+  languageName: node
+  linkType: hard
+
+"w3c-xmlserializer@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "w3c-xmlserializer@npm:5.0.0"
+  dependencies:
+    xml-name-validator: "npm:^5.0.0"
+  checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "webidl-conversions@npm:7.0.0"
+  checksum: 10c0/228d8cb6d270c23b0720cb2d95c579202db3aaf8f633b4e9dd94ec2000a04e7e6e43b76a94509cdb30479bd00ae253ab2371a2da9f81446cc313f89a4213a2c4
+  languageName: node
+  linkType: hard
+
+"whatwg-encoding@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "whatwg-encoding@npm:3.1.1"
+  dependencies:
+    iconv-lite: "npm:0.6.3"
+  checksum: 10c0/273b5f441c2f7fda3368a496c3009edbaa5e43b71b09728f90425e7f487e5cef9eb2b846a31bd760dd8077739c26faf6b5ca43a5f24033172b003b72cf61a93e
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^14.0.0":
+  version: 14.2.0
+  resolution: "whatwg-url@npm:14.2.0"
+  dependencies:
+    tr46: "npm:^5.1.0"
+    webidl-conversions: "npm:^7.0.0"
+  checksum: 10c0/f746fc2f4c906607d09537de1227b13f9494c171141e5427ed7d2c0dd0b6a48b43d8e71abaae57d368d0c06b673fd8ec63550b32ad5ed64990c7b0266c2b4272
+  languageName: node
+  linkType: hard
+
 "which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
@@ -2036,10 +3423,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
   checksum: 10c0/e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
+  languageName: node
+  linkType: hard
+
+"xml-name-validator@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "xml-name-validator@npm:5.0.0"
+  checksum: 10c0/3fcf44e7b73fb18be917fdd4ccffff3639373c7cb83f8fc35df6001fecba7942f1dbead29d91ebb8315e2f2ff786b508f0c9dc0215b6353f9983c6b7d62cb1f5
+  languageName: node
+  linkType: hard
+
+"xmlchars@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "xmlchars@npm:2.2.0"
+  checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Phase 2 of the admin-tests initiative (spec: `docs/superpowers/specs/2026-06-29-admin-tests-page-design.md`, plan: `docs/superpowers/plans/2026-06-29-admin-tests-page-phase2.md`). Adds a dedicated **`admin-tests.php`** page so `test_editor`/admin users can create, edit, delete, and view liturgical test definitions via the existing `/tests` API — porting the UnitTestInterface editor with the two agreed modernizations. Phase 1 (`GET /auth/test-scopes`, API PR #678) is already live on the API's `development`; Phase 3 (retiring the UnitTestInterface editor) follows separately.

### What's in here

- **`assets/js/AssertionsBuilder.js`** — state-first port of the UnitTestInterface assertion editor: the in-memory model is the single source of truth (`load()`/`serialize()` never read the DOM); Isotope replaced by native CSS grid; `contenteditable` replaced by `<textarea>`. Covered by **27 Vitest unit tests** (new dev-dep, `yarn test:unit`) incl. schema round-trips, per-type `generate()` rules, pivot re-splits, mutators, and the render DOM contract.
- **`admin-tests.php`** — auth-gated page (admin / test_editor / resource-admin), `window.AdminTestsConfig` blob (gettext i18n), list table + editor/comment/delete modals; registered in `$adminPages`, sidebar nav link, dashboard card.
- **`assets/js/admin-tests.js`** — bespoke native-ESM module modeled on `admin-permissions.js` (NOT the status-workflow factory), with a clean generic/specific seam. Per-row **Edit** gated on `is_global_admin || scope ∈ editor[]`, **Delete** on `admin[]` from `GET /auth/test-scopes` (fail-closed on fetch error; `deriveScope` mirrors the server's `TestScopeResolver`; API remains the backstop). Editor: `/events` datalist (per-scope reload), ported dual-range year slider (`multi-range-slider.css` verbatim), per-year assertion cards with exists↔not-exists toggle, base-date & per-card date editing, pivot-click for Since/Until, comments. Create `PUT /tests`, edit `PATCH /tests/{name}` (name read-only — it is the resource key), delete `DELETE /tests/{name}`. All rendering escape-safe (`createElement`/`textContent` — no server data in `innerHTML`).
- **Playwright**: route-stubbed specs (`e2e/admin-tests.spec.ts`) for gating + CRUD payload contracts, and a real-seeded RBAC spec (`e2e/rbac/13-admin-tests-crud.spec.ts`) — ephemeral `test_editor` scoped to `national_calendar_test:IT` creates in scope / is denied out of scope; super-admin deletes; full teardown incl. API-side removal of the created definition.
- Housekeeping: `phpcs.xml` now excludes `node_modules/`; `.gitignore` allows `admin-tests.php`.

### Review process

Built task-by-task with a fresh implementer + independent reviewer per task, plus a final whole-branch review. Notable catches fixed along the way: `applies_to` round-trip on edit (would have silently rescoped tests / 403'd scoped editors), XSS hardening of all list/alert rendering, `fetchJson` preserving HTTP status on non-JSON error bodies, a vacuous GRC gating assertion in the rbac spec, and CI-state cleanup of created test definitions.

## Test plan

- [x] `yarn test:unit` — 27/27 (AssertionsBuilder)
- [x] `yarn lint`, `yarn typecheck`, `php -l` on all touched PHP, markdownlint — clean
- [x] Offline page smoke: unauthenticated request → 302 to `index.php`, no PHP errors
- [ ] **CI**: Playwright chromium project runs `e2e/admin-tests.spec.ts` (stubbed gating/CRUD); rbac project runs spec 13 (needs the docker Zitadel/OpenFGA stack — not runnable in the dev worktree)
- [ ] Manual pass on the deployed dev stack: create/edit/delete a scoped test as a `test_editor`

## Follow-ups (non-blocking, from the final review)

- i18n catalog extraction for the new `_()` strings (page, nav heading, dashboard card) + the few hardcoded card labels in `AssertionsBuilder.render`
- Client-side pre-serialize validation (empty assertions / null-dated exists → currently surfaced as API 422s)
- Remove the `window.__adminTests` debug seam; consolidate the two delegated tbody listeners when the shared admin-page factory lands
- `fetchJson` → small `ApiError extends Error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated “Test Definitions” admin page to list, create, edit, and delete test definitions.
  * Added a “Test Definitions” card and sidebar link for eligible roles, with scope-based Edit/Delete gating.
  * Delivered a step-based editor with per-year assertions, exclusions/restores, and range slider support.
* **Bug Fixes**
  * Updated ignore rules so the new admin page is included in build contexts.
* **Tests**
  * Added unit tests for the assertions builder plus expanded end-to-end CRUD, permissions, and RBAC scenarios.
* **Documentation**
  * Added design and phase handoff docs for the admin-tests workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->