### PR TITLE
ci(tests): run vitest unit tests in a dedicated non-required job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,3 +72,28 @@ jobs:
 
       - name: Typecheck (e2e)
         run: yarn typecheck
+
+  # Kept as a separate job from "js" on purpose: "JS (eslint · typecheck)" is a
+  # required status check on the development branch, and this job is not (yet)
+  # required — folding vitest into the js job would silently make it required.
+  js-unit:
+    name: JS unit tests (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Unit tests (vitest)
+        run: yarn test:unit


### PR DESCRIPTION
## Summary

The vitest suite (`yarn test:unit`) was not exercised by any CI workflow — dependency bumps like vitest 2→3 (#381) rode in on green checks without the unit tests ever running.

This adds a `js-unit` job ("JS unit tests (vitest)") to the **Tests** workflow, running on every PR and on pushes to `development`/`main`.

## Why a separate job

`JS (eslint · typecheck)` is a **required** status check on `development`. Folding vitest into that job would silently make the unit tests required. Keeping it as its own job means it runs everywhere without (yet) gating merges — to make it required later, add `JS unit tests (vitest)` to the branch protection checks.

## Verification

- Suite passes locally against vitest 3.2.6 (40/40 tests)
- Workflow YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)