### PR TITLE
fix(deps): force markdown-it >=14.2.0 via Yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "vitest": "^3.2.6"
   },
   "resolutions": {
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "markdown-it": "^14.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2004,12 +2004,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "linkify-it@npm:5.0.0"
+"linkify-it@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "linkify-it@npm:5.0.1"
   dependencies:
     uc.micro: "npm:^2.0.0"
-  checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
+  checksum: 10c0/d06d04f1ed03be131740fc900a5e74ea1f49886b052213599e306d469d5ffe2303db76dd8f771de9f28e2b0b38852de22ec46ae597d245f8b66439b0ceb19b10
   languageName: node
   linkType: hard
 
@@ -2089,19 +2089,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it@npm:14.1.1":
-  version: 14.1.1
-  resolution: "markdown-it@npm:14.1.1"
+"markdown-it@npm:^14.2.0":
+  version: 14.2.0
+  resolution: "markdown-it@npm:14.2.0"
   dependencies:
     argparse: "npm:^2.0.1"
     entities: "npm:^4.4.0"
-    linkify-it: "npm:^5.0.0"
+    linkify-it: "npm:^5.0.1"
     mdurl: "npm:^2.0.0"
     punycode.js: "npm:^2.3.1"
     uc.micro: "npm:^2.1.0"
   bin:
     markdown-it: bin/markdown-it.mjs
-  checksum: 10c0/c67f2a4c8069a307c78d8c15104bbcb15a2c6b17f4c904364ca218ec2eccf76a397eba1ea05f5ac5de72c4b67fcf115d422d22df0bfb86a09b663f55b9478d4f
+  checksum: 10c0/1d3a50061d2fe4efbcf317aac853dbee6892ed6f5a217570eead723f2ef2dd1c9baaeef5a687cd283480c45c2d20724a73e84a9ed72843cf7b3b719067af40ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #32](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/security/dependabot/32) (moderate): quadratic-complexity DoS in markdown-it's smartquotes rule via `replaceAt` string operations, patched in **14.2.0**.

`markdown-it` is a transitive dev dependency of `markdownlint-cli2@0.22.1`, which pins `14.1.1` exactly — so a Yarn `resolutions` entry is needed until markdownlint-cli2 bumps it upstream. Same pattern as the existing `js-yaml` resolution.

## Verification

- `yarn why markdown-it` → `markdown-it@npm:14.2.0 (via npm:^14.2.0)`
- `yarn lint:md` runs correctly with markdown-it 14.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)