### PR TITLE
chore(i18n): regenerate i18n/litcal.pot

### DIFF
--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-11 13:20+0000\n"
+"POT-Creation-Date: 2026-07-12 21:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: admin-permissions.php:439 admin-applications.php:245 admin-dashboard.php:154
+#: admin-permissions.php:439 admin-applications.php:245 admin-dashboard.php:164
 msgid "Review"
 msgstr ""
 
@@ -2580,6 +2580,7 @@ msgid ""
 msgstr ""
 
 #: admin-dashboard.php:65 admin-dashboard.php:129 admin-dashboard.php:139
+#: admin-dashboard.php:149
 msgid "Administration"
 msgstr ""
 
@@ -2607,11 +2608,11 @@ msgstr ""
 msgid "Manage fine-grained resource permissions"
 msgstr ""
 
-#: admin-dashboard.php:148
+#: admin-dashboard.php:158
 msgid "Access Requests to Review"
 msgstr ""
 
-#: admin-dashboard.php:150
+#: admin-dashboard.php:160
 msgid "Review and approve access requests for the resources you administer"
 msgstr ""
 


### PR DESCRIPTION
Automated regeneration of `i18n/litcal.pot` from the project source files.

Generated by the [Update POTs workflow](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/actions/runs/29209214836).