### PR TITLE
chore(i18n): regenerate i18n/litcal.pot

### DIFF
--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-12 21:13+0000\n"
+"POT-Creation-Date: 2026-07-14 11:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1183,16 +1183,16 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: layout/header.php:261 includes/admin-blocks.php:15 admin-permissions.php:392
+#: layout/header.php:261 includes/admin-blocks.php:19 admin-permissions.php:392
 #: permission-requests.php:243 temporale.php:24 temporale.php:37
 msgid "Temporale"
 msgstr ""
 
-#: layout/header.php:265 includes/admin-blocks.php:25
+#: layout/header.php:265 includes/admin-blocks.php:35
 msgid "Sanctorale"
 msgstr ""
 
-#: layout/header.php:269 includes/admin-blocks.php:35
+#: layout/header.php:269 includes/admin-blocks.php:45
 msgid "Decrees"
 msgstr ""
 
@@ -1201,17 +1201,17 @@ msgid "Particular Calendars"
 msgstr ""
 
 #. translators: label for wider region calendar name field
-#: layout/header.php:281 includes/messages.php:206 includes/admin-blocks.php:45
+#: layout/header.php:281 includes/messages.php:206 includes/admin-blocks.php:59
 #: admin-permissions.php:81 admin-permissions.php:308 admin-permissions.php:389
 #: permission-requests.php:237
 msgid "Wider Region"
 msgstr ""
 
-#: layout/header.php:285 includes/admin-blocks.php:55
+#: layout/header.php:285 includes/admin-blocks.php:69
 msgid "National"
 msgstr ""
 
-#: layout/header.php:289 includes/admin-blocks.php:65
+#: layout/header.php:289 includes/admin-blocks.php:79
 msgid "Diocesan"
 msgstr ""
 
@@ -1961,35 +1961,35 @@ msgstr ""
 msgid "Diocesan calendar definition"
 msgstr ""
 
-#: includes/admin-blocks.php:16
+#: includes/admin-blocks.php:20
 msgid "Proprium de Tempore - temporal cycle events"
 msgstr ""
 
-#: includes/admin-blocks.php:26
+#: includes/admin-blocks.php:36
 msgid "Proprium de Sanctis - Roman Missal editions"
 msgstr ""
 
-#: includes/admin-blocks.php:36
+#: includes/admin-blocks.php:46
 msgid "Congregation for Divine Worship decrees"
 msgstr ""
 
-#: includes/admin-blocks.php:46
+#: includes/admin-blocks.php:60
 msgid "Shared events for geographical regions"
 msgstr ""
 
-#: includes/admin-blocks.php:56
+#: includes/admin-blocks.php:70
 msgid "National calendars by Bishops Conferences"
 msgstr ""
 
-#: includes/admin-blocks.php:66
+#: includes/admin-blocks.php:80
 msgid "Diocesan calendars by liturgical offices"
 msgstr ""
 
-#: includes/admin-blocks.php:83
+#: includes/admin-blocks.php:101
 msgid "View"
 msgstr ""
 
-#: includes/admin-blocks.php:84 developer-dashboard.php:269
+#: includes/admin-blocks.php:102 developer-dashboard.php:269
 msgid "Edit"
 msgstr ""
 
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: admin-permissions.php:439 admin-applications.php:245 admin-dashboard.php:164
+#: admin-permissions.php:439 admin-applications.php:245 admin-dashboard.php:168
 msgid "Review"
 msgstr ""
 
@@ -2579,8 +2579,8 @@ msgid ""
 "calendars."
 msgstr ""
 
-#: admin-dashboard.php:65 admin-dashboard.php:129 admin-dashboard.php:139
-#: admin-dashboard.php:149
+#: admin-dashboard.php:65 admin-dashboard.php:129 admin-dashboard.php:143
+#: admin-dashboard.php:153
 msgid "Administration"
 msgstr ""
 
@@ -2608,11 +2608,11 @@ msgstr ""
 msgid "Manage fine-grained resource permissions"
 msgstr ""
 
-#: admin-dashboard.php:158
+#: admin-dashboard.php:162
 msgid "Access Requests to Review"
 msgstr ""
 
-#: admin-dashboard.php:160
+#: admin-dashboard.php:164
 msgid "Review and approve access requests for the resources you administer"
 msgstr ""
 


### PR DESCRIPTION
Automated regeneration of `i18n/litcal.pot` from the project source files.

Generated by the [Update POTs workflow](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/actions/runs/29329359648).