### PR TITLE
fix(api): route server-side API calls through API_INTERNAL_URL

### DIFF
--- a/decrees.php
+++ b/decrees.php
@@ -27,14 +27,14 @@ $RowActionTitle = [
 $apiClient = new ApiClient($i18n->LOCALE);
 
 try {
-    $decreesData   = $apiClient->fetchJsonWithKey($apiConfig->decreesUrl, 'litcal_decrees');
+    $decreesData   = $apiClient->fetchJsonWithKey($apiConfig->toInternal($apiConfig->decreesUrl), 'litcal_decrees');
     $LitCalDecrees = $decreesData['litcal_decrees'];
 } catch (\RuntimeException $e) {
     die('Error fetching decrees from API: ' . $e->getMessage());
 }
 
 try {
-    $eventsData                = $apiClient->fetchJsonWithKey($apiConfig->eventsUrl, 'litcal_events');
+    $eventsData                = $apiClient->fetchJsonWithKey($apiConfig->toInternal($apiConfig->eventsUrl), 'litcal_events');
     $LiturgicalEventCollection = $eventsData['litcal_events'];
 } catch (\RuntimeException $e) {
     die('Error fetching events from API: ' . $e->getMessage());

--- a/easter.php
+++ b/easter.php
@@ -48,7 +48,7 @@ $apiClient = new ApiClient($currentLocale);
 
 try {
     $responseData  = $apiClient->fetchJsonWithKey(
-        $apiConfig->dateOfEasterUrl . '?locale=' . $currentLocale,
+        $apiConfig->toInternal($apiConfig->dateOfEasterUrl) . '?locale=' . $currentLocale,
         'litcal_easter'
     );
     $DatesOfEaster = $responseData['litcal_easter'];

--- a/extending.php
+++ b/extending.php
@@ -43,14 +43,14 @@ $c = new Collator($i18n->LOCALE);
 $apiClient = new ApiClient($i18n->LOCALE);
 
 try {
-    $metadataJson   = $apiClient->fetchJsonWithKey($apiConfig->metadataUrl, 'litcal_metadata');
+    $metadataJson   = $apiClient->fetchJsonWithKey($apiConfig->toInternal($apiConfig->metadataUrl), 'litcal_metadata');
     $LitCalMetadata = $metadataJson['litcal_metadata'];
 } catch (\RuntimeException $e) {
     die('Error fetching metadata from API: ' . $e->getMessage());
 }
 
 try {
-    $litEventsJson             = $apiClient->fetchJsonWithKey($apiConfig->eventsUrl, 'litcal_events');
+    $litEventsJson             = $apiClient->fetchJsonWithKey($apiConfig->toInternal($apiConfig->eventsUrl), 'litcal_events');
     $LiturgicalEventCollection = $litEventsJson['litcal_events'];
 } catch (\RuntimeException $e) {
     die('Error fetching events from API: ' . $e->getMessage());

--- a/includes/common.php
+++ b/includes/common.php
@@ -63,6 +63,17 @@ $_ENV['ACCURACY_TESTS_URL'] = $_ENV['ACCURACY_TESTS_URL'] ?? 'https://litcal-tes
 $apiPort    = !empty($_ENV['API_PORT']) ? ":{$_ENV['API_PORT']}" : '';
 $apiBaseUrl = rtrim("{$_ENV['API_PROTOCOL']}://{$_ENV['API_HOST']}{$apiPort}{$_ENV['API_BASE_PATH']}", '/');
 
+// Server-side (PHP) base API URL. The browser-facing $apiBaseUrl above uses
+// API_HOST (typically 'localhost'), which is not reachable from inside a
+// container; when API_INTERNAL_URL is set (e.g. http://litcal-api:8000 in the
+// Docker network) it must win for server-side requests. A no-op otherwise, so
+// standalone/production behaviour is unchanged. Mirrors AuthHelper's use of
+// API_INTERNAL_URL for its own server-side calls.
+$apiInternalUrl     = $_ENV['API_INTERNAL_URL'] ?? getenv('API_INTERNAL_URL');
+$apiInternalBaseUrl = ( is_string($apiInternalUrl) && $apiInternalUrl !== '' )
+    ? rtrim($apiInternalUrl . $_ENV['API_BASE_PATH'], '/')
+    : $apiBaseUrl;
+
 // ============================================================================
 // Security Headers - Hybrid Approach (nginx + PHP)
 // ============================================================================
@@ -182,7 +193,7 @@ if (file_exists($ghReleaseCacheFile)) {
 }
 
 // Initialize API configuration (singleton)
-$apiConfig = \LiturgicalCalendar\Frontend\ApiConfig::getInstance($apiBaseUrl);
+$apiConfig = \LiturgicalCalendar\Frontend\ApiConfig::getInstance($apiBaseUrl, $apiInternalBaseUrl);
 
 // Initialize Auth helper (singleton) - validates JWT from HttpOnly cookie
 // This enables server-side auth detection, avoiding UI flash on page load
@@ -323,6 +334,6 @@ $httpClient = HttpClientFactory::createProductionClient(
 
 // 4. Initialize ApiClient Singleton
 $apiClient = ApiClient::getInstance([
-    'apiUrl'     => $apiConfig->apiBaseUrl,
+    'apiUrl'     => $apiConfig->internalBaseUrl,
     'httpClient' => $httpClient
 ]);

--- a/missals-editor.php
+++ b/missals-editor.php
@@ -37,7 +37,7 @@ $messages = array_merge($messages, [
 $apiClient = new ApiClient($i18n->LOCALE);
 
 try {
-    $MissalData = $apiClient->fetchJson($apiConfig->missalsUrl . '/EDITIO_TYPICA_1970');
+    $MissalData = $apiClient->fetchJson($apiConfig->toInternal($apiConfig->missalsUrl) . '/EDITIO_TYPICA_1970');
 } catch (\RuntimeException $e) {
     die('Error fetching missals from API: ' . $e->getMessage());
 }
@@ -51,7 +51,7 @@ if (empty($MissalData) || !is_array($firstMissalRecord)) {
 $thh = array_values(array_filter(array_keys($firstMissalRecord), fn($key) => $key !== 'calendar'));
 
 try {
-    $eventsData                = $apiClient->fetchJsonWithKey($apiConfig->eventsUrl, 'litcal_events');
+    $eventsData                = $apiClient->fetchJsonWithKey($apiConfig->toInternal($apiConfig->eventsUrl), 'litcal_events');
     $LiturgicalEventCollection = $eventsData['litcal_events'];
 } catch (\RuntimeException $e) {
     die('Error fetching events from API: ' . $e->getMessage());

--- a/src/ApiConfig.php
+++ b/src/ApiConfig.php
@@ -13,6 +13,14 @@ class ApiConfig
     private static ?self $instance = null;
 
     public readonly string $apiBaseUrl;
+    /**
+     * Base URL for server-side (PHP) requests. Equal to $apiBaseUrl unless an
+     * internal URL is configured (e.g. inside a Docker network, where the
+     * browser-facing host 'localhost' is not reachable from the container).
+     * The *Url properties below stay browser-facing (they are emitted to JS and
+     * to user-facing links); use toInternal() to map one for a server-side call.
+     */
+    public readonly string $internalBaseUrl;
     public readonly string $dateOfEasterUrl;
     public readonly string $calendarUrl;
     public readonly string $metadataUrl;
@@ -23,9 +31,10 @@ class ApiConfig
     public readonly string $regionalDataUrl;
     public readonly string $calSubscriptionUrl;
 
-    private function __construct(string $apiBaseUrl)
+    private function __construct(string $apiBaseUrl, ?string $internalBaseUrl = null)
     {
         $this->apiBaseUrl         = rtrim($apiBaseUrl, '/');
+        $this->internalBaseUrl    = rtrim($internalBaseUrl ?? $apiBaseUrl, '/');
         $this->dateOfEasterUrl    = "{$this->apiBaseUrl}/easter";
         $this->calendarUrl        = "{$this->apiBaseUrl}/calendar";
         $this->metadataUrl        = "{$this->apiBaseUrl}/calendars";
@@ -38,6 +47,25 @@ class ApiConfig
     }
 
     /**
+     * Rewrite a browser-facing endpoint URL (one of the *Url properties, built
+     * from $apiBaseUrl) to its internal equivalent for a server-side request.
+     * A no-op when no internal URL is configured.
+     *
+     * @param string $url A URL that begins with $apiBaseUrl.
+     * @return string The same URL rebased onto $internalBaseUrl.
+     */
+    public function toInternal(string $url): string
+    {
+        if ($this->internalBaseUrl === $this->apiBaseUrl) {
+            return $url;
+        }
+        if (str_starts_with($url, $this->apiBaseUrl)) {
+            return $this->internalBaseUrl . substr($url, strlen($this->apiBaseUrl));
+        }
+        return $url;
+    }
+
+    /**
      * Get the singleton instance
      *
      * IMPORTANT: The first non-null $apiBaseUrl provided wins. Subsequent calls
@@ -46,10 +74,11 @@ class ApiConfig
      * To reconfigure, call reset() first (test environments only).
      *
      * @param string|null $apiBaseUrl Base API URL (required on first call)
+     * @param string|null $internalBaseUrl Server-side base URL (defaults to $apiBaseUrl)
      * @return self
      * @throws \RuntimeException if called without URL before initialization
      */
-    public static function getInstance(?string $apiBaseUrl = null): self
+    public static function getInstance(?string $apiBaseUrl = null, ?string $internalBaseUrl = null): self
     {
         if (self::$instance === null) {
             if ($apiBaseUrl === null) {
@@ -57,7 +86,7 @@ class ApiConfig
                     'ApiConfig must be initialized with a base URL on first call'
                 );
             }
-            self::$instance = new self($apiBaseUrl);
+            self::$instance = new self($apiBaseUrl, $internalBaseUrl);
         }
 
         return self::$instance;

--- a/tests/ApiConfigTest.php
+++ b/tests/ApiConfigTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Frontend\Tests;
+
+use LiturgicalCalendar\Frontend\ApiConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ApiConfig::class)]
+final class ApiConfigTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ApiConfig::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        ApiConfig::reset();
+    }
+
+    public function testInternalBaseUrlDefaultsToApiBaseUrl(): void
+    {
+        $config = ApiConfig::getInstance('http://localhost:8000');
+        $this->assertSame('http://localhost:8000', $config->apiBaseUrl);
+        $this->assertSame('http://localhost:8000', $config->internalBaseUrl);
+    }
+
+    public function testBrowserUrlsStayBrowserFacingWhenAnInternalBaseIsSet(): void
+    {
+        $config = ApiConfig::getInstance('http://localhost:8000', 'http://litcal-api:8000');
+        // The *Url properties feed client-side JS and user-facing links, so they
+        // must keep the browser-facing host regardless of the internal base.
+        $this->assertSame('http://localhost:8000/events', $config->eventsUrl);
+        $this->assertSame('http://localhost:8000/decrees', $config->decreesUrl);
+        $this->assertSame('http://litcal-api:8000', $config->internalBaseUrl);
+    }
+
+    public function testToInternalRebasesABrowserUrlOntoTheInternalBase(): void
+    {
+        $config = ApiConfig::getInstance('http://localhost:8000', 'http://litcal-api:8000');
+        $this->assertSame('http://litcal-api:8000/events', $config->toInternal($config->eventsUrl));
+        $this->assertSame('http://litcal-api:8000/calendars', $config->toInternal($config->metadataUrl));
+    }
+
+    public function testToInternalIsANoOpWhenNoInternalBaseIsConfigured(): void
+    {
+        $config = ApiConfig::getInstance('https://litcal.example.com/api/dev');
+        $this->assertSame($config->eventsUrl, $config->toInternal($config->eventsUrl));
+    }
+
+    public function testToInternalPassesThroughAUrlThatDoesNotStartWithTheBase(): void
+    {
+        $config = ApiConfig::getInstance('http://localhost:8000', 'http://litcal-api:8000');
+        $foreign = 'https://cdn.example.com/asset.js';
+        $this->assertSame($foreign, $config->toInternal($foreign));
+    }
+}


### PR DESCRIPTION
## Summary

Server-side PHP API requests were built from the browser-facing `API_HOST` (typically `localhost`), which is unreachable from inside a container. In the docker stack this broke every server-rendered API call: **easter.php, extending.php, decrees.php, missals-editor.php**, and the included **PHP web-calendar example** (`examples.php?example=PHP`, which reuses the frontend's `ApiClient`).

The browser-facing URLs must stay `localhost` (they're emitted to client-side JS in `layout/footer.php` and to user-facing links), so this adds a separate server-side base:

- **`ApiConfig`** gains `$internalBaseUrl` (defaults to `$apiBaseUrl`) and a `toInternal()` helper that rebases a browser endpoint URL onto the internal base.
- **`common.php`** derives `$apiInternalBaseUrl` from `API_INTERNAL_URL` (+ `API_BASE_PATH`) when set, passes it to `ApiConfig`, and points the server-side `ApiClient` at `$apiConfig->internalBaseUrl`. No-op when `API_INTERNAL_URL` is unset → standalone/production unchanged.
- The four server-side pages wrap their fetch URLs in `$apiConfig->toInternal(...)`.

## Verification (docker stack)
- `easter.php` renders live Easter dates (previously errored).
- The PHP example now requests `http://litcal-api:8000/calendar/...` and renders a live calendar (previously showed `localhost:8000` and served a stale cache).
- New phpunit `ApiConfigTest` (rebase / no-op / passthrough; browser URLs stay browser-facing). phpcs + phpstan level 7 clean.

Depends on the docker override providing `API_INTERNAL_URL` for `litcal-frontend` (already set in the base compose default). Companion: examples-repo PR for standalone direct access, and PR #391 for the override mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)