### PR TITLE
feat(admin-tests): deterministic hidden name + scope-first dialog redesign

### DIFF
--- a/admin-tests.php
+++ b/admin-tests.php
@@ -125,8 +125,49 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                 <div class="modal-body">
                     <div id="testEditorAlerts"></div>
                     <form id="testEditorForm" novalidate>
-                        <!-- Step 1: test type -->
-                        <div class="mb-3">
+                        <!-- Step 1: scope, liturgical event, base date -->
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label class="form-label" for="testScopeType">
+                                    <?php echo htmlspecialchars(_('Scope'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <select class="form-select" id="testScopeType">
+                                    <option value="general_roman_calendar">
+                                        <?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                    </option>
+                                    <option value="national_calendar">
+                                        <?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                    </option>
+                                    <option value="diocesan_calendar">
+                                        <?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                    </option>
+                                </select>
+                                <!-- Static scope display for users whose scope is fixed (single-scope
+                                     editor/admin, or when editing an existing test). -->
+                                <div id="testScopeStatic" class="form-text fw-semibold d-none"></div>
+                                <div id="testScopeIdMount" class="mt-2"></div>
+                            </div>
+                            <div class="col-md-6">
+                                <label class="form-label" for="testEventKey">
+                                    <?php echo htmlspecialchars(_('Liturgical event'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <input type="text" class="form-control" id="testEventKey"
+                                    list="testEventKeyList" required />
+                                <datalist id="testEventKeyList"></datalist>
+                                <!-- Derived, read-only test name (name = event_key + 'Test'). -->
+                                <small id="derivedTestName" class="form-text text-muted"></small>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label" for="baseDate">
+                                    <?php echo htmlspecialchars(_('Base date'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                                </label>
+                                <input type="date" class="form-control" id="baseDate"
+                                    min="1970-01-01" max="2050-12-31" />
+                            </div>
+                        </div>
+
+                        <!-- Step 2: test type -->
+                        <div class="mb-3 mt-3">
                             <label class="form-label fw-bold">
                                 <?php echo htmlspecialchars(_('Test type'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
                             </label>
@@ -154,48 +195,15 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                             </div>
                         </div>
 
-                        <div class="row g-3">
-                            <div class="col-md-6">
-                                <label class="form-label" for="testName">
-                                    <?php echo htmlspecialchars(_('Name'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                </label>
-                                <input type="text" class="form-control" id="testName"
-                                    pattern="^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$" required />
-                            </div>
-                            <div class="col-md-6">
-                                <label class="form-label" for="testScopeType">
-                                    <?php echo htmlspecialchars(_('Scope'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                </label>
-                                <select class="form-select" id="testScopeType">
-                                    <option value="general_roman_calendar">
-                                        <?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                    </option>
-                                    <option value="national_calendar">
-                                        <?php echo htmlspecialchars(_('National Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                    </option>
-                                    <option value="diocesan_calendar">
-                                        <?php echo htmlspecialchars(_('Diocesan Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                    </option>
-                                </select>
-                                <div id="testScopeIdMount" class="mt-2"></div>
-                            </div>
-                            <div class="col-md-6">
-                                <label class="form-label" for="testEventKey">
-                                    <?php echo htmlspecialchars(_('Liturgical event'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                </label>
-                                <input type="text" class="form-control" id="testEventKey"
-                                    list="testEventKeyList" required />
-                                <datalist id="testEventKeyList"></datalist>
-                            </div>
-                            <div class="col-12">
-                                <label class="form-label" for="testDescription">
-                                    <?php echo htmlspecialchars(_('Description'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                </label>
-                                <textarea class="form-control" id="testDescription" rows="2" required></textarea>
-                            </div>
+                        <!-- Step 3: description -->
+                        <div class="mb-3">
+                            <label class="form-label" for="testDescription">
+                                <?php echo htmlspecialchars(_('Description'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                            </label>
+                            <textarea class="form-control" id="testDescription" rows="2" required></textarea>
                         </div>
 
-                        <!-- Step 3: year range -->
+                        <!-- Step 4: year range -->
                         <div class="mt-3">
                             <label class="form-label fw-bold">
                                 <?php echo htmlspecialchars(_('Year range'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
@@ -216,15 +224,6 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                                 <span><span class="legend-chip bg-warning me-1"></span><?php echo htmlspecialchars(_('event not expected'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                                 <span><span class="legend-chip deleted me-1"></span><?php echo htmlspecialchars(_('excluded — click to restore'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
                             </div>
-                        </div>
-
-                        <!-- Step 4: base date -->
-                        <div class="mt-3 col-md-4">
-                            <label class="form-label" for="baseDate">
-                                <?php echo htmlspecialchars(_('Base date'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                            </label>
-                            <input type="date" class="form-control" id="baseDate"
-                                min="1970-01-01" max="2050-12-31" />
                         </div>
 
                         <!-- Step 5: per-year assertions -->
@@ -332,7 +331,9 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                 toggleAssertion:     <?php echo json_encode(_('toggle assertion')); ?>,
                 removeYear:          <?php echo json_encode(_('remove')); ?>,
                 sundayInYear:        <?php echo json_encode(_('In the year %1$s, %2$s falls on a Sunday')); ?>,
-                excludedRestore:     <?php echo json_encode(_('%s excluded — click to restore')); ?>
+                excludedRestore:     <?php echo json_encode(_('%s excluded — click to restore')); ?>,
+                testNameLabel:       <?php echo json_encode(_('Test name:')); ?>,
+                invalidName:         <?php echo json_encode(_('Select a valid liturgical event from the list.')); ?>
             }
         };
     </script>

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -156,14 +156,18 @@ export class AssertionsBuilder {
         return best ? { month: best.month, day: best.day } : null;
     }
 
+    /** Format a month/day as a locale month-name + day, e.g. "July 31". */
+    static #formatMonthDay(month, day, locale) {
+        const d = new Date(Date.UTC(1970, Number(month) - 1, Number(day)));
+        return new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric', timeZone: 'UTC' }).format(d);
+    }
+
     /** Build description text from an event, e.g. "The Memorial of 'X' should fall on July 31". */
     static #describe(event, locale) {
         const grade = event.grade_lcl ?? '';
-        let onDate = 'the expected date';
-        if (event.month && event.day) {
-            const d = new Date(Date.UTC(1970, Number(event.month) - 1, Number(event.day)));
-            onDate = new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric', timeZone: 'UTC' }).format(d);
-        }
+        const onDate = (event.month && event.day)
+            ? AssertionsBuilder.#formatMonthDay(event.month, event.day, locale)
+            : 'the expected date';
         return `The ${grade} of '${event.name}' should fall on ${onDate}`;
     }
 
@@ -246,6 +250,36 @@ export class AssertionsBuilder {
     setExpectedDate(year, iso) {
         const a = this.#find(year);
         if (a) a.expected_value = iso;
+        return this;
+    }
+
+    /**
+     * Re-anchor the whole model to a new base month/day — the effect of the
+     * editor's Base date field changing. Updates baseMonthDay (which drives the
+     * year-grid Sunday overlays), the canonical description's date phrase, and
+     * each assertion's expected_value (dated ones only) plus its suggested text.
+     * The per-year text is rebuilt from the canonical description, matching how
+     * generate()/toggleAssert() keep the sentence in step with assert/date.
+     */
+    rebaseDate({ month, day } = {}) {
+        const m = Number(month);
+        const d = Number(day);
+        if (!m || !d) return this;
+        this.baseMonthDay = { month: m, day: d };
+        const dateStr = AssertionsBuilder.#formatMonthDay(m, d, this.locale);
+        // model.description is the canonical positive form ("...should fall on X").
+        this.model.description = this.model.description.replace(/should fall on .*/, `should fall on ${dateStr}`);
+        const desc = this.model.description;
+        const notDesc = desc.replace('should fall on', 'should not exist on');
+        this.model.assertions.forEach((a) => {
+            if (a.assert === AssertType.EventTypeExact) {
+                a.expected_value = AssertionsBuilder.#expectedValue(a.year, m, d);
+                a.assertion = desc;
+            } else {
+                a.expected_value = null;
+                a.assertion = notDesc;
+            }
+        });
         return this;
     }
 

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -420,8 +420,11 @@ export class AssertionsBuilder {
             dateVal.textContent = this.#formatDate(a.expected_value);
             const editBtn = document.createElement('button');
             editBtn.type = 'button';
-            editBtn.className = `btn btn-xs editDate ms-1${a.expected_value ? ' btn-danger' : ' btn-secondary disabled'}`;
-            editBtn.disabled = !a.expected_value;
+            // Enable date editing for any dated (eventExists) assertion, even when
+            // it has no value yet — e.g. toggled to Exact for a movable feast whose
+            // base date isn't set. Only eventNotExists (no date) disables it.
+            editBtn.className = `btn btn-xs editDate ms-1${notExists ? ' btn-secondary disabled' : ' btn-danger'}`;
+            editBtn.disabled = notExists;
             editBtn.innerHTML = '<i class="fas fa-pen-to-square" aria-hidden="true"></i>';
             dateRow.append(dateLabel, dateVal, editBtn);
             card.appendChild(dateRow);

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -70,6 +70,37 @@ const sampleUntil = {
     ],
 };
 
+describe('rebaseDate', () => {
+    it('re-anchors baseMonthDay, description, dates, and per-year text', () => {
+        const b = new AssertionsBuilder({ locale: 'en-US' }).load(sampleExact);
+        b.rebaseDate({ month: 8, day: 6 });
+        expect(b.baseMonthDay).toEqual({ month: 8, day: 6 });
+        expect(b.model.description).toBe("The Memorial of 'Saint Ignatius of Loyola' should fall on August 6");
+        b.model.assertions.forEach((a) => {
+            expect(a.expected_value).toBe(`${a.year}-08-06T00:00:00+00:00`);
+            expect(a.assertion).toBe("The Memorial of 'Saint Ignatius of Loyola' should fall on August 6");
+        });
+    });
+
+    it('rewrites not-exists assertions to the new date but leaves them value-less', () => {
+        const b = new AssertionsBuilder({ locale: 'en-US' }).load(sampleSince);
+        b.rebaseDate({ month: 8, day: 6 });
+        const notExists = b.model.assertions.find((a) => a.assert === AssertType.EventNotExists);
+        expect(notExists.expected_value).toBeNull();
+        expect(notExists.assertion).toBe("The FEAST of 'Some Feast' should not exist on August 6");
+        const exists = b.model.assertions.find((a) => a.assert === AssertType.EventTypeExact);
+        expect(exists.expected_value).toBe('2026-08-06T00:00:00+00:00');
+        expect(exists.assertion).toBe("The FEAST of 'Some Feast' should fall on August 6");
+    });
+
+    it('ignores an incomplete month/day', () => {
+        const b = new AssertionsBuilder({ locale: 'en-US' }).load(sampleExact);
+        const before = b.serialize();
+        b.rebaseDate({ month: 8 });
+        expect(b.serialize()).toEqual(before);
+    });
+});
+
 describe('load + serialize round-trip', () => {
     it('round-trips an exactCorrespondence test (applies_to + comment preserved)', () => {
         const out = new AssertionsBuilder().load(sampleExact).serialize();

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -101,6 +101,25 @@ describe('rebaseDate', () => {
     });
 });
 
+describe('render date-editor enablement', () => {
+    it('enables the date editor for eventExists assertions (even value-less) and disables it for eventNotExists', () => {
+        const b = new AssertionsBuilder({ locale: 'en-US' });
+        b.model.assertions = [
+            // Dated assertion with no value yet (e.g. toggled to Exact for a
+            // movable feast) — the date editor must still be enabled.
+            new Assertion(2024, null, AssertType.EventTypeExact, 'x'),
+            new Assertion(2025, '2025-07-31T00:00:00+00:00', AssertType.EventTypeExact, 'x'),
+            new Assertion(2026, null, AssertType.EventNotExists, 'x'),
+        ];
+        const container = document.createElement('div');
+        b.render(container);
+        const editButtons = container.querySelectorAll('.assertion-card .editDate');
+        expect(editButtons[0].disabled).toBe(false); // Exact, no value → enabled
+        expect(editButtons[1].disabled).toBe(false); // Exact, valued → enabled
+        expect(editButtons[2].disabled).toBe(true);  // NotExists → disabled
+    });
+});
+
 describe('load + serialize round-trip', () => {
     it('round-trips an exactCorrespondence test (applies_to + comment preserved)', () => {
         const out = new AssertionsBuilder().load(sampleExact).serialize();

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -478,6 +478,10 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
         builder.render(assertionsContainer);
+        // The year-grid chips derive their Sunday overlay/title from
+        // baseMonthDay (via yearDateAttrs), so re-render the grid to recompute
+        // which years land on a Sunday for the new base date.
+        renderYearGrid();
     });
 
     // Year-grid interactions (ported from UnitTestInterface, state-first):

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -468,19 +468,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const v = ev.target.value; // YYYY-MM-DD
         if (!v) return;
         const [, m, d] = v.split('-').map(Number);
-        builder.baseMonthDay = { month: m, day: d };
-        builder.model.assertions.forEach((a) => {
-            if (a.assert === AssertType.EventTypeExact) {
-                builder.setExpectedDate(
-                    a.year,
-                    `${String(a.year).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}T00:00:00+00:00`,
-                );
-            }
-        });
+        // Re-anchor the model to the new base date: the expected dates, the
+        // suggested description, and every per-year assertion's suggested text
+        // all follow from the base month/day.
+        builder.rebaseDate({ month: m, day: d });
+        document.getElementById('testDescription').value = builder.model.description;
         builder.render(assertionsContainer);
-        // The year-grid chips derive their Sunday overlay/title from
-        // baseMonthDay (via yearDateAttrs), so re-render the grid to recompute
-        // which years land on a Sunday for the new base date.
+        // The year-grid chips derive their Sunday overlay/title from baseMonthDay
+        // (via yearDateAttrs), so re-render the grid too.
         renderYearGrid();
     });
 

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -422,6 +422,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (ev.target.closest('.toggleAssert')) {
             builder.toggleAssert(year);
             builder.render(assertionsContainer);
+            // The year chip's "event (not) expected" styling derives from the
+            // assertion's assert type, so re-render the grid to keep it in sync.
+            renderYearGrid();
         } else if (ev.target.closest('.comment')) {
             document.getElementById('commentYear').value = String(year);
             const a = builder.model.assertions.find((x) => x.year === year);

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -396,6 +396,7 @@ document.addEventListener('DOMContentLoaded', () => {
         renderYearGrid();
     }
 
+    document.getElementById('testEventKey').addEventListener('input', updateDerivedName);
     document.getElementById('testEventKey').addEventListener('change', regenerate);
     document.querySelectorAll('input[name="testType"]').forEach((el) => el.addEventListener('change', regenerate));
     document.getElementById('lowerRange').addEventListener('change', regenerate);
@@ -523,6 +524,116 @@ document.addEventListener('DOMContentLoaded', () => {
             sel.appendTo(mount);
         }
     }
+
+    // ---- Deterministic name + scope-constrained controls --------------------
+    // Convention (LitCalTest.json): a test's name is its event_key + 'Test'.
+    const TEST_NAME_RE = /^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$/;
+
+    function derivedName() {
+        const ev = document.getElementById('testEventKey').value.trim();
+        return ev ? `${ev}Test` : '';
+    }
+    function updateDerivedName() {
+        const name = derivedName();
+        document.getElementById('derivedTestName').textContent =
+            name ? `${i18n.testNameLabel} ${name}` : '';
+    }
+
+    function scopeChoiceLabel(type, id) {
+        if (type === 'national_calendar') return `${i18n.nationalCalendar}: ${id}`;
+        if (type === 'diocesan_calendar') return `${i18n.diocesanCalendar}: ${id}`;
+        return i18n.generalRomanCalendar;
+    }
+
+    /** Deduped scopes the current non-admin user may author tests for. */
+    function authorizedScopeChoices() {
+        const seen = new Set();
+        const choices = [];
+        [...(state.scopes.editor || []), ...(state.scopes.admin || [])].forEach((s) => {
+            const key = `${s.object_type}:${s.object_id}`;
+            if (seen.has(key)) return;
+            seen.add(key);
+            const type = s.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
+                : s.object_type === 'national_calendar_test' ? 'national_calendar'
+                    : 'general_roman_calendar';
+            choices.push({ type, id: s.object_id });
+        });
+        return choices;
+    }
+
+    // Configure the scope UI to one of three modes and guarantee that afterwards
+    // #testScopeType (value) and, for scoped types, #testScopeId (value) reflect
+    // the selection, so selectedScope() keeps working unchanged:
+    //   locked (edit)   → static text, scope pinned to the test's own scope
+    //   global admin    → full picker (type select + CalendarSelect)
+    //   one authorized  → static text, pinned to that single scope
+    //   many authorized → a select limited to those scopes
+    async function renderScopeControl(locked) {
+        const typeSel = document.getElementById('testScopeType');
+        const mount = document.getElementById('testScopeIdMount');
+        const staticEl = document.getElementById('testScopeStatic');
+        mount.innerHTML = '';
+        staticEl.textContent = '';
+        staticEl.classList.add('d-none');
+
+        const pin = (type, id) => {
+            typeSel.value = type;
+            typeSel.classList.add('d-none');
+            typeSel.disabled = true;
+            staticEl.textContent = scopeChoiceLabel(type, id);
+            staticEl.classList.remove('d-none');
+            if (type !== 'general_roman_calendar' && id) {
+                const hid = document.createElement('input');
+                hid.type = 'hidden';
+                hid.id = 'testScopeId';
+                hid.value = id;
+                mount.appendChild(hid);
+            }
+        };
+
+        if (locked) { pin(locked.type, locked.id); return; }
+
+        if (state.scopes.is_global_admin) {
+            typeSel.classList.remove('d-none');
+            typeSel.disabled = false;
+            await syncScopeIdField();
+            return;
+        }
+
+        const choices = authorizedScopeChoices();
+        if (choices.length <= 1) {
+            if (choices[0]) pin(choices[0].type, choices[0].id);
+            return;
+        }
+
+        // Multiple authorized scopes → a select limited to them. The pre-existing
+        // #testScopeIdMount 'change' listener reloads the events catalog; this
+        // listener only syncs the hidden scope fields, and being on the event
+        // target it fires before the mount's bubble-phase listener.
+        typeSel.classList.add('d-none');
+        typeSel.disabled = true;
+        const sel = document.createElement('select');
+        sel.className = 'form-select';
+        sel.id = 'scopeChoice';
+        choices.forEach((c, i) => {
+            const opt = document.createElement('option');
+            opt.value = String(i);
+            opt.textContent = scopeChoiceLabel(c.type, c.id);
+            sel.appendChild(opt);
+        });
+        const hid = document.createElement('input');
+        hid.type = 'hidden';
+        hid.id = 'testScopeId';
+        const applyChoice = () => {
+            const c = choices[Number(sel.value)] || choices[0];
+            typeSel.value = c.type;
+            hid.value = c.type === 'general_roman_calendar' ? '' : c.id;
+        };
+        sel.addEventListener('change', () => { applyChoice(); updateDerivedName(); });
+        mount.appendChild(sel);
+        mount.appendChild(hid);
+        applyChoice();
+    }
     // Reload the /events datalist for the currently selected scope, then rebuild
     // the assertions. Used whenever the scope changes, since national/diocesan
     // calendars expose events the General Roman list does not.
@@ -542,20 +653,17 @@ document.addEventListener('DOMContentLoaded', () => {
     async function openEditor(test) {
         state.editing = test ? test.name : null;
         document.getElementById('testEditorAlerts').innerHTML = '';
-        const nameEl = document.getElementById('testName');
+        const eventEl = document.getElementById('testEventKey');
         if (test) {
             builder.load(test);
-            nameEl.value = test.name;
-            nameEl.setAttribute('readonly', '');
             const typeRadio = document.querySelector(`input[name="testType"][value="${test.test_type}"]`);
             if (typeRadio) typeRadio.checked = true;
-            document.getElementById('testEventKey').value = test.event_key;
+            eventEl.value = test.event_key;
+            // Scope + event are the test's identity (name = event_key + 'Test'),
+            // so the event is read-only on edit. Scope is locked below.
+            eventEl.setAttribute('readonly', '');
+            updateDerivedName();
             document.getElementById('testDescription').value = test.description;
-            const scope = deriveScope(test.applies_to);
-            const typeSel = document.getElementById('testScopeType');
-            typeSel.value = scope.object_type === 'national_calendar_test' ? 'national_calendar'
-                : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
-                : 'general_roman_calendar';
             // Fix 4: Seed slider from loaded test assertions before any slider change fires
             const years = test.assertions.map((a) => a.year);
             if (years.length) {
@@ -603,26 +711,28 @@ document.addEventListener('DOMContentLoaded', () => {
                 .catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
         } else {
             builder.load({ name: '', event_key: '', description: '', test_type: TestType.ExactCorrespondence, assertions: [] });
-            nameEl.value = '';
-            nameEl.removeAttribute('readonly');
             document.getElementById('tt-exact').checked = true;
-            document.getElementById('testEventKey').value = '';
+            eventEl.value = '';
+            eventEl.removeAttribute('readonly');
+            updateDerivedName();
             document.getElementById('testDescription').value = '';
             document.getElementById('testScopeType').value = 'general_roman_calendar';
             assertionsContainer.innerHTML = '';
             loadEvents(null).catch((err) => showModalAlert(editorModalEl, 'danger', err.message ?? i18n.failedToLoad));
         }
-        await syncScopeIdField();
+        // Scope UI: locked to the test's own scope when editing; otherwise
+        // constrained to the user's permissions (full picker for global admins).
+        let lockedScope = null;
         if (test) {
-            // Preselect the loaded test's calendar in the freshly-mounted select so
-            // selectedScope() round-trips applies_to instead of silently rescoping
-            // the test to General Roman (or 403ing a scoped editor).
             const scope = deriveScope(test.applies_to);
-            const idEl = document.getElementById('testScopeId');
-            if (idEl && scope.object_type !== 'general_roman_calendar_test') {
-                idEl.value = scope.object_id;
-            }
+            lockedScope = {
+                type: scope.object_type === 'national_calendar_test' ? 'national_calendar'
+                    : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
+                        : 'general_roman_calendar',
+                id: scope.object_id,
+            };
         }
+        await renderScopeControl(lockedScope);
         editorModal.show();
     }
 
@@ -637,9 +747,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('saveTestBtn').addEventListener('click', async () => {
         const btn = document.getElementById('saveTestBtn');
-        const nameEl = document.getElementById('testName');
-        if (!nameEl.checkValidity() || !document.getElementById('testEventKey').value) {
-            showModalAlert(editorModalEl, 'warning', i18n.requiredFields);
+        const eventKey = document.getElementById('testEventKey').value.trim();
+        // Name is derived from the event key, never typed (schema convention
+        // name = event_key + 'Test'). On edit it's the immutable identifier.
+        const name = state.editing || `${eventKey}Test`;
+        const hasDescription = document.getElementById('testDescription').value.trim() !== '';
+        if (!eventKey || !hasDescription || !TEST_NAME_RE.test(name)) {
+            const msg = eventKey && !TEST_NAME_RE.test(name) ? i18n.invalidName : i18n.requiredFields;
+            showModalAlert(editorModalEl, 'warning', msg);
             return;
         }
         // undefined = scoped type without an ID picked yet → when editing, keep
@@ -650,8 +765,8 @@ document.addEventListener('DOMContentLoaded', () => {
             ? (state.editing ? builder.model.applies_to : null)
             : chosen;
         builder.setMeta({
-            name: nameEl.value,
-            event_key: document.getElementById('testEventKey').value,
+            name,
+            event_key: eventKey,
             description: document.getElementById('testDescription').value,
             test_type: selectedTestType(),
             applies_to: scopePayload,

--- a/docs/superpowers/specs/2026-07-07-admin-tests-dialog-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-07-admin-tests-dialog-redesign-design.md
@@ -1,0 +1,127 @@
+# Test Definition dialog redesign — deterministic name + field reorder
+
+**Date:** 2026-07-07
+**Component:** `admin-tests.php` (editor modal markup) + `assets/js/admin-tests.js` (behavior)
+**Status:** Approved design
+
+## Problem
+
+The Test Definition editor exposes a free-text **Name** field, even though a test's
+name is fully determined by convention. The field order also doesn't match the
+natural authoring flow, and the scope is a free picker for every user regardless of
+their actual permissions.
+
+## Naming convention (authority)
+
+The canonical rule, defined by the JSON schema `LitCalTest.json` and used by the
+UnitTestInterface app, is:
+
+```text
+name = event_key + 'Test'
+```
+
+Schema pattern (`LitCalTest.json`, name property):
+
+```text
+^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$
+```
+
+Diocesan/national event keys already embed their scope prefix (e.g.
+`rotter_nl_HLaurentius…`), so `event_key + 'Test'` is correct for every scope. The
+scope itself is carried separately in `applies_to`, not encoded into the name a
+second time.
+
+## Goals
+
+1. The Name is **derived**, never typed. Remove the visible Name input.
+2. Reorder the editor fields to match the authoring flow.
+3. Constrain the Scope field to the user's actual permissions.
+4. Lock the identity-bearing fields (scope + event) when editing an existing test.
+
+Non-goals: changing the API, the assertions builder logic, or the events catalog
+endpoints. The scope→events reactivity already exists and is retained.
+
+## Design
+
+### 1. Name — derived and hidden
+
+- Remove the Name label + `#testName` input from the editor modal.
+- Under the **Liturgical event** field, show read-only helper text: the derived
+  test name (e.g. `Test name: NativityJohnBaptistTest`), updated whenever the
+  selected event changes. This is display-only, not a form control.
+- On **create** save: `name = eventKeyInput.value + 'Test'`, replacing the current
+  `name: nameEl.value` in the save handler (`admin-tests.js:657`).
+- On **edit** save: name is unchanged — it is the identifier (`PATCH /tests/{name}`).
+- Validation (`admin-tests.js:645`) no longer references the name input. It
+  requires: an event key is selected, a description is present, and — as a guard
+  against a hand-typed event key not in the catalog — the derived name matches the
+  schema regex above.
+
+### 2. Field order
+
+New order in the editor modal markup:
+
+1. **Scope**
+2. **Liturgical event** (with the derived-name helper text beneath it)
+3. **Base date**
+4. **Test type** (governs the suggested description and the year-grid chip behavior)
+5. **Description**
+6. **Year range** (slider + chips + legend)
+7. **Per-year assertions**
+
+JS references elements by `id`, so reordering the markup does not affect behavior;
+IDs are unchanged.
+
+### 3. Scope RBAC (Option 1)
+
+Scopes come from `GET /auth/test-scopes` as
+`{ is_global_admin, editor: [{object_type, object_id}], admin: [...] }`.
+
+- **Global admin** → current full picker (scope-type select + `CalendarSelect`).
+- **Non-global admin** → authorized scopes = `editor ∪ admin` (deduped):
+  - **Exactly one** authorized scope → render it as **static read-only text**
+    (e.g. "Diocese: rotter_nl"), pre-set as the scope. No control.
+  - **Several** → a `<select>` limited to just those authorized scopes (not the
+    full calendar catalog).
+
+The selected scope still feeds `selectedScope()` / the save payload's `applies_to`.
+
+### 4. Edit-mode locking
+
+When editing an existing test, **Scope** and **Liturgical event** are read-only
+(so the derived name cannot drift). Base date, Test type, Description, year range,
+and assertions remain editable.
+
+### 5. Retained behavior
+
+`reloadEventsThenRegenerate` (admin-tests.js:533-544) already reloads the events
+datalist when the scope type or scope id changes. This is kept; only its position
+in the DOM moves.
+
+## Testing (`e2e/admin-tests.spec.ts`)
+
+Existing tests that must be migrated (they reference the removed `#testName`):
+
+- "create flow submits a PUT…" — remove the `#testName` fill; assert the PUT body
+  `name` equals `event_key + 'Test'` (derived), not a typed value.
+- "edit flow renders name read-only…" — rename to reflect the new invariant: assert
+  Scope and Liturgical event are read-only on edit (the name field no longer exists).
+
+New tests:
+
+- Create: selecting an event sets the derived-name helper text and the PUT body name.
+- Scope RBAC: a single-scope non-admin sees static scope text (no select); a
+  multi-scope non-admin sees a select limited to their scopes.
+- Field order: assert the DOM order of the labelled fields.
+
+## i18n
+
+Removing the Name label. New strings ("Test name:" helper, any scope static-text
+label) are added as `_()` calls and flow through the normal gettext extraction →
+Weblate; no manual `.po` edits.
+
+## Risk / rollback
+
+Markup reorder + JS-localized behavior change, all behind the existing editor modal.
+Reversible by reverting the two files. The API contract is unchanged (still
+`PUT /tests` / `PATCH /tests/{name}` with the same schema-shaped body).

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -234,22 +234,29 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(span2005.locator('.removeYear')).toHaveCount(1);
     });
 
-    test('changing the base date recalculates the Sunday chips', async ({ page }) => {
+    test('changing the base date re-anchors Sunday chips, description, and assertions', async ({ page }) => {
         await openVariableEditor(page, 'StIgnatiusOfLoyola');
 
-        // Default base date is 07-31: 2005-07-31 is a Sunday, 2006-07-31 is not.
+        // Default base date is 07-31: 2005-07-31 is a Sunday, 2006-07-31 is not,
+        // and the suggested text reads "... July 31".
         const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
         const span2006 = page.locator('#yearGrid .testYearSpan.year-2006');
         await expect(span2005).toHaveClass(/sunday/);
         await expect(span2006).not.toHaveClass(/sunday/);
+        await expect(page.locator('#testDescription')).toHaveValue(/July 31/);
 
         // Move the base date to 08-06 (only month/day matter): 2005-08-06 is a
-        // Saturday and 2006-08-06 is a Sunday, so the highlight must flip.
+        // Saturday and 2006-08-06 is a Sunday, so the highlight must flip, and the
+        // suggested description + each per-year card's assertion re-anchor to 08-06.
         await page.locator('#baseDate').fill('2005-08-06');
         await page.locator('#baseDate').dispatchEvent('change');
 
         await expect(span2005).not.toHaveClass(/sunday/);
         await expect(span2006).toHaveClass(/sunday/);
+        await expect(page.locator('#testDescription')).toHaveValue(/August 6/);
+        const card2005Text = page.locator('.assertion-card[data-year="2005"] .assertionText');
+        await expect(card2005Text).toHaveValue(/August 6/);
+        await expect(card2005Text).not.toHaveValue(/July 31/);
     });
 
     test('exclude collapses to the striped bar and restore brings the card back', async ({ page }) => {

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -277,6 +277,19 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(editBtn).toBeEnabled();
     });
 
+    test('toggling a per-year card assert updates the year chip styling', async ({ page }) => {
+        await openVariableEditor(page, 'StIgnatiusOfLoyola');
+        const chip2005 = page.locator('#yearGrid .testYearSpan.year-2005');
+        // Exact assertion → "event expected" (no not-expected warning background).
+        await expect(chip2005).not.toHaveClass(/bg-warning/);
+        // Toggle the CARD's assert to eventNotExists → the chip must reflect it.
+        await page.locator('.assertion-card[data-year="2005"] .toggleAssert').dispatchEvent('click');
+        await expect(chip2005).toHaveClass(/bg-warning/);
+        // Toggle back to eventExists → the warning background clears.
+        await page.locator('.assertion-card[data-year="2005"] .toggleAssert').dispatchEvent('click');
+        await expect(chip2005).not.toHaveClass(/bg-warning/);
+    });
+
     test('exclude collapses to the striped bar and restore brings the card back', async ({ page }) => {
         await openVariableEditor(page, 'StIgnatiusOfLoyola');
 

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -234,6 +234,24 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(span2005.locator('.removeYear')).toHaveCount(1);
     });
 
+    test('changing the base date recalculates the Sunday chips', async ({ page }) => {
+        await openVariableEditor(page, 'StIgnatiusOfLoyola');
+
+        // Default base date is 07-31: 2005-07-31 is a Sunday, 2006-07-31 is not.
+        const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
+        const span2006 = page.locator('#yearGrid .testYearSpan.year-2006');
+        await expect(span2005).toHaveClass(/sunday/);
+        await expect(span2006).not.toHaveClass(/sunday/);
+
+        // Move the base date to 08-06 (only month/day matter): 2005-08-06 is a
+        // Saturday and 2006-08-06 is a Sunday, so the highlight must flip.
+        await page.locator('#baseDate').fill('2005-08-06');
+        await page.locator('#baseDate').dispatchEvent('change');
+
+        await expect(span2005).not.toHaveClass(/sunday/);
+        await expect(span2006).toHaveClass(/sunday/);
+    });
+
     test('exclude collapses to the striped bar and restore brings the card back', async ({ page }) => {
         await openVariableEditor(page, 'StIgnatiusOfLoyola');
 

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -75,8 +75,11 @@ test.describe('admin-tests editor (stubbed)', () => {
         await page.goto('/admin-tests.php');
         await page.locator('#createTestBtn').click();
         await page.locator('#tt-exact').check({ force: true });
-        await page.locator('#testName').fill('StIgnatiusOfLoyolaTest');
+        // No Name input exists — the name is derived from the event key.
+        await expect(page.locator('#testName')).toHaveCount(0);
         await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('input');
+        await expect(page.locator('#derivedTestName')).toContainText('StIgnatiusOfLoyolaTest');
         await page.locator('#testEventKey').dispatchEvent('change');
         await page.locator('#saveTestBtn').click();
         await expect.poll(() => putBody && putBody['name']).toBe('StIgnatiusOfLoyolaTest');
@@ -85,7 +88,7 @@ test.describe('admin-tests editor (stubbed)', () => {
         expect((putBody!['assertions'] as Array<{ assert: string }>)[0].assert).toBe('eventExists AND hasExpectedDate');
     });
 
-    test('edit flow renders name read-only and submits PATCH', async ({ page }) => {
+    test('edit flow locks scope + event and submits PATCH', async ({ page }) => {
         await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
         let patched = false;
         let patchBody: Record<string, unknown> | null = null;
@@ -99,10 +102,75 @@ test.describe('admin-tests editor (stubbed)', () => {
         });
         await page.goto('/admin-tests.php');
         await page.locator('tr', { hasText: 'UsaNationalTest' }).getByRole('button', { name: 'Edit' }).click();
-        await expect(page.locator('#testName')).toHaveAttribute('readonly', '');
+        // Name field is gone; scope + event are the locked identity of the test.
+        await expect(page.locator('#testName')).toHaveCount(0);
+        await expect(page.locator('#testEventKey')).toHaveAttribute('readonly', '');
+        await expect(page.locator('#testScopeStatic')).toContainText('USA');
+        await expect(page.locator('#testScopeType')).toBeHidden();
         await page.locator('#saveTestBtn').click();
         await expect.poll(() => patched).toBe(true);
         expect(patchBody!.applies_to).toEqual({ national_calendar: 'USA' });
+        expect(patchBody!.name).toBe('UsaNationalTest');
+    });
+});
+
+test.describe('admin-tests scope RBAC (stubbed)', () => {
+    test('single-scope editor: scope is static text (no picker), PUT carries it', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: false, editor: [{ object_type: 'national_calendar_test', object_id: 'USA' }], admin: [] });
+        let putBody: Record<string, unknown> | null = null;
+        await page.route('**/tests', (r: Route) => {
+            if (r.request().method() === 'PUT') { putBody = r.request().postDataJSON() as Record<string, unknown>; return r.fulfill({ json: {} }); }
+            return r.fulfill({ json: sampleTests });
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        // One authorized scope → static text, no scope-type select, no choice select.
+        await expect(page.locator('#testScopeStatic')).toContainText('USA');
+        await expect(page.locator('#testScopeType')).toBeHidden();
+        await expect(page.locator('#scopeChoice')).toHaveCount(0);
+        await page.locator('#tt-exact').check({ force: true });
+        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('change');
+        await page.locator('#saveTestBtn').click();
+        await expect.poll(() => putBody && putBody['applies_to']).toEqual({ national_calendar: 'USA' });
+    });
+
+    test('multi-scope editor: a select limited to the authorized scopes', async ({ page }) => {
+        await stubEditor(page, {
+            is_global_admin: false,
+            editor: [{ object_type: 'national_calendar_test', object_id: 'USA' }],
+            admin: [{ object_type: 'diocesan_calendar_test', object_id: 'romamo_it' }],
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        // Several authorized scopes → a limited <select>, not static text or the full picker.
+        await expect(page.locator('#scopeChoice')).toBeVisible();
+        await expect(page.locator('#testScopeType')).toBeHidden();
+        await expect(page.locator('#scopeChoice option')).toHaveCount(2);
+        await expect(page.locator('#scopeChoice')).toContainText('USA');
+        await expect(page.locator('#scopeChoice')).toContainText('romamo_it');
+    });
+
+    test('editor fields follow the intended document order', async ({ page }) => {
+        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        // Scope → event → base date → test type → description → year grid → assertions.
+        const inOrder = await page.evaluate(() => {
+            const ids = ['testScopeType', 'testEventKey', 'baseDate', 'testTypeGroup', 'testDescription', 'yearGrid', 'assertionsContainer'];
+            const els = ids.map((id) => document.getElementById(id));
+            for (let i = 1; i < els.length; i++) {
+                const prev = els[i - 1];
+                const cur = els[i];
+                if (!prev || !cur) return false;
+                if (!(prev.compareDocumentPosition(cur) & Node.DOCUMENT_POSITION_FOLLOWING)) return false;
+            }
+            return true;
+        });
+        expect(inOrder).toBe(true);
     });
 });
 

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -259,6 +259,24 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(card2005Text).not.toHaveValue(/July 31/);
     });
 
+    test('toggling a dateless event assertion to Exact enables the date editor', async ({ page }) => {
+        await stub(page, { is_global_admin: true, editor: [], admin: [] });
+        // Event catalog whose event has NO fixed month/day (a movable feast).
+        await page.route('**/events**', (r: Route) => r.fulfill({ json: { litcal_events: [
+            { event_key: 'MovableFeastX', name: 'Movable Feast X', grade: 4, grade_lcl: 'Feast' },
+        ] } }));
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await expect(page.locator('#testEditorModal')).toBeVisible();
+        await page.locator('label[for="tt-variable"]').click();
+        await page.locator('#testEventKey').fill('MovableFeastX');
+        await page.locator('#testEventKey').dispatchEvent('change');
+        const editBtn = page.locator('.assertion-card[data-year="2005"] .editDate');
+        await expect(editBtn).toBeDisabled();
+        await page.locator('.assertion-card[data-year="2005"] .toggleAssert').dispatchEvent('click');
+        await expect(editBtn).toBeEnabled();
+    });
+
     test('exclude collapses to the striped bar and restore brings the card back', async ({ page }) => {
         await openVariableEditor(page, 'StIgnatiusOfLoyola');
 

--- a/e2e/rbac/13-admin-tests-crud.spec.ts
+++ b/e2e/rbac/13-admin-tests-crud.spec.ts
@@ -38,8 +38,10 @@ import { oidcLogin } from './support/seed';
  *  already references `national_calendar_test:IT`, keeping harness coverage consistent. */
 const NATION          = 'IT';
 
-/** Test name satisfying the API schema: `^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$` */
-const TEST_NAME       = 'PlaywrightScopedNationalTest';
+/** Derived test name. The editor computes name = event_key + 'Test' (it is never
+ *  typed), so this MUST equal `${EVENT_KEY}Test`. Also satisfies the API schema
+ *  `^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$`. */
+const TEST_NAME       = 'StIgnatiusLoyolaTest';
 
 /** Event key present in the General Roman Calendar (and therefore in every national
  *  calendar that extends it). Avoids having to seed national-specific events.
@@ -157,13 +159,12 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
             // Open the create modal.
             await tei.page.locator('#createTestBtn').click();
             await tei.page.locator('#tt-exact').check({ force: true });
-            await tei.page.locator('#testName').fill(TEST_NAME);
 
-            // Select national_calendar scope. syncScopeIdField() asynchronously mounts
-            // a CalendarSelect with id="testScopeId" — wait for it before selecting.
-            await tei.page.locator('#testScopeType').selectOption('national_calendar');
-            await expect(tei.page.locator('#testScopeId')).toBeVisible();
-            await tei.page.locator('#testScopeId').selectOption(NATION);
+            // Scope is fixed for a single-scope editor: it renders as read-only static
+            // text (National Calendar: IT), pre-set — there is no scope-type/scope-id
+            // picker to choose, and no Name field (the name is derived).
+            await expect(tei.page.locator('#testScopeStatic')).toContainText(NATION);
+            await expect(tei.page.locator('#testName')).toHaveCount(0);
 
             // Fill the event key and dispatch the change event (triggers datalist reload).
             await tei.page.locator('#testEventKey').fill(EVENT_KEY);
@@ -171,8 +172,10 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
 
             // The editor auto-fills the description once the event key matches the
             // loaded /events catalog — assert it BEFORE saving so a key/catalog
-            // mismatch fails here (the true cause) rather than at the row check.
+            // mismatch fails here (the true cause) rather than at the row check. The
+            // derived name (event_key + 'Test') is shown read-only under the field.
             await expect(tei.page.locator('#testDescription')).not.toHaveValue('');
+            await expect(tei.page.locator('#derivedTestName')).toContainText(TEST_NAME);
 
             // Save → expect the new row to appear in the table.
             await tei.page.locator('#saveTestBtn').click();


### PR DESCRIPTION
## Summary

Redesigns the Test Definition editor per the approved spec (`docs/superpowers/specs/2026-07-07-admin-tests-dialog-redesign-design.md`), plus two base-date behavior fixes.

### Deterministic, hidden name
The Name input is removed; the name is derived as `event_key + 'Test'` (the `LitCalTest.json` convention, pattern `^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$`) and shown read-only as helper text under the Liturgical event field. On edit it's the immutable identifier used in `PATCH /tests/{name}`.

### Reordered dialog
Scope → Liturgical event → Base date → Test type → Description → Year range (slider/chips/legend) → Per-year assertions.

### Scope constrained to permissions
Global admins get the full picker; a non-admin with exactly one authorized scope sees static text; several scopes render a select limited to them (keys off `/auth/test-scopes`, consistent with row gating). Editing locks Scope + Liturgical event so the derived name can't drift.

### Base-date behavior (two fixes folded in)
- Changing the base date now recalculates the year-grid **Sunday chips** (`renderYearGrid()` was missing from the handler).
- New `AssertionsBuilder.rebaseDate()` re-anchors the suggested **Description** and every per-year card's **assertion text** (plus expected dates) to the new base month/day.

## Verification
- vitest **43/43** (incl. 3 new `rebaseDate` cases), admin-tests e2e **15/15** against the docker stack, plus eslint / tsc / phpcs / parallel-lint.
- New i18n strings flow through gettext → Weblate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)