### PR TITLE
ci(deploy): deploy the examples repo into the web root

### DIFF
--- a/.github/deploy/examples-rsync-exclude.txt
+++ b/.github/deploy/examples-rsync-exclude.txt
@@ -1,0 +1,24 @@
+# Filter rules for the examples-repo deploy rsync (examples-src/ -> examples/).
+#
+# Separate from rsync-exclude.txt on purpose: that file is the FRONTEND tree's
+# exclude list (and even excludes /examples/ itself), so it cannot be reused
+# for the examples tree. Same semantics as that file, though: first match wins,
+# and a "+ " prefix is an include-override (rsync honours +/- prefixes in an
+# --exclude-from file), so entries matched here are also protected from --delete.
+
+# --- VCS / CI / editor cruft — never ship ---
+.git/
+.github/
+.vscode/
+
+# --- .env.example ships (admins diff it); real .env* are excluded so --delete
+#     can't wipe the PHP example's server-side secrets ---
++ .env.example
+.env
+.env.*
+
+# --- Runtime state the PHP example creates as the php-fpm user; excluded so
+#     --delete preserves it server-side ---
+logs/
+cache/
+*.log

--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -115,3 +115,11 @@ logs/
 
 # --- Generated data dir (gitignored locally, server-managed) ---
 /assets/json/
+
+# --- Examples repo (separate public repo, deployed out-of-band) ---
+# examples/ is a gitignored local symlink to the sibling
+# Liturgical-Calendar/examples checkout, so it is absent from this repo's CI
+# checkout entirely. The deploy workflow syncs that repo into
+# ${DEPLOY_PATH}/examples/ in its own dedicated rsync step (see deploy.yaml).
+# Exclude it here so THIS rsync's --delete never wipes that server-side dir.
+/examples/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -136,12 +136,14 @@ jobs:
       # production unless we deploy that repo alongside the frontend. Check it
       # out here into a sibling path (not examples/, to avoid any interaction
       # with the main rsync) and deploy it in a dedicated step further down.
-      # The examples repo has a single deploy ref (main) for both targets.
+      # Pinned to a commit SHA (not a branch) so staging and production always
+      # deploy the same examples revision and deploys stay reproducible; the repo
+      # has no release tags. Bump this SHA to roll examples forward.
       - name: Checkout examples repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Liturgical-Calendar/examples
-          ref: main
+          ref: 04c7fa436bb049e59546267518ac3dd72bff58c4 # main @ 2026-07-07
           path: examples-src
           persist-credentials: false
 
@@ -276,27 +278,14 @@ jobs:
           # already exists from the "Ensure ... dirs exist" step. This step owns
           # examples/ end-to-end, with its own --delete so files removed from the
           # examples repo are pruned here too — that is the "keep it up to date"
-          # half of the fix.
-          #
-          # Filters (first match wins):
-          #   - .git/.github/.vscode are dev/CI cruft — never ship them.
-          #   - .env.example ships (admins diff it), but real .env* are excluded
-          #     so --delete can't wipe the PHP example's server-side secrets.
-          #   - logs/ cache/ *.log are runtime state the PHP example creates as
-          #     the php-fpm user; excluded so --delete preserves them.
+          # half of the fix. Filter rules (VCS cruft, .env* handling, runtime
+          # state) live in a dedicated exclude file, mirroring the main rsync's
+          # --exclude-from convention.
           rsync \
             --archive --no-owner --no-group \
             --compress --human-readable --verbose \
             --delete --protect-args \
-            --exclude='.git/' \
-            --exclude='.github/' \
-            --exclude='.vscode/' \
-            --include='.env.example' \
-            --exclude='.env' \
-            --exclude='.env.*' \
-            --exclude='logs/' \
-            --exclude='cache/' \
-            --exclude='*.log' \
+            --exclude-from=.github/deploy/examples-rsync-exclude.txt \
             -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
             examples-src/ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/examples/"
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -130,6 +130,21 @@ jobs:
           ref: ${{ needs.resolve.outputs.ref }}
           persist-credentials: false
 
+      # The examples live in their own public repo, symlinked locally as a
+      # gitignored examples/ -> ../examples. That symlink is absent from this
+      # repo's checkout, so examples.php's examples/* asset references 404 in
+      # production unless we deploy that repo alongside the frontend. Check it
+      # out here into a sibling path (not examples/, to avoid any interaction
+      # with the main rsync) and deploy it in a dedicated step further down.
+      # The examples repo has a single deploy ref (main) for both targets.
+      - name: Checkout examples repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: Liturgical-Calendar/examples
+          ref: main
+          path: examples-src
+          persist-credentials: false
+
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
@@ -140,6 +155,12 @@ jobs:
 
       - name: Install production dependencies
         run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress --no-scripts --no-plugins --prefer-dist
+
+      # The PHP example (examples/php) is a standalone app that hard-exits if it
+      # can't locate its own vendor/autoload.php, and its vendor/ is gitignored
+      # in the examples repo — so build it here before deploying.
+      - name: Install examples PHP-example dependencies
+        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress --no-scripts --no-plugins --prefer-dist --working-dir=examples-src/php
 
       - name: Configure SSH
         env:
@@ -240,6 +261,44 @@ jobs:
             --exclude-from=.github/deploy/rsync-exclude.txt \
             -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
             ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"
+
+      - name: Deploy examples repo via rsync
+        env:
+          VPS_USER: ${{ secrets.VPS_USERNAME }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_PORT: ${{ vars.VPS_SSH_PORT || '22' }}
+          DEPLOY_PATH: ${{ vars.VPS_APP_PATH }}
+        run: |
+          set -euo pipefail
+          # Sync the examples checkout into ${DEPLOY_PATH}/examples/, which the
+          # main rsync leaves untouched (/examples/ is in rsync-exclude.txt).
+          # rsync creates the trailing 'examples/' component; ${DEPLOY_PATH}
+          # already exists from the "Ensure ... dirs exist" step. This step owns
+          # examples/ end-to-end, with its own --delete so files removed from the
+          # examples repo are pruned here too — that is the "keep it up to date"
+          # half of the fix.
+          #
+          # Filters (first match wins):
+          #   - .git/.github/.vscode are dev/CI cruft — never ship them.
+          #   - .env.example ships (admins diff it), but real .env* are excluded
+          #     so --delete can't wipe the PHP example's server-side secrets.
+          #   - logs/ cache/ *.log are runtime state the PHP example creates as
+          #     the php-fpm user; excluded so --delete preserves them.
+          rsync \
+            --archive --no-owner --no-group \
+            --compress --human-readable --verbose \
+            --delete --protect-args \
+            --exclude='.git/' \
+            --exclude='.github/' \
+            --exclude='.vscode/' \
+            --include='.env.example' \
+            --exclude='.env' \
+            --exclude='.env.*' \
+            --exclude='logs/' \
+            --exclude='cache/' \
+            --exclude='*.log' \
+            -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
+            examples-src/ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/examples/"
 
       - name: Signal php-fpm reload (apply new translations / code)
         env:


### PR DESCRIPTION
## Summary

`examples.php` serves its **JavaScript / PHP / FullCalendar** demos from `examples/*` paths, but those live in a separate public repo (`Liturgical-Calendar/examples`) wired in locally via a **gitignored symlink** (`examples -> ../examples`). That symlink is absent from the CI checkout, so nothing under `examples/` was ever deployed — every `examples/*` request hit the server's HTML fallback (`200 text/html`), which surfaced as:

- **example=JavaScript**: *"Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of text/html"* — the `<script type="module" src="examples/javascript/main.js">` fetched an HTML page.
- **example=PHP**: an empty body — `include_once('examples/php/index.php')` found nothing.

Verified directly against staging: `examples/javascript/main.js`, `examples/php/script.js`, etc. all return `200 text/html`.

## Change

Deploy the examples repo alongside the frontend:

1. **Checkout examples repo** (`Liturgical-Calendar/examples`, ref `main`) into a sibling `examples-src/` path.
2. **`composer install`** its PHP example (`vendor/` is gitignored there, and the example hard-`die()`s without its own autoloader).
3. **Dedicated rsync step** syncs `examples-src/ -> ${DEPLOY_PATH}/examples/` with its own `--delete` (keeps it up to date), ships `.env.example`, and protects server-managed `.env*`, `logs/`, `cache/` from deletion.
4. Add `/examples/` to `rsync-exclude.txt` so the **main** deploy's `--delete` never wipes the out-of-band directory.

## Notes

- The PHP example needs no dedicated env file: `examples.php` includes `includes/common.php` (frontend env bootstrap) before including the example, and the example inherits the frontend's `$_ENV` (API_PROTOCOL/HOST/PORT/BASE_PATH) via `createImmutable` + `??` fallbacks. Staging picks up the staging API, production the production API.
- Takes effect on the **next deploy** to staging/production; does not retroactively fix the currently-running server.

## Verification

- `deploy.yaml` parses (`yaml.safe_load`).
- rsync dry-run against the real examples repo confirmed: `.env.example` + `vendor/` ship, `.git/.github/.vscode` skipped, extraneous files prune, and pre-existing server `.env*`/`logs/`/`cache/` survive `--delete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed the examples site alongside the main application.
  * Added a dedicated sync step so example content is published independently.

* **Bug Fixes**
  * Prevented the deployed `/examples/` area from being wiped during main deployment updates.
  * Kept runtime files and local secrets out of published example builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->