### PR TITLE
chore(dependabot): group github-actions bumps into a single PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,6 +26,16 @@ updates:
     target-branch: "development"
     labels:
       - "github-actions"
+    # Batch all action bumps into a single PR. Dependabot treats each action
+    # subpath (github/codeql-action/init, /autobuild, /analyze) as a separate
+    # dependency, so without a group each gets its own PR — and a lone
+    # codeql-action bump can never pass CI: the CodeQL workflow refuses to run
+    # mixed versions ("Loaded a configuration file for version X, but running
+    # version Y"). All three must bump together.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # npm/Yarn devDependencies (eslint, playwright, typescript, markdownlint-cli2, …).
   # Yarn Berry is supported via package.json + yarn.lock. A bump of


### PR DESCRIPTION
## Summary

Adds a `groups` block to the `github-actions` ecosystem entry in `.github/dependabot.yaml`, batching all action bumps into one weekly PR — mirroring the grouping the npm entry already uses.

## Why

Dependabot treats each action subpath as a separate dependency, so the current config produced three simultaneous PRs for `github/codeql-action/init` / `/autobuild` / `/analyze` (#405, #407, #408) — each bumping only one of the three. The CodeQL workflow refuses to run mixed versions, so each PR fails its own CodeQL check:

> `Loaded a configuration file for version '4.36.3', but running version '4.36.2'`

Grouping is opt-in per ecosystem (dependabot never groups by default), so those singleton PRs can never go green without this config.

## After merging

On its next update run (or via Insights → Dependency graph → Dependabot → "Check for updates"), dependabot will close #405/#407/#408 and open a single grouped PR bumping all three `codeql-action` uses together, which can pass CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)