### PR TITLE
feat(admin-dashboard): relation-aware card gating via /auth/dashboard-scopes

### DIFF
--- a/admin-dashboard.php
+++ b/admin-dashboard.php
@@ -123,7 +123,7 @@ if (!$hasCalendarRole) {
     </div>
     <?php endif; ?>
 
-    <?php if (!$isAdmin && $authHelper->hasRole('calendar_editor')) : ?>
+    <?php if (!$isAdmin && $authHelper->hasRole('calendar_editor') && $authHelper->canViewResource('general_roman_calendar', 'decrees')) : ?>
     <hr class="my-4">
     <h4 class="mb-3 text-black" style="--bs-text-opacity: .6;">
         <i class="fas fa-user-shield me-2"></i><?php echo htmlspecialchars(_('Administration'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
@@ -133,7 +133,11 @@ if (!$hasCalendarRole) {
     </div>
     <?php endif; ?>
 
-    <?php if (!$isAdmin && $authHelper->hasRole('test_editor')) : ?>
+    <?php if (
+    !$isAdmin
+    && $authHelper->hasRole('test_editor')
+    && $authHelper->canViewAnyResourceOfType('national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test')
+) : ?>
     <hr class="my-4">
     <h4 class="mb-3 text-black" style="--bs-text-opacity: .6;">
         <i class="fas fa-user-shield me-2"></i><?php echo htmlspecialchars(_('Administration'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
@@ -143,7 +147,7 @@ if (!$hasCalendarRole) {
     </div>
     <?php endif; ?>
 
-    <?php if (!$isAdmin && $authHelper->isResourceAdmin()) : ?>
+    <?php if (!$isAdmin && $authHelper->dashboardScopes()['is_resource_admin']) : ?>
     <hr class="my-4">
     <h4 class="mb-3 text-black" style="--bs-text-opacity: .6;">
         <i class="fas fa-user-shield me-2"></i><?php echo htmlspecialchars(_('Administration'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>

--- a/docs/superpowers/plans/2026-07-12-admin-dashboard-fga-gating.md
+++ b/docs/superpowers/plans/2026-07-12-admin-dashboard-fga-gating.md
@@ -1,0 +1,1266 @@
+# Admin Dashboard Relation-Aware Card Gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate admin-dashboard cards on Zitadel role AND OpenFGA relation, fetched server-side in one API round-trip
+(frontend issue #399; spec: `docs/superpowers/specs/2026-07-12-admin-dashboard-fga-gating-design.md`).
+
+**Architecture:** A new batched `GET /auth/dashboard-scopes` endpoint in LiturgicalCalendarAPI returns admin scopes plus
+viewer-or-above scopes for `general_roman_calendar` and the three `*_test` types. The frontend `AuthHelper` fetches it
+server-side (cookie-forwarded, memoized, lazy) and `admin-dashboard.php` / `includes/admin-blocks.php` gate the
+Temporale block, Decrees block + card, Tests card, and Access Requests card at render time. The interim client-side
+check in `admin-decrees-card.php` is deleted.
+
+**Tech Stack:** PHP 8.4 (both repos), PSR-7/15 handlers + Guzzle-mocked PHPUnit (API), Guzzle + PHPUnit (frontend),
+Playwright e2e against the local docker stack (Zitadel + OpenFGA + API + frontend).
+
+## Global Constraints
+
+- Two repos: `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI` (Tasks 1-3) and
+  `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend` (Tasks 4-7). Paths below are
+  relative to the repo named in each task.
+- Branches from `development`; PRs target `development`, never `main`.
+- Never `git commit --no-verify`. Do not push after committing (CodeRabbit rate limits) — PRs only on explicit user request, API PR before frontend PR.
+- PHP: PSR-12, 4-space indent, single quotes, short arrays. API PHPStan level 10; frontend PHPStan level 7.
+- Fail closed everywhere: any scopes-fetch error → empty scopes → relation-gated cards hidden. `is_global_admin` always honored from the token.
+- No new user-visible strings (no i18n changes).
+- Docker gotcha: top-level frontend PHP files are inode-pinned bind mounts — after editing `admin-dashboard.php`, run
+  `docker compose up -d --force-recreate litcal-frontend` before browser verification. After API edits, rebuild with
+  `docker compose up -d --build litcal-api`.
+
+---
+
+### Task 1: API — `ResourceAdminService::resolveViewerScopes()`
+
+**Repo:** LiturgicalCalendarAPI
+
+**Files:**
+
+- Modify: `src/Services/ResourceAdminService.php` (after `resolveTestScopes()`, ~line 105)
+- Test: `phpunit_tests/Services/ResourceAdminServiceTest.php`
+
+**Interfaces:**
+
+- Consumes: existing `OpenFgaClient::listObjects(string $user, string $relation, string $type): array` (returns object
+  IDs with the `type:` prefix already stripped, e.g. `['IT']`).
+- Produces: `public const VIEWER_OBJECT_TYPES` and
+  `public function resolveViewerScopes(string $sub): array` returning `array<string, list<string>>` keyed by every
+  entry of `VIEWER_OBJECT_TYPES` (all keys always present). Task 2 consumes both.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+git checkout development && git pull
+git checkout -b feat/dashboard-scopes
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append inside `ResourceAdminServiceTest` (it already has a `serviceWith(array $responses)` helper that queues mocked
+OpenFGA responses in call order):
+
+```php
+    public function testResolveViewerScopesReturnsIdsKeyedByType(): void
+    {
+        // One list-objects response per VIEWER_OBJECT_TYPES entry, in order:
+        // general_roman_calendar, national_calendar_test, diocesan_calendar_test, general_roman_calendar_test
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:temporale","general_roman_calendar:decrees"]}'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        self::assertSame(
+            [
+                'general_roman_calendar'      => ['temporale', 'decrees'],
+                'national_calendar_test'      => ['IT'],
+                'diocesan_calendar_test'      => [],
+                'general_roman_calendar_test' => [],
+            ],
+            $service->resolveViewerScopes('grc-editor')
+        );
+    }
+
+    public function testResolveViewerScopesFailsClosedOnOpenFgaError(): void
+    {
+        $service = $this->serviceWith([
+            new GuzzleResponse(500, [], 'boom'),
+        ]);
+
+        self::assertSame(
+            [
+                'general_roman_calendar'      => [],
+                'national_calendar_test'      => [],
+                'diocesan_calendar_test'      => [],
+                'general_roman_calendar_test' => [],
+            ],
+            $service->resolveViewerScopes('grc-editor')
+        );
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/ResourceAdminServiceTest.php
+```
+
+Expected: 2 errors — `Call to undefined method ...::resolveViewerScopes()`.
+
+- [ ] **Step 4: Implement**
+
+In `src/Services/ResourceAdminService.php`, add after the `TEST_OBJECT_TYPES` constant:
+
+```php
+    /**
+     * Object types whose `viewer` relation the frontend admin dashboard consults
+     * for card visibility (issue LiturgicalCalendarFrontend#399). In the FGA model
+     * `viewer` is a union including `editor` and `admin`, so a single `viewer`
+     * query means "viewer or above".
+     */
+    public const VIEWER_OBJECT_TYPES = [
+        'general_roman_calendar',
+        'national_calendar_test',
+        'diocesan_calendar_test',
+        'general_roman_calendar_test',
+    ];
+```
+
+And add after `resolveTestScopes()`:
+
+```php
+    /**
+     * Object IDs the caller can view (viewer-or-above), keyed by object type,
+     * across VIEWER_OBJECT_TYPES. Every key is always present.
+     *
+     * Fails closed: any OpenFGA transport error yields all-empty lists.
+     *
+     * @param string $sub Zitadel user ID (without "user:" prefix)
+     * @return array<string, list<string>>
+     */
+    public function resolveViewerScopes(string $sub): array
+    {
+        $fgaUser = "user:{$sub}";
+        $scopes  = array_fill_keys(self::VIEWER_OBJECT_TYPES, []);
+
+        try {
+            foreach (self::VIEWER_OBJECT_TYPES as $type) {
+                $scopes[$type] = $this->fgaClient->listObjects($fgaUser, 'viewer', $type);
+            }
+        } catch (\RuntimeException) {
+            return array_fill_keys(self::VIEWER_OBJECT_TYPES, []);
+        }
+
+        return $scopes;
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass, plus static analysis**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/ResourceAdminServiceTest.php && composer analyse
+```
+
+Expected: OK (all tests pass), PHPStan no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/ResourceAdminService.php phpunit_tests/Services/ResourceAdminServiceTest.php
+git commit -m "feat(auth): add ResourceAdminService::resolveViewerScopes for dashboard gating"
+```
+
+---
+
+### Task 2: API — `DashboardScopesHandler` + Router registration
+
+**Repo:** LiturgicalCalendarAPI
+
+**Files:**
+
+- Create: `src/Handlers/Auth/DashboardScopesHandler.php`
+- Modify: `src/Router.php` (auth dispatch ~line 371; OIDC-protected list ~line 622; `use` block near the
+  `AdminScopesHandler` import)
+- Test: `phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php`
+
+**Interfaces:**
+
+- Consumes: `ResourceAdminService::resolveScopes(string $sub)`, `ResourceAdminService::resolveViewerScopes(string $sub)`,
+  `ResourceAdminService::VIEWER_OBJECT_TYPES` (Task 1).
+- Produces: route `GET /auth/dashboard-scopes` returning JSON
+  `{is_global_admin: bool, is_resource_admin: bool, admin_scopes: list<{object_type, object_id}>, viewer_scopes: map<type, list<id>>}`.
+  Tasks 3 (OpenAPI) and 4 (frontend fetch) depend on exactly this shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php` (modeled on `AdminScopesHandlerTest` in the same
+directory — same `handlerWith()` mock plumbing, `requestFor()`, `decodeJsonBody()` from `AbstractHandlerTestCase`):
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Auth;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Handlers\Auth\DashboardScopesHandler;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(DashboardScopesHandler::class)]
+final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
+{
+    /**
+     * @param array<int, GuzzleResponse> $responses
+     */
+    private function handlerWith(array $responses): DashboardScopesHandler
+    {
+        $stack  = HandlerStack::create(new MockHandler($responses));
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+        return new DashboardScopesHandler($client);
+    }
+
+    /**
+     * Response queue order: 4 admin list-objects (ADMIN_OBJECT_TYPES: national_calendar,
+     * diocesan_calendar, wider_region, general_roman_calendar), then 4 viewer list-objects
+     * (VIEWER_OBJECT_TYPES: general_roman_calendar, national_calendar_test,
+     * diocesan_calendar_test, general_roman_calendar_test).
+     *
+     * @param array<int, GuzzleResponse> $viewerResponses
+     * @return array<int, GuzzleResponse>
+     */
+    private static function emptyAdminThenViewer(array $viewerResponses): array
+    {
+        $empty = new GuzzleResponse(200, [], '{"objects":[]}');
+        return [$empty, $empty, $empty, $empty, ...$viewerResponses];
+    }
+
+    public function testMissingOidcUserIsUnauthorized(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->handlerWith([])->handle($this->requestFor('GET', '/auth/dashboard-scopes'));
+    }
+
+    public function testViewerScopesAreKeyedByType(): void
+    {
+        $handler = $this->handlerWith(self::emptyAdminThenViewer([
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:decrees"]}'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]));
+
+        $request = $this->requestFor('GET', '/auth/dashboard-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-editor', 'roles' => ['calendar_editor']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertFalse($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+        self::assertSame(
+            [
+                'general_roman_calendar'      => ['decrees'],
+                'national_calendar_test'      => ['IT'],
+                'diocesan_calendar_test'      => [],
+                'general_roman_calendar_test' => [],
+            ],
+            $body['viewer_scopes']
+        );
+    }
+
+    public function testResourceAdminScopesMatchAdminScopesEndpointSemantics(): void
+    {
+        $empty   = new GuzzleResponse(200, [], '{"objects":[]}');
+        $handler = $this->handlerWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            $empty, $empty, $empty, // remaining admin types
+            $empty, $empty, $empty, $empty, // viewer types
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/dashboard-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-admin', 'roles' => ['calendar_editor']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertTrue($body['is_resource_admin']);
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $body['admin_scopes']
+        );
+    }
+
+    public function testGlobalAdminIsFlaggedFromToken(): void
+    {
+        $handler = $this->handlerWith(self::emptyAdminThenViewer([
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]));
+
+        $request = $this->requestFor('GET', '/auth/dashboard-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'root', 'roles' => ['admin']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertTrue($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+    }
+
+    public function testFailsClosedWhenOpenFgaErrors(): void
+    {
+        // First 500 aborts resolveScopes(); second 500 aborts resolveViewerScopes().
+        $handler = $this->handlerWith([
+            new GuzzleResponse(500, [], 'boom'),
+            new GuzzleResponse(500, [], 'boom'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/dashboard-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'root', 'roles' => ['admin']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertTrue($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+        self::assertSame(
+            [
+                'general_roman_calendar'      => [],
+                'national_calendar_test'      => [],
+                'diocesan_calendar_test'      => [],
+                'general_roman_calendar_test' => [],
+            ],
+            $body['viewer_scopes']
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php
+```
+
+Expected: errors — `Class "LiturgicalCalendar\Api\Handlers\Auth\DashboardScopesHandler" not found`.
+
+- [ ] **Step 3: Create the handler**
+
+Create `src/Handlers/Auth/DashboardScopesHandler.php` (mirrors `AdminScopesHandler.php` in the same directory):
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Dashboard Scopes Handler
+ *
+ * GET /auth/dashboard-scopes — batched capability report for the frontend admin
+ * dashboard (LiturgicalCalendarFrontend#399). One round-trip returns everything
+ * the dashboard needs to gate its cards server-side:
+ *   - is_global_admin: the Zitadel `admin` role is present in the token.
+ *   - is_resource_admin / admin_scopes: same semantics as GET /auth/admin-scopes.
+ *   - viewer_scopes: object IDs the caller can view (viewer-or-above; the FGA
+ *     model unions `viewer` with `editor` and `admin`), keyed by object type,
+ *     across ResourceAdminService::VIEWER_OBJECT_TYPES.
+ *
+ * Fails closed: when OpenFGA is unavailable, all scope lists are empty, but
+ * is_global_admin is still honored from the token.
+ */
+final class DashboardScopesHandler extends AbstractHandler
+{
+    private ?OpenFgaClient $fgaClient = null;
+
+    public function __construct(?OpenFgaClient $fgaClient = null)
+    {
+        parent::__construct();
+
+        $this->fgaClient             = $fgaClient;
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+        $this->allowCredentials      = true;
+    }
+
+    private function isFgaClientAvailable(): bool
+    {
+        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
+    }
+
+    private function getFgaClient(): OpenFgaClient
+    {
+        if ($this->fgaClient === null) {
+            $this->fgaClient = OpenFgaClient::fromEnv();
+        }
+        return $this->fgaClient;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+        $method   = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime)
+            ->withHeader('Cache-Control', 'no-store');
+
+        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+
+        $sub = $oidcUser['sub'] ?? null;
+        if (!is_string($sub) || trim($sub) === '') {
+            throw new UnauthorizedException('Invalid authentication token');
+        }
+
+        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
+
+        $adminScopes  = [];
+        $viewerScopes = array_fill_keys(ResourceAdminService::VIEWER_OBJECT_TYPES, []);
+        if ($this->isFgaClientAvailable()) {
+            $service      = new ResourceAdminService($this->getFgaClient());
+            $adminScopes  = $service->resolveScopes($sub);
+            $viewerScopes = $service->resolveViewerScopes($sub);
+        }
+
+        return $this->encodeResponseBody($response, [
+            'is_global_admin'   => $isGlobalAdmin,
+            'is_resource_admin' => $adminScopes !== [],
+            'admin_scopes'      => $adminScopes,
+            'viewer_scopes'     => $viewerScopes,
+        ]);
+    }
+}
+```
+
+- [ ] **Step 4: Register the route in `src/Router.php`**
+
+Three edits:
+
+1. In the `use` block, next to the existing `AdminScopesHandler` import, add:
+
+   ```php
+   use LiturgicalCalendar\Api\Handlers\Auth\DashboardScopesHandler;
+   ```
+
+2. In the auth dispatch chain, after the `test-scopes` elseif (~line 371-375):
+
+   ```php
+                       } elseif ($authRoute === 'dashboard-scopes') {
+                           // GET /auth/dashboard-scopes - Batched admin/viewer scopes for the frontend admin dashboard
+                           $dashboardScopesHandler = new DashboardScopesHandler();
+                           $this->handler          = $dashboardScopesHandler;
+   ```
+
+3. In the OIDC-protected auth route list (~line 622), add `'dashboard-scopes'`:
+
+   ```php
+   in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications', 'admin-scopes', 'test-scopes', 'dashboard-scopes'], true)
+   ```
+
+- [ ] **Step 5: Run tests to verify they pass, plus static analysis and lint**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php && composer analyse && composer lint
+```
+
+Expected: all tests PASS, PHPStan clean, phpcs clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Handlers/Auth/DashboardScopesHandler.php src/Router.php phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php
+git commit -m "feat(auth): add GET /auth/dashboard-scopes batched capability endpoint"
+```
+
+---
+
+### Task 3: API — OpenAPI schema + full-suite verification
+
+**Repo:** LiturgicalCalendarAPI
+
+**Files:**
+
+- Modify: `jsondata/schemas/openapi.json` (add path `/auth/dashboard-scopes`; add component schema
+  `DashboardScopesResponse`)
+
+**Interfaces:**
+
+- Consumes: response shape from Task 2.
+- Produces: OpenAPI documentation only; no code interfaces.
+
+- [ ] **Step 1: Add the path entry**
+
+In `openapi.json` `paths`, alongside `/auth/admin-scopes`, add:
+
+```json
+"/auth/dashboard-scopes": {
+    "get": {
+        "tags": ["Authentication"],
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "summary": "Get the caller's batched dashboard capability scopes",
+        "operationId": "authDashboardScopes",
+        "description": "Batched capability report for the frontend admin dashboard: global-admin flag, resource-admin scopes (as /auth/admin-scopes), and viewer-or-above object IDs keyed by object type across general_roman_calendar and the *_test types. Response is not cacheable (`Cache-Control: no-store`).",
+        "responses": {
+            "200": {
+                "description": "OK: Dashboard scope information",
+                "headers": {
+                    "Cache-Control": {
+                        "schema": { "type": "string", "example": "no-store" },
+                        "description": "Always set to `no-store` to prevent caching of auth state."
+                    }
+                },
+                "content": {
+                    "application/json": {
+                        "schema": { "$ref": "#/components/schemas/DashboardScopesResponse" }
+                    }
+                }
+            },
+            "401": { "$ref": "#/components/responses/Unauthorized401" }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the component schema**
+
+In `components.schemas`, alongside `AdminScopesResponse`, add (reusing its `admin_scopes` item shape verbatim):
+
+```json
+"DashboardScopesResponse": {
+    "type": "object",
+    "properties": {
+        "is_global_admin": {
+            "type": "boolean",
+            "description": "True when the caller holds the global `admin` Zitadel role."
+        },
+        "is_resource_admin": {
+            "type": "boolean",
+            "description": "True when the caller holds an OpenFGA `admin` relation on at least one resource."
+        },
+        "admin_scopes": {
+            "type": "array",
+            "description": "Resources the caller administers via OpenFGA. Empty when `is_resource_admin` is false.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "object_type": { "type": "string", "example": "national_calendar", "description": "The OpenFGA object type." },
+                    "object_id": { "type": "string", "example": "IT", "description": "The OpenFGA object ID." }
+                },
+                "required": ["object_type", "object_id"],
+                "additionalProperties": false
+            }
+        },
+        "viewer_scopes": {
+            "type": "object",
+            "description": "Object IDs the caller can view (viewer-or-above), keyed by OpenFGA object type. Keys cover general_roman_calendar, national_calendar_test, diocesan_calendar_test and general_roman_calendar_test.",
+            "additionalProperties": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "example": {
+                "general_roman_calendar": ["temporale", "decrees"],
+                "national_calendar_test": ["IT"],
+                "diocesan_calendar_test": [],
+                "general_roman_calendar_test": []
+            }
+        }
+    },
+    "required": ["is_global_admin", "is_resource_admin", "admin_scopes", "viewer_scopes"],
+    "additionalProperties": false
+}
+```
+
+- [ ] **Step 3: Lint the OpenAPI schema and run the full API suite**
+
+```bash
+composer lint:openapi && composer parallel-lint && composer lint && composer analyse && composer test:quick
+```
+
+Expected: Redocly lint clean; phpcs/PHPStan clean; PHPUnit green (slow group excluded).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add jsondata/schemas/openapi.json
+git commit -m "docs(openapi): document GET /auth/dashboard-scopes"
+```
+
+---
+
+### Task 4: Frontend — `AuthHelper` dashboard-scopes support
+
+**Repo:** LiturgicalCalendarFrontend
+
+**Files:**
+
+- Modify: `src/AuthHelper.php` (new property next to `$adminScopesResult` ~line 54; new methods after `adminScopes()`
+  ~line 333; new static fetch after `fetchAdminScopes()` ~line 434)
+- Test: `tests/AuthHelperDashboardScopesTest.php` (new; modeled on `tests/AuthHelperAdminScopesTest.php`)
+
+**Interfaces:**
+
+- Consumes: `GET {apiBase}/auth/dashboard-scopes` (Task 2 shape); existing private `buildCookieHeader()`,
+  `ApiConfig::getInstance()->apiBaseUrl`, `API_INTERNAL_URL` env override.
+- Produces (Task 5 consumes exactly these):
+  - `public function dashboardScopes(): array` —
+    `array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}`
+  - `public function canViewResource(string $objectType, string $objectId): bool`
+  - `public function canViewAnyResourceOfType(string ...$objectTypes): bool`
+  - `public static function fetchDashboardScopes(string $apiBaseUrl, ?string $cookieHeader, ?\GuzzleHttp\Client $client = null): array`
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+git checkout development
+git checkout -b feature/admin-dashboard-fga-gating
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/AuthHelperDashboardScopesTest.php`. Copy the `clientWith()`, `stashAndClearEnv()` and `restoreEnv()`
+helpers verbatim from `tests/AuthHelperAdminScopesTest.php`, then add:
+
+```php
+    public function testFetchDashboardScopesParsesFullResponse(): void
+    {
+        $client = $this->clientWith(new Response(200, [], json_encode([
+            'is_global_admin'   => false,
+            'is_resource_admin' => true,
+            'admin_scopes'      => [
+                ['object_type' => 'national_calendar', 'object_id' => 'IT'],
+            ],
+            'viewer_scopes'     => [
+                'general_roman_calendar'      => ['temporale', 'decrees'],
+                'national_calendar_test'      => ['IT'],
+                'diocesan_calendar_test'      => [],
+                'general_roman_calendar_test' => [],
+            ],
+        ])));
+
+        $result = AuthHelper::fetchDashboardScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_global_admin']);
+        self::assertTrue($result['is_resource_admin']);
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $result['admin_scopes']
+        );
+        self::assertSame(['temporale', 'decrees'], $result['viewer_scopes']['general_roman_calendar']);
+        self::assertSame(['IT'], $result['viewer_scopes']['national_calendar_test']);
+    }
+
+    public function testFetchDashboardScopesFailsClosedOnHttpError(): void
+    {
+        $client = $this->clientWith(new Response(401, [], 'Unauthorized'));
+
+        $result = AuthHelper::fetchDashboardScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_global_admin']);
+        self::assertFalse($result['is_resource_admin']);
+        self::assertSame([], $result['admin_scopes']);
+        self::assertSame([], $result['viewer_scopes']);
+    }
+
+    public function testFetchDashboardScopesFiltersMalformedViewerScopes(): void
+    {
+        $client = $this->clientWith(new Response(200, [], json_encode([
+            'is_global_admin'   => false,
+            'is_resource_admin' => false,
+            'admin_scopes'      => [],
+            'viewer_scopes'     => [
+                'general_roman_calendar' => ['temporale', 42, null],
+                'bogus_non_list'         => 'not-an-array',
+            ],
+        ])));
+
+        $result = AuthHelper::fetchDashboardScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertSame(['temporale'], $result['viewer_scopes']['general_roman_calendar']);
+        self::assertArrayNotHasKey('bogus_non_list', $result['viewer_scopes']);
+    }
+
+    public function testUnauthenticatedInstanceFailsClosedAndMemoizes(): void
+    {
+        AuthHelper::reset();
+        $envSaved = $this->stashAndClearEnv(['ZITADEL_ISSUER', 'ZITADEL_CLIENT_ID', 'JWT_SECRET']);
+
+        $cookieSaved = [];
+        foreach (['litcal_access_token', 'litcal_id_token'] as $name) {
+            $cookieSaved[$name] = $_COOKIE[$name] ?? null;
+            unset($_COOKIE[$name]);
+        }
+
+        try {
+            $auth = AuthHelper::getInstance();
+            self::assertFalse($auth->isAuthenticated, 'Precondition: instance must be unauthenticated');
+
+            self::assertFalse($auth->dashboardScopes()['is_resource_admin']);
+            self::assertSame([], $auth->dashboardScopes()['viewer_scopes']);
+            self::assertFalse($auth->canViewResource('general_roman_calendar', 'decrees'));
+            self::assertFalse($auth->canViewAnyResourceOfType('national_calendar_test', 'diocesan_calendar_test'));
+        } finally {
+            $this->restoreEnv($envSaved);
+            foreach ($cookieSaved as $name => $val) {
+                if ($val !== null) {
+                    $_COOKIE[$name] = $val;
+                }
+            }
+            AuthHelper::reset();
+        }
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+vendor/bin/phpunit tests/AuthHelperDashboardScopesTest.php
+```
+
+Expected: errors — `Call to undefined method ...::fetchDashboardScopes()` / `dashboardScopes()`.
+
+- [ ] **Step 4: Implement in `src/AuthHelper.php`**
+
+Add the memoization property next to `$adminScopesResult`:
+
+```php
+    /**
+     * Memoized dashboard-scopes result for this request.
+     *
+     * @var array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}|null
+     */
+    private ?array $dashboardScopesResult = null;
+```
+
+Add after `adminScopes()`:
+
+```php
+    /**
+     * The caller's batched dashboard capability scopes, resolved once per request
+     * from GET /auth/dashboard-scopes (server-side, using the caller's session
+     * cookies). Lazy: the API is only contacted on first use. Fails closed.
+     *
+     * @return array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}
+     */
+    public function dashboardScopes(): array
+    {
+        if ($this->dashboardScopesResult !== null) {
+            return $this->dashboardScopesResult;
+        }
+
+        if (!$this->isAuthenticated) {
+            return $this->dashboardScopesResult = [
+                'is_global_admin'   => false,
+                'is_resource_admin' => false,
+                'admin_scopes'      => [],
+                'viewer_scopes'     => [],
+            ];
+        }
+
+        $internalUrl = $_ENV['API_INTERNAL_URL'] ?? getenv('API_INTERNAL_URL') ?: null;
+        $apiBaseUrl  = $internalUrl ? rtrim($internalUrl, '/') : ApiConfig::getInstance()->apiBaseUrl;
+
+        return $this->dashboardScopesResult = self::fetchDashboardScopes($apiBaseUrl, self::buildCookieHeader());
+    }
+
+    /**
+     * Whether the caller can view (viewer-or-above) a specific OpenFGA object.
+     * Global admins (Zitadel role) always can — no API call is made for them.
+     */
+    public function canViewResource(string $objectType, string $objectId): bool
+    {
+        if ($this->hasRole('admin')) {
+            return true;
+        }
+        return in_array($objectId, $this->dashboardScopes()['viewer_scopes'][$objectType] ?? [], true);
+    }
+
+    /**
+     * Whether the caller can view (viewer-or-above) ANY object of any of the
+     * given OpenFGA object types. Global admins always can.
+     */
+    public function canViewAnyResourceOfType(string ...$objectTypes): bool
+    {
+        if ($this->hasRole('admin')) {
+            return true;
+        }
+        $viewerScopes = $this->dashboardScopes()['viewer_scopes'];
+        foreach ($objectTypes as $type) {
+            if (( $viewerScopes[$type] ?? [] ) !== []) {
+                return true;
+            }
+        }
+        return false;
+    }
+```
+
+Add after `fetchAdminScopes()` (same Guzzle defaults: `timeout 5`, `connect_timeout 2`, `http_errors true`):
+
+```php
+    /**
+     * Fetch and parse GET /auth/dashboard-scopes. Fails closed on any error.
+     *
+     * @param string $apiBaseUrl Base API URL (no trailing slash)
+     * @param string|null $cookieHeader Cookie header forwarding the caller's session
+     * @param \GuzzleHttp\Client|null $client Injectable client (tests)
+     * @return array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}
+     */
+    public static function fetchDashboardScopes(
+        string $apiBaseUrl,
+        ?string $cookieHeader,
+        ?\GuzzleHttp\Client $client = null
+    ): array {
+        $failClosed = [
+            'is_global_admin'   => false,
+            'is_resource_admin' => false,
+            'admin_scopes'      => [],
+            'viewer_scopes'     => [],
+        ];
+
+        $client ??= new \GuzzleHttp\Client(['timeout' => 5, 'connect_timeout' => 2, 'http_errors' => true]);
+
+        $headers = ['Accept' => 'application/json'];
+        if ($cookieHeader !== null) {
+            $headers['Cookie'] = $cookieHeader;
+        }
+
+        try {
+            $response = $client->get("{$apiBaseUrl}/auth/dashboard-scopes", ['headers' => $headers]);
+            $data     = json_decode((string) $response->getBody(), true);
+        } catch (\Throwable) {
+            return $failClosed;
+        }
+
+        if (!is_array($data)) {
+            return $failClosed;
+        }
+
+        $adminScopes = [];
+        if (isset($data['admin_scopes']) && is_array($data['admin_scopes'])) {
+            foreach ($data['admin_scopes'] as $scope) {
+                if (
+                    is_array($scope)
+                    && isset($scope['object_type'], $scope['object_id'])
+                    && is_string($scope['object_type'])
+                    && is_string($scope['object_id'])
+                ) {
+                    $adminScopes[] = ['object_type' => $scope['object_type'], 'object_id' => $scope['object_id']];
+                }
+            }
+        }
+
+        $viewerScopes = [];
+        if (isset($data['viewer_scopes']) && is_array($data['viewer_scopes'])) {
+            foreach ($data['viewer_scopes'] as $type => $ids) {
+                if (!is_string($type) || !is_array($ids)) {
+                    continue;
+                }
+                $viewerScopes[$type] = array_values(array_filter($ids, 'is_string'));
+            }
+        }
+
+        // Strict, fail-closed booleans: only an explicit JSON `true` counts,
+        // mirroring fetchAdminScopes().
+        return [
+            'is_global_admin'   => ( $data['is_global_admin'] ?? false ) === true,
+            'is_resource_admin' => ( $data['is_resource_admin'] ?? false ) === true,
+            'admin_scopes'      => $adminScopes,
+            'viewer_scopes'     => $viewerScopes,
+        ];
+    }
+```
+
+- [ ] **Step 5: Run tests, lint, static analysis**
+
+```bash
+vendor/bin/phpunit tests/AuthHelperDashboardScopesTest.php && composer test && composer lint && composer analyse
+```
+
+Expected: new tests PASS, full frontend suite still green, phpcs and PHPStan (level 7) clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AuthHelper.php tests/AuthHelperDashboardScopesTest.php
+git commit -m "feat(auth): AuthHelper dashboard-scopes fetch with viewer-scope helpers (#399)"
+```
+
+---
+
+### Task 5: Frontend — server-side card gating
+
+**Repo:** LiturgicalCalendarFrontend
+
+**Files:**
+
+- Modify: `admin-dashboard.php` (branch conditions at lines 126, 136, 146)
+- Modify: `includes/admin-blocks.php` (temporale + decrees entries; render loop)
+- Modify: `includes/admin-decrees-card.php` (delete interim script + data attributes)
+
+**Interfaces:**
+
+- Consumes: `$authHelper->canViewResource()`, `$authHelper->canViewAnyResourceOfType()`,
+  `$authHelper->dashboardScopes()` (Task 4); `$isAdmin` and `$authHelper` from `includes/common.php` /
+  `admin-dashboard.php`.
+- Produces: rendered dashboard; e2e selectors unchanged (`.admin-block[data-block-id="..."]`,
+  `a[href="admin-decrees.php"]`, `a[href="admin-tests.php"]`, `.admin-block:has(i.fa-inbox)`).
+
+- [ ] **Step 1: Gate the Temporale and Decrees blocks in `includes/admin-blocks.php`**
+
+Add a `visible` key to the `temporale` entry (after `'permission' => 'temporale:write'`):
+
+```php
+        'permission'  => 'temporale:write',
+        // Relation-aware gating (#399): non-admins need the calendar_editor role AND
+        // viewer-or-above on general_roman_calendar:temporale.
+        'visible'     => $isAdmin || (
+            $authHelper->hasRole('calendar_editor')
+            && $authHelper->canViewResource('general_roman_calendar', 'temporale')
+        )
+```
+
+Add the analogous `visible` key to the `decrees` entry:
+
+```php
+        'permission'  => 'decrees:write',
+        'visible'     => $isAdmin || (
+            $authHelper->hasRole('calendar_editor')
+            && $authHelper->canViewResource('general_roman_calendar', 'decrees')
+        )
+```
+
+At the top of the render loop, skip hidden blocks (blocks without a `visible` key stay visible):
+
+```php
+foreach ($adminBlocks as $block) {
+    if (( $block['visible'] ?? true ) === false) {
+        continue;
+    }
+```
+
+Also extend the file docblock: the component now expects `$isAdmin` (bool) and `$authHelper` (AuthHelper) to be
+defined by the including page (`admin-dashboard.php`).
+
+- [ ] **Step 2: Gate the section branches in `admin-dashboard.php`**
+
+Line 126 (dedicated Decrees card section) — from:
+
+```php
+<?php if (!$isAdmin && $authHelper->hasRole('calendar_editor')) : ?>
+```
+
+to:
+
+```php
+<?php if (!$isAdmin && $authHelper->hasRole('calendar_editor') && $authHelper->canViewResource('general_roman_calendar', 'decrees')) : ?>
+```
+
+Line 136 (Tests card section) — from:
+
+```php
+<?php if (!$isAdmin && $authHelper->hasRole('test_editor')) : ?>
+```
+
+to:
+
+```php
+<?php if (
+    !$isAdmin
+    && $authHelper->hasRole('test_editor')
+    && $authHelper->canViewAnyResourceOfType('national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test')
+) : ?>
+```
+
+Line 146 (Access Requests card) — from:
+
+```php
+<?php if (!$isAdmin && $authHelper->isResourceAdmin()) : ?>
+```
+
+to (same rule, but sourced from the single batched call so the dashboard makes exactly one scopes request):
+
+```php
+<?php if (!$isAdmin && $authHelper->dashboardScopes()['is_resource_admin']) : ?>
+```
+
+- [ ] **Step 3: Remove the interim client-side check from `includes/admin-decrees-card.php`**
+
+Delete the entire `<script>(function () { ... }());</script>` block and the `data-fga-gate` / `data-user-sub`
+attributes from the wrapper `<div>`, leaving:
+
+```php
+<div class="col-12 col-md-6 col-lg-4 mb-4">
+```
+
+Update the file docblock: visibility is now decided server-side in `admin-dashboard.php` via
+`AuthHelper::canViewResource('general_roman_calendar', 'decrees')`; global admins always see the card.
+Remove the stale `@var string $apiBaseUrl` reference if no longer used in the file.
+
+- [ ] **Step 4: Lint and static analysis**
+
+```bash
+composer parallel-lint && composer lint && composer analyse
+```
+
+Expected: clean. (If phpcs flags the modified files, run `composer lint:fix` and re-check.)
+
+- [ ] **Step 5: Manual smoke against the docker stack (optional but recommended)**
+
+```bash
+docker compose up -d --build litcal-api
+docker compose up -d --force-recreate litcal-frontend
+```
+
+Log in as a seeded global admin → all cards visible. Log in as a calendar_editor without GRC relations →
+Temporale and Decrees blocks absent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add admin-dashboard.php includes/admin-blocks.php includes/admin-decrees-card.php
+git commit -m "feat(admin-dashboard): relation-aware card gating via dashboard-scopes (#399)"
+```
+
+---
+
+### Task 6: Frontend — e2e coverage
+
+**Repo:** LiturgicalCalendarFrontend
+
+**Files:**
+
+- Modify: `e2e/rbac/support/users.ts` (role union + two seeded `test_editor` users)
+- Modify: `e2e/rbac/07-dashboard-card-scoping.spec.ts` (per-user visible/hidden block matrix)
+- Create: `e2e/rbac/15-dashboard-tests-card-matrix.spec.ts`
+
+**Interfaces:**
+
+- Consumes: dashboard DOM from Task 5; support helpers `actingAs(browser, userKey)`, `grantScope(userKey, {role?})`,
+  `revokeScope(userKey)`; `rbac.setup.ts` auto-seeds every `SEEDED_USER_IDS` entry (Zitadel user + role + `.auth`
+  state; FGA tuples seeded only for `relation: 'admin'` users).
+- Produces: green e2e suite documenting the new gating.
+
+**Why seeded users (not runtime role grants):** Zitadel roles are baked into the JWT at login. A role granted after
+`.auth` state is written (spec-14 style runtime grants) would not appear in the stored token, so `hasRole()` would
+fail. FGA tuples ARE evaluated live, so tuple grants at runtime remain fine.
+
+- [ ] **Step 1: Add `test_editor` users to `e2e/rbac/support/users.ts`**
+
+Widen the role union:
+
+```ts
+    role: 'admin' | 'calendar_editor' | 'test_editor';
+```
+
+(also update the `mk()` parameter type if it repeats the union). Add to `USERS`:
+
+```ts
+    'tests-editor': mk('tests-editor', 'test_editor', { relation: 'editor', objectType: 'national_calendar_test', objectId: 'IT' }),
+    'tests-editor-noscope': mk('tests-editor-noscope', 'test_editor', null),
+```
+
+Both are seeded automatically (they are not in `REGISTRATION_USER_IDS`). `tests-editor`'s tuple is NOT seeded by
+`seedUser` (only `admin` relations are) — spec 15 grants it at runtime via `grantScope`.
+
+- [ ] **Step 2: Update the matrix in `e2e/rbac/07-dashboard-card-scoping.spec.ts`**
+
+Replace the "all six cards visible" assertion with a per-user visible/hidden block matrix. Update the `Expected`
+interface and `MATRIX`:
+
+```ts
+interface Expected {
+    visibleBlocks: readonly string[];
+    hiddenBlocks: readonly string[];
+    globalAdminSection: boolean;
+    reviewCard: boolean;
+}
+
+const ALWAYS_VISIBLE = ['sanctorale', 'widerregion', 'national', 'diocesan'] as const;
+
+const MATRIX: Record<string, Expected> = {
+    // Global admin: role bypasses all FGA gates — all six blocks.
+    'super-admin': { visibleBlocks: [...ALWAYS_VISIBLE, 'temporale', 'decrees'], hiddenBlocks: [], globalAdminSection: true, reviewCard: false },
+    // calendar_editors WITHOUT any general_roman_calendar relation: temporale + decrees hidden.
+    'cei-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
+    'cei-editor': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: false },
+    'usccb-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
+    // admin@general_roman_calendar:temporale → temporale visible (viewer via admin), decrees still hidden.
+    'grc-admin': { visibleBlocks: [...ALWAYS_VISIBLE, 'temporale'], hiddenBlocks: ['decrees'], globalAdminSection: false, reviewCard: true },
+    'europe-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
+};
+```
+
+In `assertMatrix()`, replace the six-card loop with:
+
+```ts
+    for (const id of expected.visibleBlocks) {
+        await expect(page.locator(SEL.calendarBlock(id))).toBeVisible();
+    }
+    for (const id of expected.hiddenBlocks) {
+        await expect(page.locator(SEL.calendarBlock(id))).toHaveCount(0);
+    }
+```
+
+Rewrite the header comment's "NOTE on scope narrowing" section: the dashboard NOW narrows Temporale/Decrees block
+visibility by `general_roman_calendar` viewer relation (issue #399, server-side via `/auth/dashboard-scopes`); the
+remaining four blocks stay role-gated.
+
+- [ ] **Step 3: Create `e2e/rbac/15-dashboard-tests-card-matrix.spec.ts`**
+
+```ts
+/**
+ * Scenario 15 — dashboard Tests-card matrix (test_editor role × FGA test scope)
+ *
+ * Issue #399: the Tests card renders for non-admins only when the user holds the
+ * test_editor role AND a viewer-or-above relation on at least one *_test object
+ * (checked server-side via GET /auth/dashboard-scopes).
+ *
+ * Preconditions (seeded by rbac-setup):
+ *   - tests-editor: Zitadel test_editor role, no FGA tuple at seed time; this spec
+ *     grants editor@national_calendar_test:IT at runtime (FGA is evaluated live,
+ *     unlike Zitadel roles which are baked into the login token).
+ *   - tests-editor-noscope: Zitadel test_editor role, never granted any tuple.
+ */
+
+import { test, expect, Browser } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+import { grantScope, revokeScope } from './support/grant';
+
+const TESTS_CARD_LINK = 'a[href="admin-tests.php"]';
+const HEADING = '.admin-dashboard-heading';
+
+test.describe.serial('15 — dashboard Tests-card matrix', () => {
+    test.beforeAll(async () => {
+        // editor@national_calendar_test:IT — editor satisfies the viewer-or-above gate.
+        await grantScope('tests-editor', { role: false });
+    });
+
+    test.afterAll(async () => {
+        await revokeScope('tests-editor');
+    });
+
+    test('test_editor WITH a test scope sees the Tests card', async ({ browser }) => {
+        const page = await actingAs(browser, 'tests-editor');
+        await page.goto('/admin-dashboard.php');
+        await expect(page.locator(HEADING)).toBeVisible();
+        await expect(page.locator(TESTS_CARD_LINK)).toBeVisible();
+        await page.context().close();
+    });
+
+    test('test_editor WITHOUT a test scope does NOT see the Tests card', async ({ browser }) => {
+        const page = await actingAs(browser, 'tests-editor-noscope');
+        await page.goto('/admin-dashboard.php');
+        await expect(page.locator(HEADING)).toBeVisible();
+        await expect(page.locator(TESTS_CARD_LINK)).toHaveCount(0);
+        await page.context().close();
+    });
+});
+```
+
+Match `actingAs`'s actual signature/return to how `14-admin-decrees-capability-matrix.spec.ts` uses it — adjust the
+two call sites if it returns `{ page, context }` instead of a bare `Page`.
+
+- [ ] **Step 4: Typecheck and run the affected specs**
+
+```bash
+yarn typecheck
+```
+
+Expected: clean. Then, with the docker stack up (API rebuilt in Task 5 Step 5):
+
+```bash
+yarn test:chromium e2e/rbac/07-dashboard-card-scoping.spec.ts e2e/rbac/15-dashboard-tests-card-matrix.spec.ts
+```
+
+Expected: both specs green (rbac.setup reseeds users, including the two new `test_editor` users).
+
+- [ ] **Step 5: Run the full rbac e2e suite (regression)**
+
+```bash
+yarn test:chromium e2e/rbac
+```
+
+Expected: all green — notably 12 (test_editor request flow), 13 (admin-tests CRUD) and 14 (decrees matrix) must be
+unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/rbac/support/users.ts e2e/rbac/07-dashboard-card-scoping.spec.ts e2e/rbac/15-dashboard-tests-card-matrix.spec.ts
+git commit -m "test(e2e): dashboard card gating matrix by FGA relation (#399)"
+```
+
+---
+
+### Task 7: Final verification (both repos)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: API repo full check**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+composer parallel-lint && composer lint && composer analyse && composer test:quick && composer lint:openapi
+```
+
+Expected: all clean/green.
+
+- [ ] **Step 2: Frontend repo full check**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+composer parallel-lint && composer lint && composer analyse && composer test && composer lint:md && yarn typecheck && yarn lint
+```
+
+Expected: all clean/green.
+
+- [ ] **Step 3: Report and stop**
+
+Report results to the user. Do NOT push either branch and do NOT open PRs — wait for the user's explicit request.
+When asked: open the API PR first (`feat/dashboard-scopes` → `development` in LiturgicalCalendarAPI), then the
+frontend PR (`feature/admin-dashboard-fga-gating` → `development`), noting the frontend PR depends on the API one.

--- a/docs/superpowers/specs/2026-07-12-admin-dashboard-fga-gating-design.md
+++ b/docs/superpowers/specs/2026-07-12-admin-dashboard-fga-gating-design.md
@@ -1,0 +1,137 @@
+# Admin Dashboard Relation-Aware Card Gating — Design
+
+**Date:** 2026-07-12
+**Issue:** [Liturgical-Calendar/LiturgicalCalendarFrontend#399](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/issues/399)
+**Repos touched:** LiturgicalCalendarAPI (new endpoint), LiturgicalCalendarFrontend (gating)
+
+## Problem
+
+Admin-dashboard cards are gated purely on Zitadel roles. A user holding the `test_editor` role but no
+test-scope OpenFGA relation still sees the Tests card, and only discovers they cannot do anything after
+entering the page. The Decrees card ships an interim per-card client-side `/admin/permissions/check`
+script (one fetch per card, visible flash) that was explicitly marked for replacement by a batched check.
+
+## Goal
+
+Cards reflect what the user can actually do: Zitadel roles remain the coarse outer gate, OpenFGA
+relations refine visibility. All relation checks for the dashboard happen server-side at render time,
+in **one** API round-trip.
+
+## Decisions (from brainstorming)
+
+- Small API addition approved: new batched `GET /auth/dashboard-scopes` endpoint (Approach 1).
+- Gating happens server-side during render; the interim client-side script is deleted.
+- Fail closed: on any scopes-fetch error, relation-gated cards are hidden. Global admins are
+  unaffected (their visibility derives from the token role only).
+- Scope: Tests card, Decrees card/block, and Temporale block. The Sanctorale (missals-editor) block is
+  **excluded** — the missals editor extends to any `calendar_editor`, so it stays role-gated only.
+  Wider Region / National / Diocesan blocks are unchanged. Access Requests card keeps its rule but
+  reads from the new batched payload. In-page capability logic (`admin-tests.js`, `admin-decrees.js`)
+  is out of scope.
+
+## Section 1 — API: `GET /auth/dashboard-scopes`
+
+New `DashboardScopesHandler` in `src/Handlers/Auth/`, modeled on `AdminScopesHandler`:
+GET-only, JSON, `allowCredentials`, `Cache-Control: no-store`, requires `oidc_user` (401 otherwise).
+
+Response shape:
+
+```json
+{
+    "is_global_admin": false,
+    "is_resource_admin": false,
+    "admin_scopes": [ { "object_type": "national_calendar", "object_id": "NL" } ],
+    "viewer_scopes": {
+        "general_roman_calendar": [ "temporale", "decrees" ],
+        "national_calendar_test": [ "NL" ],
+        "diocesan_calendar_test": [],
+        "general_roman_calendar_test": []
+    }
+}
+```
+
+- `is_global_admin`, `is_resource_admin`, `admin_scopes`: same semantics as `/auth/admin-scopes`,
+  computed via the existing `ResourceAdminService::resolveScopes()`.
+- New `ResourceAdminService::resolveViewerScopes(string $sub): array<string, list<string>>` —
+  one `listObjects(viewer)` call per type over a new constant
+  `VIEWER_OBJECT_TYPES = ['general_roman_calendar', 'national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test']`.
+  In the FGA model `viewer` is a union including `editor` and `admin`, so a single `viewer` query is
+  exactly "viewer or above". Fails closed: any FGA transport error yields all-empty lists.
+- `is_global_admin` is honored from the token even when OpenFGA is unavailable.
+- Router: add `dashboard-scopes` to the `/auth` sub-route dispatch and to the OIDC-protected auth
+  route list.
+- Update `jsondata/schemas/openapi.json` (`composer lint:openapi` must pass).
+- `/auth/admin-scopes` and `/auth/test-scopes` are untouched (other consumers exist:
+  `admin-permissions.php`, `admin-tests.php`, `auth.js`, `notifications.js`, `admin-tests.js`).
+
+## Section 2 — Frontend gating
+
+### AuthHelper additions
+
+Mirror the existing `loadAdminScopes()` pattern: server-side Guzzle call to
+`{API_INTERNAL_URL|apiBaseUrl}/auth/dashboard-scopes`, forwarding the session cookies, memoized per
+request, injectable client for tests, fail closed on any error.
+
+- `dashboardScopes(): array` — full payload
+  (`is_global_admin`, `is_resource_admin`, `admin_scopes`, `viewer_scopes`).
+- `canViewResource(string $objectType, string $objectId): bool` — true if global admin OR
+  `$objectId` is present in `viewer_scopes[$objectType]`.
+- `canViewAnyResourceOfType(string ...$objectTypes): bool` — true if global admin OR any of the
+  listed types has a non-empty viewer scope list.
+- `public static fetchDashboardScopes(string $apiBaseUrl, ?string $cookieHeader, ?Client $client = null): array`
+  — fetch + parse + fail-closed, mirroring `fetchAdminScopes()`.
+
+The loader is lazy: it fires only when a gate consults it. All gates short-circuit on `$isAdmin`
+(token role), so a global admin's dashboard render performs **zero** scopes calls; every other user
+performs exactly **one**.
+
+### Card gating matrix (non-admin rules; global admins always see their cards)
+
+| Card / block                                        | Visibility rule for non-admins                                            |
+|-----------------------------------------------------|---------------------------------------------------------------------------|
+| Temporale block (admin-blocks grid)                 | `calendar_editor` role AND viewer+ on `general_roman_calendar:temporale`  |
+| Decrees block (grid) and dedicated Decrees card     | `calendar_editor` role AND viewer+ on `general_roman_calendar:decrees`    |
+| Tests card                                          | `test_editor` role AND viewer+ on any `*_test` object                     |
+| Access Requests card                                | unchanged rule, read from `dashboardScopes()['is_resource_admin']`        |
+| Sanctorale, Wider Region, National, Diocesan blocks | unchanged (role-gated as today)                                           |
+| Users, Applications, Permissions cards              | unchanged (`isAdmin` only)                                                |
+
+### Mechanics
+
+- `includes/admin-blocks.php`: each block config gains a `visible` condition (computed with
+  `$isAdmin` / `$authHelper` from the including page); blocks with `visible === false` are skipped.
+  Untouched blocks default to visible.
+- `admin-dashboard.php`: the non-admin section branches fold the relation check into the branch
+  condition, so no empty "Administration" heading renders when the card is hidden.
+- `includes/admin-decrees-card.php`: delete the interim inline `<script>` and the
+  `data-fga-gate` / `data-user-sub` attributes; the card renders only when the server-side gate passed.
+- No new user-visible strings (no i18n changes).
+
+## Section 3 — Error handling, testing, rollout
+
+### Error handling
+
+- Fail closed: fetch error, timeout, non-200, or malformed body → empty scopes →
+  relation-gated cards hidden. Role-only cards and global-admin visibility unaffected.
+- Guzzle timeouts identical to `fetchAdminScopes()`: 5 s total, 2 s connect.
+
+### Testing
+
+- **API (PHPUnit):** new handler test mirroring `AdminScopesHandler` coverage — 401 when
+  unauthenticated; `is_global_admin` from token; viewer/admin scope resolution with a mocked
+  `OpenFgaClient`; fail-closed (empty scopes) when the FGA client throws.
+- **Frontend (PHPUnit):** `fetchDashboardScopes()` parsing and fail-closed behavior;
+  `canViewResource()` / `canViewAnyResourceOfType()` logic including the global-admin bypass.
+- **Frontend (Playwright e2e):** dashboard card-visibility matrix by FGA grant, following the
+  admin-decrees capability-matrix pattern: `test_editor` without any test scope sees no Tests card;
+  with a viewer grant sees it; `calendar_editor` without decrees/temporale viewer sees neither the
+  Decrees card nor the Temporale block; global admin sees everything.
+
+### Rollout
+
+Two PRs, both targeting `development` in their respective repos:
+
+1. **API:** `DashboardScopesHandler` + `resolveViewerScopes()` + router + OpenAPI + tests.
+2. **Frontend:** `AuthHelper` additions + card gating + interim-script deletion + tests. Lands after
+   the API PR merges (the local docker stack builds the API from the sibling repo, so local e2e works
+   before the API PR merges upstream).

--- a/e2e/rbac/07-dashboard-card-scoping.spec.ts
+++ b/e2e/rbac/07-dashboard-card-scoping.spec.ts
@@ -15,8 +15,7 @@ import { USERS } from './support/users';
  * durable DOM (data-block-id / href / icon-class locators), not text/toasts.
  *
  * ── Pinned selectors (derived from admin-dashboard.php + includes/admin-blocks.php) ──
- *   Calendar section (includes/admin-blocks.php, ALWAYS rendered for any calendar-role
- *   holder — see the gate below): six cards, each
+ *   Calendar section (includes/admin-blocks.php): six possible cards, each
  *       .admin-block[data-block-id="<id>"]
  *   with ids: temporale, sanctorale, decrees, widerregion, national, diocesan.
  *
@@ -25,44 +24,45 @@ import { USERS } from './support/users';
  *       a[href="admin-users.php"]          (only in the $isAdmin block)
  *       a[href="admin-applications.php"]   (only in the $isAdmin block)
  *   `a[href="admin-permissions.php"]` is NOT unique — it also backs the resource-admin
- *   review card (L160) — so it is deliberately not used to identify the global section.
+ *   review card (L167) — so it is deliberately not used to identify the global section.
  *
- *   Resource-admin review card (admin-dashboard.php L143, gated on
- *   `!$isAdmin && $authHelper->isResourceAdmin()`): the only `.admin-block` carrying the
- *   fa-inbox icon →
+ *   Resource-admin review card (admin-dashboard.php L150, gated on
+ *   `!$isAdmin && $authHelper->dashboardScopes()['is_resource_admin']`): the only
+ *   `.admin-block` carrying the fa-inbox icon →
  *       .admin-block:has(i.fa-inbox)        ("Access Requests to Review")
  *
- * ── Gating (admin-dashboard.php) ──
+ * ── Gating (admin-dashboard.php + includes/admin-blocks.php) ──
  *   - L15  unauthenticated            → redirect to index.php
  *   - L24  $hasCalendarRole = admin | calendar_editor | test_editor
  *   - L29  !$hasCalendarRole          → redirect to developer-dashboard.php
- *           ⇒ every user that REACHES the dashboard renders ALL SIX calendar cards.
  *   - L62  $isAdmin                   → global admin section (admin-users/applications/…)
- *   - L143 !$isAdmin && isResourceAdmin() → single "Access Requests to Review" card
- *   `isResourceAdmin()` (src/AuthHelper.php) is true when the user holds an `admin` FGA
- *   tuple on ANY resource (national/diocesan/general_roman/wider_region). All *-admin
- *   users hold such a tuple; cei-editor holds none (editor grants are earned via UI).
+ *   - L150 !$isAdmin && dashboardScopes()['is_resource_admin'] → "Access Requests to
+ *          Review" card
  *
- * ── Empirically-confirmed per-user matrix (durable DOM) ──
- *   user          | 6 calendar cards | global admin section | review card (fa-inbox)
- *   --------------|------------------|----------------------|-----------------------
- *   super-admin   | visible          | VISIBLE              | hidden (gated on !$isAdmin)
- *   cei-admin     | visible          | hidden               | VISIBLE
- *   cei-editor    | visible          | hidden               | hidden
- *   usccb-admin   | visible          | hidden               | VISIBLE
- *   grc-admin     | visible          | hidden               | VISIBLE
- *   europe-admin  | visible          | hidden               | VISIBLE
+ *   admin-blocks.php (#399, relation-aware gating): sanctorale/widerregion/national/
+ *   diocesan render unconditionally for any calendar-role holder. temporale and decrees,
+ *   however, are each independently narrowed to:
+ *       $isAdmin || ($authHelper->hasRole('calendar_editor') && canViewResource(...))
+ *   i.e. non-admins additionally need viewer-or-above on
+ *   general_roman_calendar:temporale (for the Temporale card) and
+ *   general_roman_calendar:decrees (for the Decrees card). `isResourceAdmin()`
+ *   (src/AuthHelper.php, via dashboardScopes()) is true when the user holds an `admin`
+ *   FGA tuple on ANY resource (national/diocesan/general_roman/wider_region).
  *
- * ── NOTE on "scope narrowing" (IT vs USA, romamo_it, GRC, Europe) ──
- *   The dashboard does NOT narrow calendar-CARD visibility by scope. admin-blocks.php
- *   renders all six cards unconditionally for every calendar-role holder, and the
- *   client JS (assets/js/admin-dashboard.js) only toggles per-card EDIT BUTTONS /
- *   COUNT BADGES, never the cards themselves. So cei-admin (IT), usccb-admin (US),
- *   grc-admin and europe-admin all see an IDENTICAL set of cards — scope enforcement
- *   lives downstream (extending.php / the API), not in card visibility. This spec
- *   therefore asserts the real, observable behaviour and explicitly verifies that all
- *   resource-admins see the same card set (no scope-based card hiding), rather than a
- *   per-scope card subset that the running app does not implement.
+ * ── NOTE on scope narrowing (issue #399) ──
+ *   Prior to #399, the dashboard did not narrow calendar-CARD visibility by scope at
+ *   all — all six cards rendered unconditionally for every calendar-role holder. The
+ *   server-side `/auth/dashboard-scopes` endpoint (AuthHelper::dashboardScopes()) now
+ *   narrows Temporale and Decrees specifically: a calendar_editor whose only FGA
+ *   relation is on a national/diocesan/wider_region object (e.g. cei-admin on IT,
+ *   usccb-admin on US, europe-admin on Europe) holds no viewer-or-above relation on
+ *   general_roman_calendar, so temporale and decrees are both hidden for them. Only
+ *   grc-admin (admin@general_roman_calendar:temporale) satisfies the Temporale gate —
+ *   an `admin` relation on an FGA object also satisfies viewer-or-above self-checks —
+ *   but even grc-admin's tuple is scoped to the `temporale` object id, not `decrees`,
+ *   so decrees remains hidden for grc-admin too. The remaining four blocks
+ *   (sanctorale/widerregion/national/diocesan) are unaffected by #399 and stay
+ *   role-gated only, so they render for every user in the matrix below.
  *
  * Preconditions (seeded by rbac-setup): super-admin, cei-editor, usccb-admin,
  *   grc-admin, europe-admin (.auth/<id>.json each).
@@ -70,8 +70,6 @@ import { USERS } from './support/users';
  *   rbac-setup; seedAndLogin provisions it (Zitadel account + admin@IT tuple + .auth),
  *   and afterAll purges it.
  */
-
-const CALENDAR_BLOCK_IDS = ['temporale', 'sanctorale', 'decrees', 'widerregion', 'national', 'diocesan'] as const;
 
 const SEL = {
     heading: '.admin-dashboard-heading',
@@ -82,17 +80,24 @@ const SEL = {
 } as const;
 
 interface Expected {
+    visibleBlocks: readonly string[];
+    hiddenBlocks: readonly string[];
     globalAdminSection: boolean; // Users + Applications cards ($isAdmin block)
     reviewCard: boolean; // "Access Requests to Review" (!$isAdmin && isResourceAdmin)
 }
 
+const ALWAYS_VISIBLE = ['sanctorale', 'widerregion', 'national', 'diocesan'] as const;
+
 const MATRIX: Record<string, Expected> = {
-    'super-admin': { globalAdminSection: true, reviewCard: false },
-    'cei-admin': { globalAdminSection: false, reviewCard: true },
-    'cei-editor': { globalAdminSection: false, reviewCard: false },
-    'usccb-admin': { globalAdminSection: false, reviewCard: true },
-    'grc-admin': { globalAdminSection: false, reviewCard: true },
-    'europe-admin': { globalAdminSection: false, reviewCard: true },
+    // Global admin: role bypasses all FGA gates — all six blocks.
+    'super-admin': { visibleBlocks: [...ALWAYS_VISIBLE, 'temporale', 'decrees'], hiddenBlocks: [], globalAdminSection: true, reviewCard: false },
+    // calendar_editors WITHOUT any general_roman_calendar relation: temporale + decrees hidden.
+    'cei-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
+    'cei-editor': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: false },
+    'usccb-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
+    // admin@general_roman_calendar:temporale → temporale visible (viewer via admin), decrees still hidden.
+    'grc-admin': { visibleBlocks: [...ALWAYS_VISIBLE, 'temporale'], hiddenBlocks: ['decrees'], globalAdminSection: false, reviewCard: true },
+    'europe-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
 };
 
 async function assertMatrix(page: Page, expected: Expected): Promise<void> {
@@ -102,9 +107,11 @@ async function assertMatrix(page: Page, expected: Expected): Promise<void> {
     // index.php / developer-dashboard.php) before asserting card visibility.
     await expect(page.locator(SEL.heading)).toBeVisible();
 
-    // All six calendar cards render for every calendar-role holder (no scope hiding).
-    for (const id of CALENDAR_BLOCK_IDS) {
+    for (const id of expected.visibleBlocks) {
         await expect(page.locator(SEL.calendarBlock(id))).toBeVisible();
+    }
+    for (const id of expected.hiddenBlocks) {
+        await expect(page.locator(SEL.calendarBlock(id))).toHaveCount(0);
     }
 
     // Global admin section (global FGA-tuple management): super-admin only.

--- a/e2e/rbac/09-revoke-after-grant.spec.ts
+++ b/e2e/rbac/09-revoke-after-grant.spec.ts
@@ -19,8 +19,15 @@ import { USERS } from './support/users';
  *   2. Moves the request row to the 'revoked' status tab on admin-permissions.php.
  *   3. Shows the revoked badge on the requester's permission-requests.php.
  *   4. Does NOT remove the Zitadel calendar_editor role — so cei-editor still
- *      reaches admin-dashboard.php and sees all six calendar blocks (no scope-
- *      based card hiding: same behaviour documented in scenario 07).
+ *      reaches admin-dashboard.php throughout (before grant, after grant, and
+ *      after revoke). Per #399's relation-aware card gating (includes/admin-
+ *      blocks.php), cei-editor's only possible FGA grant is editor@
+ *      national_calendar:IT, which carries no viewer-or-above relation on
+ *      general_roman_calendar — so the temporale and decrees blocks are hidden
+ *      for cei-editor at every point in this lifecycle. The four unconditional
+ *      blocks (sanctorale/widerregion/national/diocesan) remain visible
+ *      throughout, unaffected by the grant/revoke (same matrix documented in
+ *      scenario 07).
  *
  * Preconditions (created on-demand):
  *   - cei-admin: Zitadel calendar_editor role, FGA admin@national_calendar:IT
@@ -39,13 +46,40 @@ import { USERS } from './support/users';
  *   dropdown.
  */
 
-const CALENDAR_BLOCK_IDS = [
-    'temporale', 'sanctorale', 'decrees', 'widerregion', 'national', 'diocesan',
+const ALWAYS_VISIBLE_BLOCK_IDS = [
+    'sanctorale', 'widerregion', 'national', 'diocesan',
 ] as const;
+
+const RELATION_GATED_BLOCK_IDS = ['temporale', 'decrees'] as const;
+
+// Asserts the #399 card matrix for cei-editor: the four unconditional blocks are
+// visible and temporale/decrees are hidden, regardless of the editor@
+// national_calendar:IT grant's lifecycle state (absent, active, or revoked) —
+// that grant never carries a general_roman_calendar relation.
+async function assertCeiEditorCardMatrix(browser: Parameters<typeof actingAs>[0]): Promise<void> {
+    const { context, page } = await actingAs(browser, 'cei-editor');
+    try {
+        await page.goto('/admin-dashboard.php');
+        await expect(page.locator('.admin-dashboard-heading')).toBeVisible();
+        for (const id of ALWAYS_VISIBLE_BLOCK_IDS) {
+            await expect(page.locator(`.admin-block[data-block-id="${id}"]`)).toBeVisible();
+        }
+        for (const id of RELATION_GATED_BLOCK_IDS) {
+            await expect(page.locator(`.admin-block[data-block-id="${id}"]`)).toHaveCount(0);
+        }
+    } finally {
+        await context.close();
+    }
+}
 
 test('09 — revoke-after-grant: FGA tuple removed and request shows revoked status', async ({ browser }) => {
     // ── Precondition: seed cei-admin (IT admin) ───────────────────────────────
     await seedAndLogin('cei-admin');
+
+    // ── Precondition check: before any grant, cei-editor already sees the #399
+    // matrix (temporale/decrees hidden) — establishes the baseline the grant/
+    // revoke lifecycle below must not disturb.
+    await assertCeiEditorCardMatrix(browser);
 
     // ── Step 1: cei-editor submits request for editor@national_calendar:IT ────
     const ceied = await actingAs(browser, 'cei-editor');
@@ -77,6 +111,11 @@ test('09 — revoke-after-grant: FGA tuple removed and request shows revoked sta
     expect(
         await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:IT'),
     ).toBe(true);
+
+    // ── Post-grant check: with the editor@national_calendar:IT tuple now active,
+    // the #399 matrix is unchanged — that relation doesn't touch
+    // general_roman_calendar, so temporale/decrees stay hidden.
+    await assertCeiEditorCardMatrix(browser);
 
     // ── Step 4: cei-admin revokes the grant ───────────────────────────────────
     const ceiadm2 = await actingAs(browser, 'cei-admin');
@@ -134,17 +173,18 @@ test('09 — revoke-after-grant: FGA tuple removed and request shows revoked sta
 
     // ── Step 9: Secondary — cei-editor still reaches dashboard (role intact) ──
     // Revoking the FGA tuple does NOT remove the Zitadel calendar_editor role.
-    // cei-editor therefore still passes the dashboard gate and sees all six
-    // calendar blocks (no scope-based card hiding — matches scenario 07 matrix).
+    // cei-editor therefore still passes the dashboard gate. Per #399, temporale
+    // and decrees remain hidden after revoke (cei-editor never held a relation
+    // on general_roman_calendar — only editor@national_calendar:IT, which was
+    // just revoked); the four unconditional blocks stay visible.
+    await assertCeiEditorCardMatrix(browser);
+
+    // The resource-admin "Access Requests to Review" card must NOT appear
+    // (cei-editor holds no admin FGA tuple).
     const ceied3 = await actingAs(browser, 'cei-editor');
     try {
         await ceied3.page.goto('/admin-dashboard.php');
         await expect(ceied3.page.locator('.admin-dashboard-heading')).toBeVisible();
-        for (const id of CALENDAR_BLOCK_IDS) {
-            await expect(ceied3.page.locator(`.admin-block[data-block-id="${id}"]`)).toBeVisible();
-        }
-        // The resource-admin "Access Requests to Review" card must NOT appear
-        // (cei-editor holds no admin FGA tuple).
         await expect(ceied3.page.locator('.admin-block:has(i.fa-inbox)')).toHaveCount(0);
     } finally {
         await ceied3.context.close();

--- a/e2e/rbac/15-dashboard-tests-card-matrix.spec.ts
+++ b/e2e/rbac/15-dashboard-tests-card-matrix.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Scenario 15 — dashboard Tests-card matrix (test_editor role x FGA test scope)
+ *
+ * Issue #399: the Tests card renders for non-admins only when the user holds the
+ * test_editor role AND a viewer-or-above relation on at least one *_test object
+ * (checked server-side via GET /auth/dashboard-scopes).
+ *
+ * Preconditions (seeded by rbac-setup):
+ *   - tests-editor: Zitadel test_editor role, no FGA tuple at seed time; this spec
+ *     grants editor@national_calendar_test:IT at runtime (FGA is evaluated live,
+ *     unlike Zitadel roles which are baked into the login token).
+ *   - tests-editor-noscope: Zitadel test_editor role, never granted any tuple.
+ */
+
+import { test, expect } from '@playwright/test';
+import { actingAs } from './support/actingAs';
+import { grantScope, revokeScope } from './support/grant';
+
+// Scoped to the dashboard admin-block card, not layout/header.php's own nav-link to the
+// same href (`.nav-link[href="admin-tests.php"]`), which renders independently of the
+// per-user gating asserted here and would otherwise make the plain href selector
+// ambiguous (strict-mode violation: 2 matches).
+const TESTS_CARD_LINK = '.admin-block a[href="admin-tests.php"]';
+const HEADING = '.admin-dashboard-heading';
+
+test.describe.serial('15 — dashboard Tests-card matrix', () => {
+    test.beforeAll(async () => {
+        // editor@national_calendar_test:IT — editor satisfies the viewer-or-above gate.
+        await grantScope('tests-editor', { role: false });
+    });
+
+    test.afterAll(async () => {
+        await revokeScope('tests-editor');
+    });
+
+    test('test_editor WITH a test scope sees the Tests card', async ({ browser }) => {
+        const { context, page } = await actingAs(browser, 'tests-editor');
+        try {
+            await page.goto('/admin-dashboard.php');
+            await expect(page.locator(HEADING)).toBeVisible();
+            await expect(page.locator(TESTS_CARD_LINK)).toBeVisible();
+        } finally {
+            await context.close();
+        }
+    });
+
+    test('test_editor WITHOUT a test scope does NOT see the Tests card', async ({ browser }) => {
+        const { context, page } = await actingAs(browser, 'tests-editor-noscope');
+        try {
+            await page.goto('/admin-dashboard.php');
+            await expect(page.locator(HEADING)).toBeVisible();
+            await expect(page.locator(TESTS_CARD_LINK)).toHaveCount(0);
+        } finally {
+            await context.close();
+        }
+    });
+});

--- a/e2e/rbac/support/users.test.ts
+++ b/e2e/rbac/support/users.test.ts
@@ -1,18 +1,39 @@
 import { test, expect } from '@playwright/test';
 import { USERS, SEEDED_USER_IDS, REGISTRATION_USER_IDS } from './users';
 
-test('matrix has 11 users with unique emails', () => {
+test('matrix has 13 users with unique emails', () => {
     const ids = Object.keys(USERS);
-    expect(ids).toHaveLength(11);
+    expect(ids).toHaveLength(13);
     const emails = ids.map((i) => USERS[i].email);
-    expect(new Set(emails).size).toBe(11);
+    expect(new Set(emails).size).toBe(13);
 });
 
-test('only super-admin holds the global admin role; others are calendar_editor', () => {
-    expect(USERS['super-admin'].role).toBe('admin');
+test('roles are assigned per fixture design: super-admin=admin, tests-editor*=test_editor, rest=calendar_editor', () => {
+    const validRoles = ['admin', 'calendar_editor', 'test_editor'];
+    const testEditorIds = ['tests-editor', 'tests-editor-noscope'];
+
+    for (const id of Object.keys(USERS)) {
+        expect(validRoles).toContain(USERS[id].role);
+
+        if (id === 'super-admin') {
+            expect(USERS[id].role).toBe('admin');
+        } else if (testEditorIds.includes(id)) {
+            expect(USERS[id].role).toBe('test_editor');
+        } else {
+            expect(USERS[id].role).toBe('calendar_editor');
+        }
+    }
+});
+
+test('super-admin has no fga scope; tests-editor-noscope has no fga scope by design; all others are scoped', () => {
     expect(USERS['super-admin'].fga).toBeNull();
-    for (const id of Object.keys(USERS).filter((i) => i !== 'super-admin')) {
-        expect(USERS[id].role).toBe('calendar_editor');
+    // tests-editor-noscope is the deliberate "role without scope" fixture: test_editor role, fga: null
+    expect(USERS['tests-editor-noscope'].fga).toBeNull();
+
+    const scopedIds = Object.keys(USERS).filter(
+        (id) => id !== 'super-admin' && id !== 'tests-editor-noscope'
+    );
+    for (const id of scopedIds) {
         expect(USERS[id].fga).not.toBeNull();
     }
 });

--- a/e2e/rbac/support/users.ts
+++ b/e2e/rbac/support/users.ts
@@ -4,7 +4,7 @@ export interface RbacUser {
     id: string;
     email: string;
     password: string;
-    role: 'admin' | 'calendar_editor';
+    role: 'admin' | 'calendar_editor' | 'test_editor';
     fga: { relation: RbacRelation; objectType: string; objectId: string } | null;
 }
 
@@ -26,6 +26,8 @@ export const USERS: Record<string, RbacUser> = {
     'grc-editor': mk('grc-editor', 'calendar_editor', { relation: 'editor', objectType: 'general_roman_calendar', objectId: 'temporale' }),
     'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: 'Europe' }),
     'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: 'Europe' }),
+    'tests-editor': mk('tests-editor', 'test_editor', { relation: 'editor', objectType: 'national_calendar_test', objectId: 'IT' }),
+    'tests-editor-noscope': mk('tests-editor-noscope', 'test_editor', null),
 };
 
 export const REGISTRATION_USER_IDS = ['cei-admin', 'usccb-editor'];

--- a/includes/admin-blocks.php
+++ b/includes/admin-blocks.php
@@ -5,6 +5,10 @@
  *
  * Renders the 6 admin section blocks for the unified admin dashboard.
  * Each block displays a title, description, count badge, and action buttons.
+ *
+ * Expects the following variables to be defined by the including page:
+ * - $isAdmin (bool): Whether the current user has the admin role.
+ * - $authHelper (AuthHelper): Authentication and authorization helper instance.
  */
 
 $adminBlocks = [
@@ -16,7 +20,13 @@ $adminBlocks = [
         'description' => _('Proprium de Tempore - temporal cycle events'),
         'viewUrl'     => 'temporale.php',
         'editUrl'     => 'temporale.php?edit=1',
-        'permission'  => 'temporale:write'
+        'permission'  => 'temporale:write',
+        // Relation-aware gating (#399): non-admins need the calendar_editor role AND
+        // viewer-or-above on general_roman_calendar:temporale.
+        'visible'     => $isAdmin || (
+            $authHelper->hasRole('calendar_editor')
+            && $authHelper->canViewResource('general_roman_calendar', 'temporale')
+        )
     ],
     [
         'id'          => 'sanctorale',
@@ -36,7 +46,11 @@ $adminBlocks = [
         'description' => _('Congregation for Divine Worship decrees'),
         'viewUrl'     => 'admin-decrees.php',
         'editUrl'     => 'admin-decrees.php',
-        'permission'  => 'decrees:write'
+        'permission'  => 'decrees:write',
+        'visible'     => $isAdmin || (
+            $authHelper->hasRole('calendar_editor')
+            && $authHelper->canViewResource('general_roman_calendar', 'decrees')
+        )
     ],
     [
         'id'          => 'widerregion',
@@ -71,6 +85,10 @@ $adminBlocks = [
 ];
 
 foreach ($adminBlocks as $block) {
+    if (( $block['visible'] ?? true ) === false) {
+        continue;
+    }
+
     $id          = htmlspecialchars($block['id'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     $icon        = htmlspecialchars($block['icon'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     $color       = htmlspecialchars($block['color'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');

--- a/includes/admin-decrees-card.php
+++ b/includes/admin-decrees-card.php
@@ -1,8 +1,7 @@
 <?php
 
 /**
- * @var bool   $isAdmin    Defined by the including page (admin-dashboard.php).
- * @var string $apiBaseUrl Defined by includes/common.php.
+ * @var bool $isAdmin Defined by the including page (admin-dashboard.php).
  */
 
 /**
@@ -11,15 +10,13 @@
  * blocks grid) and scoped calendar_editors (in their own Administration section),
  * so the markup lives here once instead of being duplicated per branch.
  *
- * The data-fga-gate attribute is used by Task 3 capability detection to hide
- * this card when the user has no viewer relation on the resource. Global admins
- * always see it regardless of FGA state.
+ * Visibility is now decided server-side in admin-dashboard.php via
+ * AuthHelper::canViewResource('general_roman_calendar', 'decrees').
+ * Global admins always see the card.
  */
 
 ?>
-<div class="col-12 col-md-6 col-lg-4 mb-4"
-    data-fga-gate="general_roman_calendar:decrees"
-    data-user-sub="<?php echo htmlspecialchars($authHelper->sub ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+<div class="col-12 col-md-6 col-lg-4 mb-4">
     <div class="card admin-block shadow h-100 border-dark">
         <div class="card-body text-center d-flex flex-column">
             <div class="admin-block-icon mb-3">
@@ -37,60 +34,3 @@
         </div>
     </div>
 </div>
-<script>
-(function () {
-    'use strict';
-    // Interim per-card FGA visibility check (Task 3 will batch these).
-    // Global admins always see the card; for calendar_editors we confirm
-    // the viewer relation via /admin/permissions/check before showing the link.
-    const isGlobalAdmin = <?php echo json_encode($isAdmin); ?>;
-    if (isGlobalAdmin) {
-        return; // always visible for global admins
-    }
-    const card = document.currentScript.closest('[data-fga-gate]');
-    if (!card) {
-        return;
-    }
-    const apiBase = <?php echo json_encode($apiBaseUrl); ?>;
-    const gate = card.dataset.fgaGate; // "general_roman_calendar:decrees"
-    const parts = gate.split(':');
-    const objectType = parts[0];
-    const objectId   = parts[1];
-    const userSub    = card.dataset.userSub;
-    const params     = new URLSearchParams({
-        user:        userSub,
-        object_type: objectType,
-        object_id:   objectId,
-        relation:    'viewer'
-    });
-    var controller = new AbortController();
-    var timeoutId = setTimeout(function () { controller.abort(); }, 15000);
-    fetch(apiBase + '/admin/permissions/check?' + params.toString(), {
-        credentials: 'include',
-        headers: { 'Accept': 'application/json' },
-        signal: controller.signal
-    })
-        .then(function (r) {
-            clearTimeout(timeoutId);
-            if (!r.ok) {
-                console.warn('[admin-decrees-card] permissions/check returned HTTP ' + r.status + ' — hiding card');
-                card.classList.add('d-none');
-                return null;
-            }
-            return r.json();
-        })
-        .then(function (data) {
-            if (data === null) {
-                return;
-            }
-            if (!data || data.allowed !== true) {
-                card.classList.add('d-none');
-            }
-        })
-        .catch(function (err) {
-            clearTimeout(timeoutId);
-            console.warn('[admin-decrees-card] permissions/check unreachable — hiding card', err);
-            card.classList.add('d-none');
-        });
-}());
-</script>

--- a/includes/admin-decrees-card.php
+++ b/includes/admin-decrees-card.php
@@ -1,10 +1,6 @@
 <?php
 
 /**
- * @var bool $isAdmin Defined by the including page (admin-dashboard.php).
- */
-
-/**
  * "Decrees" dashboard card.
  * Rendered from admin-dashboard.php for both global admins (inside the admin
  * blocks grid) and scoped calendar_editors (in their own Administration section),
@@ -16,6 +12,7 @@
  */
 
 ?>
+
 <div class="col-12 col-md-6 col-lg-4 mb-4">
     <div class="card admin-block shadow h-100 border-dark">
         <div class="card-body text-center d-flex flex-column">

--- a/includes/admin-decrees-card.php
+++ b/includes/admin-decrees-card.php
@@ -2,13 +2,11 @@
 
 /**
  * "Decrees" dashboard card.
- * Rendered from admin-dashboard.php for both global admins (inside the admin
- * blocks grid) and scoped calendar_editors (in their own Administration section),
- * so the markup lives here once instead of being duplicated per branch.
+ * Rendered from admin-dashboard.php for scoped calendar_editors in their own Administration section.
+ * The markup lives here instead of being duplicated per branch.
  *
- * Visibility is now decided server-side in admin-dashboard.php via
+ * Visibility is decided server-side in admin-dashboard.php via
  * AuthHelper::canViewResource('general_roman_calendar', 'decrees').
- * Global admins always see the card.
  */
 
 ?>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -57,3 +57,15 @@ parameters:
                 - translations.php
                 - usage.php
                 - user-profile.php
+        # Included blocks pass variables from their includer (e.g., admin-blocks.php uses
+        # $isAdmin and $authHelper from admin-dashboard.php). PHPStan cannot detect this
+        # since it doesn't execute include statements. These are FALSE POSITIVES.
+        -
+            message: '#Variable \$isAdmin might not be defined\.#'
+            paths:
+                - includes/admin-blocks.php
+                - includes/admin-decrees-card.php
+        -
+            message: '#Variable \$authHelper might not be defined\.#'
+            paths:
+                - includes/admin-blocks.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -64,7 +64,6 @@ parameters:
             message: '#Variable \$isAdmin might not be defined\.#'
             paths:
                 - includes/admin-blocks.php
-                - includes/admin-decrees-card.php
         -
             message: '#Variable \$authHelper might not be defined\.#'
             paths:

--- a/src/AuthHelper.php
+++ b/src/AuthHelper.php
@@ -51,6 +51,12 @@ class AuthHelper
      * @var array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}|null
      */
     private ?array $adminScopesResult = null;
+    /**
+     * Memoized dashboard-scopes result for this request.
+     *
+     * @var array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}|null
+     */
+    private ?array $dashboardScopesResult = null;
 
     /**
      * Private constructor - use getInstance() to get the singleton
@@ -332,6 +338,64 @@ class AuthHelper
     }
 
     /**
+     * The caller's batched dashboard capability scopes, resolved once per request
+     * from GET /auth/dashboard-scopes (server-side, using the caller's session
+     * cookies). Lazy: the API is only contacted on first use. Fails closed.
+     *
+     * @return array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}
+     */
+    public function dashboardScopes(): array
+    {
+        if ($this->dashboardScopesResult !== null) {
+            return $this->dashboardScopesResult;
+        }
+
+        if (!$this->isAuthenticated) {
+            return $this->dashboardScopesResult = [
+                'is_global_admin'   => false,
+                'is_resource_admin' => false,
+                'admin_scopes'      => [],
+                'viewer_scopes'     => [],
+            ];
+        }
+
+        $internalUrl = $_ENV['API_INTERNAL_URL'] ?? getenv('API_INTERNAL_URL') ?: null;
+        $apiBaseUrl  = $internalUrl ? rtrim($internalUrl, '/') : ApiConfig::getInstance()->apiBaseUrl;
+
+        return $this->dashboardScopesResult = self::fetchDashboardScopes($apiBaseUrl, self::buildCookieHeader());
+    }
+
+    /**
+     * Whether the caller can view (viewer-or-above) a specific OpenFGA object.
+     * Global admins (Zitadel role) always can — no API call is made for them.
+     */
+    public function canViewResource(string $objectType, string $objectId): bool
+    {
+        if ($this->hasRole('admin')) {
+            return true;
+        }
+        return in_array($objectId, $this->dashboardScopes()['viewer_scopes'][$objectType] ?? [], true);
+    }
+
+    /**
+     * Whether the caller can view (viewer-or-above) ANY object of any of the
+     * given OpenFGA object types. Global admins always can.
+     */
+    public function canViewAnyResourceOfType(string ...$objectTypes): bool
+    {
+        if ($this->hasRole('admin')) {
+            return true;
+        }
+        $viewerScopes = $this->dashboardScopes()['viewer_scopes'];
+        foreach ($objectTypes as $type) {
+            if (( $viewerScopes[$type] ?? [] ) !== []) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Resolve (and memoize) the admin-scopes result for this request.
      *
      * @return array{is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>}
@@ -428,6 +492,78 @@ class AuthHelper
         return [
             'is_resource_admin' => ( $data['is_resource_admin'] ?? false ) === true,
             'admin_scopes'      => $scopes,
+        ];
+    }
+
+    /**
+     * Fetch and parse GET /auth/dashboard-scopes. Fails closed on any error.
+     *
+     * @param string $apiBaseUrl Base API URL (no trailing slash)
+     * @param string|null $cookieHeader Cookie header forwarding the caller's session
+     * @param \GuzzleHttp\Client|null $client Injectable client (tests)
+     * @return array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}
+     */
+    public static function fetchDashboardScopes(
+        string $apiBaseUrl,
+        ?string $cookieHeader,
+        ?\GuzzleHttp\Client $client = null
+    ): array {
+        $failClosed = [
+            'is_global_admin'   => false,
+            'is_resource_admin' => false,
+            'admin_scopes'      => [],
+            'viewer_scopes'     => [],
+        ];
+
+        $client ??= new \GuzzleHttp\Client(['timeout' => 5, 'connect_timeout' => 2, 'http_errors' => true]);
+
+        $headers = ['Accept' => 'application/json'];
+        if ($cookieHeader !== null) {
+            $headers['Cookie'] = $cookieHeader;
+        }
+
+        try {
+            $response = $client->get("{$apiBaseUrl}/auth/dashboard-scopes", ['headers' => $headers]);
+            $data     = json_decode((string) $response->getBody(), true);
+        } catch (\Throwable) {
+            return $failClosed;
+        }
+
+        if (!is_array($data)) {
+            return $failClosed;
+        }
+
+        $adminScopes = [];
+        if (isset($data['admin_scopes']) && is_array($data['admin_scopes'])) {
+            foreach ($data['admin_scopes'] as $scope) {
+                if (
+                    is_array($scope)
+                    && isset($scope['object_type'], $scope['object_id'])
+                    && is_string($scope['object_type'])
+                    && is_string($scope['object_id'])
+                ) {
+                    $adminScopes[] = ['object_type' => $scope['object_type'], 'object_id' => $scope['object_id']];
+                }
+            }
+        }
+
+        $viewerScopes = [];
+        if (isset($data['viewer_scopes']) && is_array($data['viewer_scopes'])) {
+            foreach ($data['viewer_scopes'] as $type => $ids) {
+                if (!is_string($type) || !is_array($ids)) {
+                    continue;
+                }
+                $viewerScopes[$type] = array_values(array_filter($ids, 'is_string'));
+            }
+        }
+
+        // Strict, fail-closed booleans: only an explicit JSON `true` counts,
+        // mirroring fetchAdminScopes().
+        return [
+            'is_global_admin'   => ( $data['is_global_admin'] ?? false ) === true,
+            'is_resource_admin' => ( $data['is_resource_admin'] ?? false ) === true,
+            'admin_scopes'      => $adminScopes,
+            'viewer_scopes'     => $viewerScopes,
         ];
     }
 

--- a/tests/AuthHelperDashboardScopesTest.php
+++ b/tests/AuthHelperDashboardScopesTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Frontend\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Frontend\AuthHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AuthHelper::class)]
+final class AuthHelperDashboardScopesTest extends TestCase
+{
+    private function clientWith(Response ...$responses): Client
+    {
+        return new Client(['handler' => HandlerStack::create(new MockHandler($responses))]);
+    }
+
+    /**
+     * Clear a set of env vars from both $_ENV and the process environment,
+     * returning the previous values so they can be restored.
+     *
+     * @param list<string> $keys
+     * @return array<string, array{env: string|null, proc: string|false}>
+     */
+    private function stashAndClearEnv(array $keys): array
+    {
+        $saved = [];
+        foreach ($keys as $k) {
+            $saved[$k] = ['env' => $_ENV[$k] ?? null, 'proc' => getenv($k)];
+            unset($_ENV[$k]);
+            putenv($k); // no '=value' → removes the variable from the process environment
+        }
+        return $saved;
+    }
+
+    /**
+     * @param array<string, array{env: string|null, proc: string|false}> $saved
+     */
+    private function restoreEnv(array $saved): void
+    {
+        foreach ($saved as $k => $v) {
+            if ($v['env'] !== null) {
+                $_ENV[$k] = $v['env'];
+            }
+            if ($v['proc'] !== false) {
+                putenv("{$k}={$v['proc']}");
+            }
+        }
+    }
+
+    public function testFetchDashboardScopesParsesFullResponse(): void
+    {
+        $client = $this->clientWith(new Response(200, [], json_encode([
+            'is_global_admin'   => false,
+            'is_resource_admin' => true,
+            'admin_scopes'      => [
+                ['object_type' => 'national_calendar', 'object_id' => 'IT'],
+            ],
+            'viewer_scopes'     => [
+                'general_roman_calendar'      => ['temporale', 'decrees'],
+                'national_calendar_test'      => ['IT'],
+                'diocesan_calendar_test'      => [],
+                'general_roman_calendar_test' => [],
+            ],
+        ])));
+
+        $result = AuthHelper::fetchDashboardScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_global_admin']);
+        self::assertTrue($result['is_resource_admin']);
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $result['admin_scopes']
+        );
+        self::assertSame(['temporale', 'decrees'], $result['viewer_scopes']['general_roman_calendar']);
+        self::assertSame(['IT'], $result['viewer_scopes']['national_calendar_test']);
+    }
+
+    public function testFetchDashboardScopesFailsClosedOnHttpError(): void
+    {
+        $client = $this->clientWith(new Response(401, [], 'Unauthorized'));
+
+        $result = AuthHelper::fetchDashboardScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertFalse($result['is_global_admin']);
+        self::assertFalse($result['is_resource_admin']);
+        self::assertSame([], $result['admin_scopes']);
+        self::assertSame([], $result['viewer_scopes']);
+    }
+
+    public function testFetchDashboardScopesFiltersMalformedViewerScopes(): void
+    {
+        $client = $this->clientWith(new Response(200, [], json_encode([
+            'is_global_admin'   => false,
+            'is_resource_admin' => false,
+            'admin_scopes'      => [],
+            'viewer_scopes'     => [
+                'general_roman_calendar' => ['temporale', 42, null],
+                'bogus_non_list'         => 'not-an-array',
+            ],
+        ])));
+
+        $result = AuthHelper::fetchDashboardScopes('http://api.test', 'litcal_access_token=abc', $client);
+
+        self::assertSame(['temporale'], $result['viewer_scopes']['general_roman_calendar']);
+        self::assertArrayNotHasKey('bogus_non_list', $result['viewer_scopes']);
+    }
+
+    public function testUnauthenticatedInstanceFailsClosedAndMemoizes(): void
+    {
+        AuthHelper::reset();
+        $envSaved = $this->stashAndClearEnv(['ZITADEL_ISSUER', 'ZITADEL_CLIENT_ID', 'JWT_SECRET']);
+
+        $cookieSaved = [];
+        foreach (['litcal_access_token', 'litcal_id_token'] as $name) {
+            $cookieSaved[$name] = $_COOKIE[$name] ?? null;
+            unset($_COOKIE[$name]);
+        }
+
+        try {
+            $auth = AuthHelper::getInstance();
+            self::assertFalse($auth->isAuthenticated, 'Precondition: instance must be unauthenticated');
+
+            self::assertFalse($auth->dashboardScopes()['is_resource_admin']);
+            self::assertSame([], $auth->dashboardScopes()['viewer_scopes']);
+            self::assertFalse($auth->canViewResource('general_roman_calendar', 'decrees'));
+            self::assertFalse($auth->canViewAnyResourceOfType('national_calendar_test', 'diocesan_calendar_test'));
+        } finally {
+            $this->restoreEnv($envSaved);
+            foreach ($cookieSaved as $name => $val) {
+                if ($val !== null) {
+                    $_COOKIE[$name] = $val;
+                }
+            }
+            AuthHelper::reset();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #399. Admin-dashboard cards are now gated on Zitadel role AND OpenFGA relation, resolved server-side at render time in a single batched API call.

**Depends on Liturgical-Calendar/LiturgicalCalendarAPI#710 — hard deploy-order constraint.** Against an API without `GET /auth/dashboard-scopes`, the endpoint 404s and all relation-gated cards fail closed (hidden) — including the resource-admin "Access Requests to Review" card, which previously worked via `/auth/admin-scopes`. Merge freely, but do not deploy this before the API PR is live.

### Gating matrix (non-admins; global admins bypass all FGA gates and trigger zero scopes calls)

| Card / block | Rule |
|---|---|
| Temporale block | `calendar_editor` role AND viewer+ on `general_roman_calendar:temporale` |
| Decrees block + dedicated card | `calendar_editor` role AND viewer+ on `general_roman_calendar:decrees` |
| Tests card | `test_editor` role AND viewer+ on any `*_test` object |
| Access Requests card | unchanged rule, now read from the batched payload |
| Sanctorale, Wider Region, National, Diocesan | unchanged — deliberately role-gated only (the missals editor extends to any `calendar_editor`) |

### Changes

- `AuthHelper`: `dashboardScopes()` (memoized, cookie-forwarded, lazy, fail-closed) + `canViewResource()` / `canViewAnyResourceOfType()` helpers, mirroring the existing `loadAdminScopes()`/`fetchAdminScopes()` pattern.
- `admin-dashboard.php` / `includes/admin-blocks.php`: relation checks folded into branch conditions and per-block `visible` keys — no flash, no empty "Administration" headings.
- `includes/admin-decrees-card.php`: the interim per-card client-side `/admin/permissions/check` script and its `data-fga-gate`/`data-user-sub` attributes are deleted (this was the "Task 3 will batch these" placeholder).
- E2E: spec 07 rewritten to the new per-user visibility matrix; new spec 15 (Tests card: `test_editor` with vs. without a test scope, via two new seeded `test_editor` users); spec 09 lifecycle expectations realigned; `users.test.ts` fixtures updated.

## Notes for reviewers

- `assets/js/admin-decrees.js` still uses `/admin/permissions/check` — that is the in-page capability-tier logic (view/edit/admin), explicitly out of scope for #399 which covers dashboard card visibility.
- `layout/header.php` still calls `isResourceAdmin()` (backed by `/auth/admin-scopes`) — pre-existing consumer, intentionally untouched; backing it from the memoized dashboard payload is a possible follow-up.
- The `phpstan.neon.dist` ignore entries follow the established include-pattern false-positive convention for template variables.
- A non-admin `calendar_editor` with the decrees viewer relation sees Decrees twice (grid block + dedicated Administration card) — spec-prescribed: both surfaces share the identical gate, and the duplication predates this PR for role-holders.

## Testing

- PHPUnit 13/13 (new `AuthHelperDashboardScopesTest`); PHPStan level 7 clean; phpcs, markdownlint, tsc, eslint clean.
- Playwright against the live docker stack (API built from the sibling feature branch): rbac 32/32, rbac-support 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administration dashboard cards now appear according to role and resource permissions.
  * Decrees and Temporale sections require access to the relevant calendar resources.
  * Tests administration is available only to authorized test editors with applicable test access.
  * Access request visibility now reflects current resource-admin permissions.

* **Bug Fixes**
  * Unauthorized dashboard cards are consistently hidden server-side.
  * Permission failures default to restricted visibility.

* **Tests**
  * Expanded automated coverage for dashboard card visibility, access changes, and test-editor scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->