### PR TITLE
feat: clarify FGA tuple subjects in admin permissions table

### DIFF
--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -373,7 +373,8 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                 revoking: <?php echo json_encode(_('Revoking...')); ?>,
                 confirmRevoke: <?php echo json_encode(_('Are you sure you want to revoke this permission?')); ?>,
                 // Table headers
-                user: <?php echo json_encode(_('User')); ?>,
+                subject: <?php echo json_encode(_('Subject')); ?>,
+                unknownUser: <?php echo json_encode(_('Unknown user')); ?>,
                 objectType: <?php echo json_encode(_('Object Type')); ?>,
                 objectId: <?php echo json_encode(_('Object ID')); ?>,
                 relation: <?php echo json_encode(_('Relation')); ?>,

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -167,6 +167,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // human-readable user info instead of raw zitadel IDs in the tuple table.
     let userMap = new Map();
 
+    // Whether the /admin/users fetch succeeded at least once. Distinguishes
+    // "this user ID is not in Zitadel" (orphaned tuple — flag it) from
+    // "we couldn't load the user list at all" (don't flag anyone).
+    let userMapLoaded = false;
+
     // Object type display names
     const objectTypeNames = {
         'national_calendar': config.i18n.nationalCalendar,
@@ -244,6 +249,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 ...(Array.isArray(data.usersWithoutRoles) ? data.usersWithoutRoles : [])
             ];
             userMap = new Map(users.map(function (u) { return [u.userId, u]; }));
+            userMapLoaded = true;
         } catch (error) {
             console.error('Failed to load user map for permissions display:', error);
         }
@@ -306,7 +312,7 @@ document.addEventListener('DOMContentLoaded', function() {
         html += `
             <thead>
                 <tr>
-                    <th>${config.i18n.user}</th>
+                    <th>${config.i18n.subject}</th>
                     <th>${config.i18n.objectType}</th>
                     <th>${config.i18n.objectId}</th>
                     <th>${config.i18n.relation}</th>
@@ -329,13 +335,34 @@ document.addEventListener('DOMContentLoaded', function() {
             const relationName = relationNames[relation] || relation;
             const badgeClass = relationBadgeClasses[relation] || 'bg-secondary';
 
-            // API returns user as "user:<zitadel-id>"; strip the prefix for the userMap lookup.
-            const lookupId = user.startsWith('user:') ? user.slice('user:'.length) : user;
-            const userInfo = userMap.get(lookupId);
-            const userCellHtml = userInfo
-                ? `<strong>${escapeHtml(userInfo.displayName || userInfo.username || lookupId)}</strong>`
-                    + (userInfo.email ? `<br><small class="text-muted">${escapeHtml(userInfo.email)}</small>` : '')
-                : `<small class="text-muted font-monospace">${escapeHtml(user)}</small>`;
+            // The tuple subject is either a human ("user:<zitadel-id>") or another
+            // resource ("national_calendar:CA" powering e.g. wider_region membership).
+            let userCellHtml;
+            if (user.startsWith('user:')) {
+                const lookupId = user.slice('user:'.length);
+                const userInfo = userMap.get(lookupId);
+                if (userInfo) {
+                    userCellHtml = `<strong>${escapeHtml(userInfo.displayName || userInfo.username || lookupId)}</strong>`
+                        + (userInfo.email ? `<br><small class="text-muted">${escapeHtml(userInfo.email)}</small>` : '');
+                } else {
+                    // An ID missing from a successfully loaded user map means the
+                    // Zitadel user no longer exists: an orphaned tuple (e.g. a grant
+                    // that survived an identity-store reset). Flag it so admins spot
+                    // and revoke it.
+                    const orphanBadge = userMapLoaded
+                        ? `<span class="badge bg-warning text-dark me-1">${escapeHtml(config.i18n.unknownUser)}</span>`
+                        : '';
+                    userCellHtml = orphanBadge
+                        + `<small class="text-muted font-monospace">${escapeHtml(user)}</small>`;
+                }
+            } else {
+                const subjColonIdx = user.indexOf(':');
+                const subjType = subjColonIdx !== -1 ? user.substring(0, subjColonIdx) : user;
+                const subjId = subjColonIdx !== -1 ? user.substring(subjColonIdx + 1) : '';
+                const subjTypeName = objectTypeNames[subjType] || subjType;
+                userCellHtml = `<span class="badge bg-secondary me-1">${escapeHtml(subjTypeName)}</span>`
+                    + (subjId ? `<code>${escapeHtml(subjId)}</code>` : '');
+            }
 
             html += `
                 <tr>
@@ -476,7 +503,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         revokeConfirmText.innerHTML = `
             ${config.i18n.confirmRevoke}<br><br>
-            <strong>${config.i18n.user}:</strong> ${escapeHtml(data.user)}<br>
+            <strong>${config.i18n.subject}:</strong> ${escapeHtml(data.user)}<br>
             <strong>${config.i18n.objectType}:</strong> ${escapeHtml(objectTypeName)}<br>
             <strong>${config.i18n.objectId}:</strong> <code>${escapeHtml(data.objectId)}</code><br>
             <strong>${config.i18n.relation}:</strong> ${escapeHtml(relationName)}

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -294,6 +294,77 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     /**
+     * Render the Subject cell for a permission tuple.
+     * The tuple subject is either a human ("user:<zitadel-id>") or another
+     * resource ("national_calendar:CA" powering e.g. wider_region membership).
+     * @param {string} subject - The tuple's user field
+     * @returns {string} HTML for the subject cell
+     */
+    function renderSubjectCell(subject) {
+        if (subject.startsWith('user:')) {
+            const lookupId = subject.slice('user:'.length);
+            const userInfo = userMap.get(lookupId);
+            if (userInfo) {
+                return `<strong>${escapeHtml(userInfo.displayName || userInfo.username || lookupId)}</strong>`
+                    + (userInfo.email ? `<br><small class="text-muted">${escapeHtml(userInfo.email)}</small>` : '');
+            }
+            // An ID missing from a successfully loaded user map means the
+            // Zitadel user no longer exists: an orphaned tuple (e.g. a grant
+            // that survived an identity-store reset). Flag it so admins spot
+            // and revoke it.
+            const orphanBadge = userMapLoaded
+                ? `<span class="badge bg-warning text-dark me-1">${escapeHtml(config.i18n.unknownUser)}</span>`
+                : '';
+            return orphanBadge
+                + `<small class="text-muted font-monospace">${escapeHtml(subject)}</small>`;
+        }
+        const colonIdx = subject.indexOf(':');
+        const subjType = colonIdx !== -1 ? subject.substring(0, colonIdx) : subject;
+        const subjId = colonIdx !== -1 ? subject.substring(colonIdx + 1) : '';
+        const subjTypeName = objectTypeNames[subjType] || subjType;
+        return `<span class="badge bg-secondary me-1">${escapeHtml(subjTypeName)}</span>`
+            + (subjId ? `<code>${escapeHtml(subjId)}</code>` : '');
+    }
+
+    /**
+     * Render a single permission tuple table row.
+     * @param {Object} tuple - Permission tuple
+     * @returns {string} HTML for the table row
+     */
+    function renderPermissionRow(tuple) {
+        const user = tuple.user || '';
+        const relation = tuple.relation || '';
+        // The API returns "object" as "type:id" (e.g., "national_calendar:IT")
+        const objectFull = tuple.object || '';
+        const colonIdx = objectFull.indexOf(':');
+        const objectType = colonIdx !== -1 ? objectFull.substring(0, colonIdx) : objectFull;
+        const objectId = colonIdx !== -1 ? objectFull.substring(colonIdx + 1) : '';
+
+        const objectTypeName = objectTypeNames[objectType] || objectType;
+        const relationName = relationNames[relation] || relation;
+        const badgeClass = relationBadgeClasses[relation] || 'bg-secondary';
+
+        return `
+            <tr>
+                <td>${renderSubjectCell(user)}</td>
+                <td>${escapeHtml(objectTypeName)}</td>
+                <td><code>${escapeHtml(objectId)}</code></td>
+                <td><span class="badge ${badgeClass}">${escapeHtml(relationName)}</span></td>
+                <td>
+                    <button class="btn btn-outline-danger btn-sm revoke-btn"
+                            data-user="${escapeHtml(user)}"
+                            data-object-type="${escapeHtml(objectType)}"
+                            data-object-id="${escapeHtml(objectId)}"
+                            data-relation="${escapeHtml(relation)}"
+                            data-requires-auth>
+                        <i class="fas fa-trash-alt me-1"></i>${config.i18n.revoke}
+                    </button>
+                </td>
+            </tr>
+        `;
+    }
+
+    /**
      * Display permissions in a table
      * @param {Array} tuples - Permission tuples
      */
@@ -323,65 +394,7 @@ document.addEventListener('DOMContentLoaded', function() {
         `;
 
         for (const tuple of tuples) {
-            const user = tuple.user || '';
-            const relation = tuple.relation || '';
-            // The API returns "object" as "type:id" (e.g., "national_calendar:IT")
-            const objectFull = tuple.object || '';
-            const colonIdx = objectFull.indexOf(':');
-            const objectType = colonIdx !== -1 ? objectFull.substring(0, colonIdx) : objectFull;
-            const objectId = colonIdx !== -1 ? objectFull.substring(colonIdx + 1) : '';
-
-            const objectTypeName = objectTypeNames[objectType] || objectType;
-            const relationName = relationNames[relation] || relation;
-            const badgeClass = relationBadgeClasses[relation] || 'bg-secondary';
-
-            // The tuple subject is either a human ("user:<zitadel-id>") or another
-            // resource ("national_calendar:CA" powering e.g. wider_region membership).
-            let userCellHtml;
-            if (user.startsWith('user:')) {
-                const lookupId = user.slice('user:'.length);
-                const userInfo = userMap.get(lookupId);
-                if (userInfo) {
-                    userCellHtml = `<strong>${escapeHtml(userInfo.displayName || userInfo.username || lookupId)}</strong>`
-                        + (userInfo.email ? `<br><small class="text-muted">${escapeHtml(userInfo.email)}</small>` : '');
-                } else {
-                    // An ID missing from a successfully loaded user map means the
-                    // Zitadel user no longer exists: an orphaned tuple (e.g. a grant
-                    // that survived an identity-store reset). Flag it so admins spot
-                    // and revoke it.
-                    const orphanBadge = userMapLoaded
-                        ? `<span class="badge bg-warning text-dark me-1">${escapeHtml(config.i18n.unknownUser)}</span>`
-                        : '';
-                    userCellHtml = orphanBadge
-                        + `<small class="text-muted font-monospace">${escapeHtml(user)}</small>`;
-                }
-            } else {
-                const subjColonIdx = user.indexOf(':');
-                const subjType = subjColonIdx !== -1 ? user.substring(0, subjColonIdx) : user;
-                const subjId = subjColonIdx !== -1 ? user.substring(subjColonIdx + 1) : '';
-                const subjTypeName = objectTypeNames[subjType] || subjType;
-                userCellHtml = `<span class="badge bg-secondary me-1">${escapeHtml(subjTypeName)}</span>`
-                    + (subjId ? `<code>${escapeHtml(subjId)}</code>` : '');
-            }
-
-            html += `
-                <tr>
-                    <td>${userCellHtml}</td>
-                    <td>${escapeHtml(objectTypeName)}</td>
-                    <td><code>${escapeHtml(objectId)}</code></td>
-                    <td><span class="badge ${badgeClass}">${escapeHtml(relationName)}</span></td>
-                    <td>
-                        <button class="btn btn-outline-danger btn-sm revoke-btn"
-                                data-user="${escapeHtml(user)}"
-                                data-object-type="${escapeHtml(objectType)}"
-                                data-object-id="${escapeHtml(objectId)}"
-                                data-relation="${escapeHtml(relation)}"
-                                data-requires-auth>
-                            <i class="fas fa-trash-alt me-1"></i>${config.i18n.revoke}
-                        </button>
-                    </td>
-                </tr>
-            `;
+            html += renderPermissionRow(tuple);
         }
 
         html += '</tbody></table></div>';


### PR DESCRIPTION
## Summary

OpenFGA tuple "users" are generic subjects: they can be humans (`user:<zitadel-id>`) or other resources
(e.g. `national_calendar:CA` as `member_nation` of a `wider_region`, powering the wider-region admin TTU).
The Permission Tuples table rendered both the same way under a "User" header, which read as if resources
were being treated as users.

- Rename the tuple table column (and revoke-modal label) from "User" to "Subject"
- Render resource subjects as a localized object-type badge followed by the ID in code style, matching the Object ID column
- Flag `user:` subjects missing from a successfully loaded `/admin/users` map with an "Unknown user" badge,
  making orphaned grants (e.g. tuples that survived an identity-store reset) obvious; when the user map
  failed to load, nobody is flagged (raw-ID fallback unchanged)

## Test plan

- [x] `node --check` / ESLint on `assets/js/admin-permissions.js`
- [x] `php -l` / `phpcs` on `admin-permissions.php`
- [x] Verified in the local docker stack as a system admin: resource subjects (wider-region membership tuples)
      show a type badge + code ID, human subjects show display name + email, and an orphaned grant from a
      pre-reset Zitadel user is flagged with the "Unknown user" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved permission table subject display for users and other resource types.
  * Added a clear fallback for subjects linked to users who are no longer available.
  * Updated table and revoke-dialog labels to use the broader “Subject” terminology.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->