### PR TITLE
chore(i18n): regenerate i18n/litcal.pot

### DIFF
--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-06 13:09+0000\n"
+"POT-Creation-Date: 2026-07-11 12:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -99,7 +99,7 @@ msgstr ""
 #. translators: part of page title - refers to the Catholic liturgical calendar
 #: index.php:65 usage.php:29 examples.php:98 liturgyOfAnyDay.php:18
 #: layout/header.php:257 admin-permissions.php:77 admin-permissions.php:301
-#: admin-permissions.php:387 permission-requests.php:242
+#: admin-permissions.php:388 permission-requests.php:242
 msgid "General Roman Calendar"
 msgstr ""
 
@@ -1139,7 +1139,7 @@ msgstr ""
 #: layout/header.php:140 admin-permissions.php:134 admin-permissions.php:190
 #: admin-permissions.php:197 admin-permissions.php:204
 #: admin-permissions.php:211 admin-permissions.php:365
-#: admin-permissions.php:409 permission-requests.php:64
+#: admin-permissions.php:410 permission-requests.php:64
 #: permission-requests.php:204 admin-applications.php:136
 #: admin-applications.php:145 admin-applications.php:154
 #: admin-applications.php:163 admin-applications.php:228
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: layout/header.php:188 layout/header.php:251 admin-permissions.php:443
+#: layout/header.php:188 layout/header.php:251 admin-permissions.php:444
 #: permission-requests.php:90 permission-requests.php:255
 #: admin-role-requests.php:260 admin-users.php:144
 msgid "Developer"
@@ -1188,7 +1188,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: layout/header.php:261 includes/admin-blocks.php:15 admin-permissions.php:388
+#: layout/header.php:261 includes/admin-blocks.php:15 admin-permissions.php:389
 #: permission-requests.php:243 temporale.php:24 temporale.php:37
 msgid "Temporale"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgstr ""
 
 #. translators: label for wider region calendar name field
 #: layout/header.php:281 includes/messages.php:206 includes/admin-blocks.php:45
-#: admin-permissions.php:81 admin-permissions.php:305 admin-permissions.php:385
+#: admin-permissions.php:81 admin-permissions.php:305 admin-permissions.php:386
 #: permission-requests.php:237
 msgid "Wider Region"
 msgstr ""
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Just now"
 msgstr ""
 
-#: layout/footer.php:96 admin-permissions.php:439 admin-role-requests.php:252
+#: layout/footer.php:96 admin-permissions.php:440 admin-role-requests.php:252
 msgid "Requested"
 msgstr ""
 
@@ -1693,7 +1693,7 @@ msgstr ""
 
 #. translators: label for national calendar name field
 #: includes/messages.php:208 admin-permissions.php:79 admin-permissions.php:303
-#: admin-permissions.php:383 permission-requests.php:235
+#: admin-permissions.php:384 permission-requests.php:235
 msgid "National Calendar"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: admin-permissions.php:67 admin-permissions.php:376 admin-permissions.php:419
+#: admin-permissions.php:67 admin-permissions.php:420
 #: admin-applications.php:238 admin-role-requests.php:248 admin-users.php:213
 #: admin-users.php:290
 msgid "User"
@@ -2022,7 +2022,7 @@ msgstr ""
 msgid "Filter by user ID..."
 msgstr ""
 
-#: admin-permissions.php:73 admin-permissions.php:377 admin-permissions.php:422
+#: admin-permissions.php:73 admin-permissions.php:378 admin-permissions.php:423
 msgid "Object Type"
 msgstr ""
 
@@ -2030,27 +2030,27 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: admin-permissions.php:78 admin-permissions.php:302 admin-permissions.php:400
-#: admin-permissions.php:429 permission-requests.php:241
+#: admin-permissions.php:78 admin-permissions.php:302 admin-permissions.php:401
+#: admin-permissions.php:430 permission-requests.php:241
 msgid "General Roman Calendar Tests"
 msgstr ""
 
-#: admin-permissions.php:80 admin-permissions.php:304 admin-permissions.php:384
+#: admin-permissions.php:80 admin-permissions.php:304 admin-permissions.php:385
 #: permission-requests.php:236
 msgid "Diocesan Calendar"
 msgstr ""
 
-#: admin-permissions.php:82 admin-permissions.php:306 admin-permissions.php:398
-#: admin-permissions.php:427 permission-requests.php:239
+#: admin-permissions.php:82 admin-permissions.php:306 admin-permissions.php:399
+#: admin-permissions.php:428 permission-requests.php:239
 msgid "National Calendar Tests"
 msgstr ""
 
-#: admin-permissions.php:83 admin-permissions.php:307 admin-permissions.php:399
-#: admin-permissions.php:428 permission-requests.php:240
+#: admin-permissions.php:83 admin-permissions.php:307 admin-permissions.php:400
+#: admin-permissions.php:429 permission-requests.php:240
 msgid "Diocesan Calendar Tests"
 msgstr ""
 
-#: admin-permissions.php:87 admin-permissions.php:378 admin-permissions.php:423
+#: admin-permissions.php:87 admin-permissions.php:379 admin-permissions.php:424
 msgid "Object ID"
 msgstr ""
 
@@ -2058,22 +2058,22 @@ msgstr ""
 msgid "Filter by object ID..."
 msgstr ""
 
-#: admin-permissions.php:93 admin-permissions.php:289 admin-permissions.php:379
-#: admin-permissions.php:430 permission-requests.php:227
+#: admin-permissions.php:93 admin-permissions.php:289 admin-permissions.php:380
+#: admin-permissions.php:431 permission-requests.php:227
 msgid "Relation"
 msgstr ""
 
-#: admin-permissions.php:97 admin-permissions.php:292 admin-permissions.php:402
+#: admin-permissions.php:97 admin-permissions.php:292 admin-permissions.php:403
 #: permission-requests.php:257
 msgid "Viewer"
 msgstr ""
 
-#: admin-permissions.php:98 admin-permissions.php:293 admin-permissions.php:403
+#: admin-permissions.php:98 admin-permissions.php:293 admin-permissions.php:404
 #: permission-requests.php:258
 msgid "Editor"
 msgstr ""
 
-#: admin-permissions.php:99 admin-permissions.php:294 admin-permissions.php:404
+#: admin-permissions.php:99 admin-permissions.php:294 admin-permissions.php:405
 #: permission-requests.php:259
 msgctxt "permission relation"
 msgid "Admin"
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Access Requests"
 msgstr ""
 
-#: admin-permissions.php:160 admin-permissions.php:445
+#: admin-permissions.php:160 admin-permissions.php:446
 #: permission-requests.php:261 admin-applications.php:57
 #: admin-applications.php:101 admin-applications.php:250
 #: admin-role-requests.php:67 admin-role-requests.php:111
@@ -2114,7 +2114,7 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#: admin-permissions.php:167 admin-permissions.php:446
+#: admin-permissions.php:167 admin-permissions.php:447
 #: permission-requests.php:262 admin-applications.php:68
 #: admin-applications.php:108 admin-applications.php:251
 #: admin-role-requests.php:78 admin-role-requests.php:118
@@ -2122,7 +2122,7 @@ msgstr ""
 msgid "Approved"
 msgstr ""
 
-#: admin-permissions.php:173 admin-permissions.php:447
+#: admin-permissions.php:173 admin-permissions.php:448
 #: permission-requests.php:263 admin-applications.php:79
 #: admin-applications.php:114 admin-applications.php:252
 #: admin-role-requests.php:89 admin-role-requests.php:124
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: admin-permissions.php:179 admin-permissions.php:448
+#: admin-permissions.php:179 admin-permissions.php:449
 #: permission-requests.php:264 admin-applications.php:90
 #: admin-applications.php:120 admin-applications.php:253
 #: admin-role-requests.php:100 admin-role-requests.php:130
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: admin-permissions.php:255 admin-permissions.php:381
+#: admin-permissions.php:255 admin-permissions.php:382
 #: admin-applications.php:213 admin-role-requests.php:223
 #: admin-role-requests.php:269 developer-dashboard.php:271
 msgid "Revoke"
@@ -2200,8 +2200,8 @@ msgstr ""
 msgid "Select relation..."
 msgstr ""
 
-#: admin-permissions.php:298 admin-permissions.php:395
-#: admin-permissions.php:424 permission-requests.php:230
+#: admin-permissions.php:298 admin-permissions.php:396
+#: admin-permissions.php:425 permission-requests.php:230
 msgid "Calendar scope"
 msgstr ""
 
@@ -2209,13 +2209,13 @@ msgstr ""
 msgid "Select calendar scope..."
 msgstr ""
 
-#: admin-permissions.php:311 admin-permissions.php:396
-#: admin-permissions.php:425 permission-requests.php:231
+#: admin-permissions.php:311 admin-permissions.php:397
+#: admin-permissions.php:426 permission-requests.php:231
 msgid "Calendar ID"
 msgstr ""
 
-#: admin-permissions.php:314 admin-permissions.php:397
-#: admin-permissions.php:426 permission-requests.php:233
+#: admin-permissions.php:314 admin-permissions.php:398
+#: admin-permissions.php:427 permission-requests.php:233
 msgid "Select calendar ID..."
 msgstr ""
 
@@ -2259,125 +2259,133 @@ msgstr ""
 msgid "Are you sure you want to revoke this permission?"
 msgstr ""
 
-#: admin-permissions.php:380 admin-permissions.php:434
+#: admin-permissions.php:376
+msgid "Subject"
+msgstr ""
+
+#: admin-permissions.php:377
+msgid "Unknown user"
+msgstr ""
+
+#: admin-permissions.php:381 admin-permissions.php:435
 #: admin-applications.php:244 admin-role-requests.php:253 temporale.php:138
 msgid "Actions"
 msgstr ""
 
-#: admin-permissions.php:386 permission-requests.php:238
+#: admin-permissions.php:387 permission-requests.php:238
 msgid "Test Definition"
 msgstr ""
 
-#: admin-permissions.php:389 permission-requests.php:245
+#: admin-permissions.php:390 permission-requests.php:245
 msgid "Sanctorale — Editio Typica 1970"
 msgstr ""
 
-#: admin-permissions.php:390 permission-requests.php:247
+#: admin-permissions.php:391 permission-requests.php:247
 msgid "Sanctorale — Editio Typica 2002"
 msgstr ""
 
-#: admin-permissions.php:391 permission-requests.php:249
+#: admin-permissions.php:392 permission-requests.php:249
 msgid "Sanctorale — Editio Typica 2008"
 msgstr ""
 
-#: admin-permissions.php:392 permission-requests.php:251
+#: admin-permissions.php:393 permission-requests.php:251
 msgid "Decrees of the Dicastery for Divine Worship"
 msgstr ""
 
-#: admin-permissions.php:393
+#: admin-permissions.php:394
 msgid "Enter object ID..."
 msgstr ""
 
-#: admin-permissions.php:394
+#: admin-permissions.php:395
 msgid "Select object ID..."
 msgstr ""
 
-#: admin-permissions.php:406
+#: admin-permissions.php:407
 msgid "All fields are required."
 msgstr ""
 
-#: admin-permissions.php:410 admin-role-requests.php:239
+#: admin-permissions.php:411 admin-role-requests.php:239
 msgid "No requests found."
 msgstr ""
 
-#: admin-permissions.php:411
+#: admin-permissions.php:412
 msgid "No pending access requests. All caught up!"
 msgstr ""
 
-#: admin-permissions.php:412
+#: admin-permissions.php:413
 msgid "Failed to load access requests. Please try again later."
 msgstr ""
 
-#: admin-permissions.php:413 admin-applications.php:232
+#: admin-permissions.php:414 admin-applications.php:232
 #: admin-role-requests.php:242
 msgid "Processing..."
 msgstr ""
 
-#: admin-permissions.php:414
+#: admin-permissions.php:415
 msgid "Access request approved successfully."
 msgstr ""
 
-#: admin-permissions.php:415
+#: admin-permissions.php:416
 msgid "Access request rejected."
 msgstr ""
 
-#: admin-permissions.php:416
+#: admin-permissions.php:417
 msgid "Access revoked successfully."
 msgstr ""
 
-#: admin-permissions.php:417 admin-applications.php:236
+#: admin-permissions.php:418 admin-applications.php:236
 #: admin-role-requests.php:246
 msgid "Failed to process request. Please try again."
 msgstr ""
 
-#: admin-permissions.php:420 permission-requests.php:219
+#: admin-permissions.php:421 permission-requests.php:219
 msgid "Role"
 msgstr ""
 
-#: admin-permissions.php:421 permission-requests.php:133
+#: admin-permissions.php:422 permission-requests.php:133
 #: permission-requests.php:220 admin-dashboard.php:128 user-profile.php:178
 msgid "Permissions"
 msgstr ""
 
-#: admin-permissions.php:431 permission-requests.php:151
+#: admin-permissions.php:432 permission-requests.php:151
 #: permission-requests.php:222 admin-role-requests.php:255
 msgid "Justification"
 msgstr ""
 
-#: admin-permissions.php:432 permission-requests.php:166
+#: admin-permissions.php:433 permission-requests.php:166
 msgid "Credentials"
 msgstr ""
 
-#: admin-permissions.php:433 admin-role-requests.php:251
+#: admin-permissions.php:434 admin-role-requests.php:251
 msgid "Date"
 msgstr ""
 
-#: admin-permissions.php:435 admin-applications.php:245 admin-dashboard.php:172
+#: admin-permissions.php:436 admin-applications.php:245 admin-dashboard.php:172
 #: admin-role-requests.php:254
 msgid "Review"
 msgstr ""
 
-#: admin-permissions.php:436 admin-applications.php:247
+#: admin-permissions.php:437 admin-applications.php:247
 #: admin-role-requests.php:256
 msgid "Reviewed At"
 msgstr ""
 
-#: admin-permissions.php:437 permission-requests.php:223
+#: admin-permissions.php:438 permission-requests.php:223
 #: admin-applications.php:248 admin-role-requests.php:257
 msgid "Review Notes"
 msgstr ""
 
-#: admin-permissions.php:438 permission-requests.php:221
+#: admin-permissions.php:439 permission-requests.php:221
 #: admin-applications.php:243 admin-role-requests.php:258
 msgid "Status"
 msgstr ""
 
-#: admin-permissions.php:441 permission-requests.php:80
+#: admin-permissions.php:442 permission-requests.php:80
 #: permission-requests.php:253 admin-role-requests.php:261 admin-users.php:145
 msgid "Calendar Editor"
 msgstr ""
 
-#: admin-permissions.php:442 permission-requests.php:85
+#: admin-permissions.php:443 permission-requests.php:85
 #: permission-requests.php:254 admin-role-requests.php:262 admin-users.php:146
 msgid "Accuracy Test Editor"
 msgstr ""


### PR DESCRIPTION
Automated regeneration of `i18n/litcal.pot` from the project source files.

Generated by the [Update POTs workflow](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/actions/runs/29152170434).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated translation catalog metadata and source references to reflect current locations in the permissions and access-request interface.
  * No user-facing translation text was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->