### PR TITLE
refactor: merge variableCorrespondence test type into exactCorrespondence

### DIFF
--- a/admin-tests.php
+++ b/admin-tests.php
@@ -187,11 +187,6 @@ if (!$isGlobalAdmin && !$hasTestEditor && !$isResourceAdmin) {
                                 <label class="btn btn-outline-primary" for="tt-until">
                                     <i class="fas fa-right-to-bracket me-1"></i><?php echo htmlspecialchars(_('Exact until year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
                                 </label>
-                                <input type="radio" class="btn-check" name="testType" id="tt-variable"
-                                    value="variableCorrespondence" autocomplete="off">
-                                <label class="btn btn-outline-primary" for="tt-variable">
-                                    <i class="fas fa-square-root-variable me-1"></i><?php echo htmlspecialchars(_('Variable by year'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
-                                </label>
                             </div>
                         </div>
 

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -10,7 +10,6 @@ export const TestType = Object.freeze({
     ExactCorrespondence:      'exactCorrespondence',
     ExactCorrespondenceSince: 'exactCorrespondenceSince',
     ExactCorrespondenceUntil: 'exactCorrespondenceUntil',
-    VariableCorrespondence:   'variableCorrespondence',
 });
 
 export const AssertType = Object.freeze({

--- a/assets/js/__tests__/AssertionsBuilder.test.js
+++ b/assets/js/__tests__/AssertionsBuilder.test.js
@@ -2,11 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { TestType, AssertType, LitGrade, Assertion } from '../AssertionsBuilder.js';
 
 describe('enums', () => {
-    it('exposes the four test types', () => {
+    it('exposes the three test types', () => {
         expect(TestType.ExactCorrespondence).toBe('exactCorrespondence');
         expect(TestType.ExactCorrespondenceSince).toBe('exactCorrespondenceSince');
         expect(TestType.ExactCorrespondenceUntil).toBe('exactCorrespondenceUntil');
-        expect(TestType.VariableCorrespondence).toBe('variableCorrespondence');
     });
 
     it('exposes the two assert types', () => {
@@ -150,12 +149,12 @@ describe('load + serialize round-trip', () => {
 
     it('setMeta updates name/description/event_key/test_type without touching assertions', () => {
         const b = new AssertionsBuilder().load(sampleExact);
-        b.setMeta({ name: 'RenamedTest', description: 'new desc', event_key: 'RenamedKeyEvent', test_type: 'variableCorrespondence' });
+        b.setMeta({ name: 'RenamedTest', description: 'new desc', event_key: 'RenamedKeyEvent', test_type: 'exactCorrespondenceSince' });
         const out = b.serialize();
         expect(out.name).toBe('RenamedTest');
         expect(out.description).toBe('new desc');
         expect(out.event_key).toBe('RenamedKeyEvent');
-        expect(out.test_type).toBe('variableCorrespondence');
+        expect(out.test_type).toBe('exactCorrespondenceSince');
         expect(out.assertions).toHaveLength(2);
     });
 
@@ -190,7 +189,7 @@ describe('load + serialize round-trip', () => {
             name: 'GroupedTest',
             event_key: 'StJaneFrancesDeChantal',
             description: 'x',
-            test_type: 'variableCorrespondence',
+            test_type: 'exactCorrespondence',
             assertions: [
                 { year: 2001, expected_value: '2001-12-12T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
                 { year: 2010, expected_value: '2010-12-12T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: 'x' },
@@ -266,7 +265,7 @@ describe('generate', () => {
 describe('mutators', () => {
     const build = () => {
         const b = new AssertionsBuilder();
-        b.setMeta({ test_type: 'variableCorrespondence' });
+        b.setMeta({ test_type: 'exactCorrespondence' });
         b.generate({ event, minYear: 2024, maxYear: 2026 });
         return b;
     };
@@ -336,7 +335,7 @@ describe('mutators', () => {
 describe('render', () => {
     it('renders one card per assertion with textarea, toggle, and color classes', () => {
         const b = new AssertionsBuilder();
-        b.setMeta({ test_type: 'variableCorrespondence' });
+        b.setMeta({ test_type: 'exactCorrespondence' });
         b.generate({ event, minYear: 2024, maxYear: 2025 });
         b.toggleAssert(2025); // make 2025 eventNotExists
         const container = document.createElement('div');
@@ -358,10 +357,10 @@ describe('render', () => {
 });
 
 describe('coverage hardening', () => {
-    it('generate variableCorrespondence: all in-range years are eventExists', () => {
+    it('generate exactCorrespondence: all in-range years are eventExists, no pivot keys', () => {
         const event = { event_key: 'VEvent', name: 'Variable Event', grade: 3, grade_lcl: 'Memorial', month: 6, day: 15 };
         const b = new AssertionsBuilder();
-        b.setMeta({ event_key: 'VEvent', test_type: 'variableCorrespondence' });
+        b.setMeta({ event_key: 'VEvent', test_type: 'exactCorrespondence' });
         b.generate({ event, minYear: 2020, maxYear: 2022 });
         const out = b.serialize();
         expect(out.assertions.map((a) => a.year)).toEqual([2020, 2021, 2022]);
@@ -412,7 +411,7 @@ describe('coverage hardening', () => {
             name: 'NoBaseTest',
             event_key: 'NB',
             description: "The FEAST of 'NB' should fall on July 4",
-            test_type: 'variableCorrespondence',
+            test_type: 'exactCorrespondence',
             assertions: [
                 { year: 2024, expected_value: null, assert: 'eventNotExists', assertion: "The FEAST of 'NB' should not exist on July 4" },
             ],
@@ -428,7 +427,7 @@ describe('coverage hardening', () => {
     it('render exposes grid class, color classes, comment icon, textarea', () => {
         const event = { event_key: 'REvent', name: 'Render Event', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 };
         const b = new AssertionsBuilder();
-        b.setMeta({ event_key: 'REvent', test_type: 'variableCorrespondence' });
+        b.setMeta({ event_key: 'REvent', test_type: 'exactCorrespondence' });
         b.generate({ event, minYear: 2024, maxYear: 2025 });
         b.toggleAssert(2025);                 // 2025 -> eventNotExists
         b.setComment(2024, 'a note');         // 2024 has a comment

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -310,7 +310,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 : tt === TestType.ExactCorrespondenceUntil
                     ? builder.model.year_until
                     : null;
-        const showHammer = tt !== TestType.ExactCorrespondence;
         grid.innerHTML = '';
         for (let y = minYear; y <= maxYear; y++) {
             const span = document.createElement('span');
@@ -322,20 +321,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 grid.appendChild(span);
                 continue;
             }
-            if (showHammer) {
-                // Icon semantics per test type (spec R5): Since/Until = hammer
-                // ("set the pivot year"); Variable = fa-repeat ("toggle
-                // assertion", matching the per-year cards' toggle button). The
-                // behavioral hook class (hammerYear) is shared — only the
-                // visual icon and title differ.
-                const isVariable = tt === TestType.VariableCorrespondence;
-                const actionIcon = document.createElement('i');
-                actionIcon.className = `fas ${isVariable ? 'fa-repeat' : 'fa-hammer'} me-1 opacity-50 hammerYear`;
-                actionIcon.setAttribute('role', 'button');
-                actionIcon.setAttribute('aria-hidden', 'true');
-                actionIcon.title = isVariable ? i18n.toggleAssertion : i18n.setYear;
-                span.appendChild(actionIcon);
-            }
+            // Icon semantics per test type: Since/Until = hammer ("set the
+            // pivot year"); ExactCorrespondence = fa-repeat ("toggle
+            // assertion", matching the per-year cards' toggle button). The
+            // behavioral hook class (hammerYear) is shared — only the
+            // visual icon and title differ.
+            const isPivot = tt === TestType.ExactCorrespondenceSince || tt === TestType.ExactCorrespondenceUntil;
+            const actionIcon = document.createElement('i');
+            actionIcon.className = `fas ${isPivot ? 'fa-hammer' : 'fa-repeat'} me-1 opacity-50 hammerYear`;
+            actionIcon.setAttribute('role', 'button');
+            actionIcon.setAttribute('aria-hidden', 'true');
+            actionIcon.title = isPivot ? i18n.setYear : i18n.toggleAssertion;
+            span.appendChild(actionIcon);
             span.appendChild(document.createTextNode(String(y)));
             const xmark = document.createElement('i');
             xmark.className = 'fas fa-circle-xmark ms-1 opacity-50 removeYear';
@@ -483,7 +480,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Year-grid interactions (ported from UnitTestInterface, state-first):
-    //   hammer  → Since/Until: set the pivot; Variable: toggle that year
+    //   hammer  → Since/Until: set the pivot; ExactCorrespondence: toggle that year
     //   x-mark  → exclude the year (collapses to the striped bar)
     //   striped bar → restore the year
     //   span body   → no action (the icons are the affordances)
@@ -502,7 +499,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 tt === TestType.ExactCorrespondenceUntil
             ) {
                 builder.setPivot(year);
-            } else if (tt === TestType.VariableCorrespondence) {
+            } else {
                 builder.toggleAssert(year);
             }
         } else {


### PR DESCRIPTION
Closes #393

## Summary

Merges the `variableCorrespondence` test type into `exactCorrespondence`, following Liturgical-Calendar/LiturgicalCalendarAPI#704 / Liturgical-Calendar/LiturgicalCalendarAPI#705. In this repo's AssertionsBuilder the two types were already behaviorally identical (`generate()`, `toggleAssert()`, `includeYear()`, `rebaseDate()` never distinguished them), so this mostly removes a redundant choice from the admin-tests UI.

## Changes

- `admin-tests.php`: remove the "Variable by year" radio option
- `assets/js/admin-tests.js`: always render the per-year action icon in the year grid — `ExactCorrespondence` gets `fa-repeat`/`toggleAssert` (the former `VariableCorrespondence` affordance), Since/Until keep `fa-hammer`/`setPivot`
- `assets/js/AssertionsBuilder.js`: drop the `VariableCorrespondence` TestType constant
- `assets/js/__tests__/AssertionsBuilder.test.js`: retype the `variableCorrespondence` specs to `exactCorrespondence`

## Verification

- `yarn test:unit`: 44 tests green
- `yarn lint` on the changed JS files: clean
- `php -l admin-tests.php`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the “Variable by year” test type from the test editor.
  - Test type options now include Exact, Since, and Until.
  - Updated year-grid controls so Since and Until set a pivot year, while other available types toggle assertions.
  - Updated related test behavior and displays to reflect the revised test type options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->