### PR TITLE
feat: use PUT /{collection}/{id} creation paths

### DIFF
--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -778,7 +778,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (state.editing) {
                 await fetchJson('PATCH', `/tests/${encodeURIComponent(state.editing)}`, payload);
             } else {
-                await fetchJson('PUT', '/tests', payload);
+                await fetchJson('PUT', `/tests/${encodeURIComponent(payload.name)}`, payload);
             }
             editorModal.hide();
             await loadTests();

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -467,6 +467,24 @@ Promise.all(fetchRequests).then(responses => {
 
 
 /**
+ * Build the RegionalData API path from the current category and key.
+ * The path is based on category and key, regardless of method
+ * (PUT creation also targets a per-item URL: /{category}/{key}).
+ * @param {string} category - the calendar category, or '' when not yet set
+ * @param {string} key - the calendar key, or '' when not yet set
+ * @returns {string} `${RegionalDataUrl}/{category}/{key}`, `${RegionalDataUrl}/{category}`, or `${RegionalDataUrl}`
+ */
+const buildRegionalDataPath = (category = '', key = '') => {
+    if (category !== '' && key !== '') {
+        return `${RegionalDataUrl}/${category}/${key}`;
+    }
+    if (category !== '') {
+        return `${RegionalDataUrl}/${category}`;
+    }
+    return `${RegionalDataUrl}`;
+};
+
+/**
  * Proxy sanitizer for the proxied API object. Sanitizes the values assigned to properties of the proxied API object.
  * @type {Proxy}
  * @prop {function} get - the getter for the proxy
@@ -500,30 +518,14 @@ const sanitizeProxiedAPI = {
         }
         switch (prop) {
             case 'path':
-                // the path is based on category and key parameters, regardless of method
-                // (PUT creation now also targets a per-item URL: /{category}/{key})
-                if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
-                    value = `${RegionalDataUrl}/${target['category']}/${target['key']}`;
-                }
-                else if (target.hasOwnProperty('category') && target['category'] !== '') {
-                    value = `${RegionalDataUrl}/${target['category']}`;
-                } else {
-                    value = `${RegionalDataUrl}`;
-                }
+                value = buildRegionalDataPath(target['category'] ?? '', target['key'] ?? '');
                 break;
             case 'category':
                 if (false === ['widerregion', 'nation', 'diocese'].includes(value)) {
                     console.error(`property 'category' of this object must be one of the values 'widerregion', 'nation', or 'diocese'`);
                     return;
                 }
-                // the path is based on category and key, regardless of method
-                // (PUT creation now also targets a per-item URL: /{category}/{key})
-                if (target.hasOwnProperty('key') && target['key'] !== '') {
-                    target['path'] = `${RegionalDataUrl}/${value}/${target['key']}`;
-                }
-                else {
-                    target['path'] = `${RegionalDataUrl}/${value}`;
-                }
+                target['path'] = buildRegionalDataPath(value, target['key'] ?? '');
                 break;
             case 'key':
                 if (target['category'] === 'widerregion') {
@@ -556,10 +558,9 @@ const sanitizeProxiedAPI = {
                     return;
                 }
 
-                // the path is based on category and key, regardless of method
-                // (PUT creation now also targets a per-item URL: /{category}/{key})
-                if (target.hasOwnProperty('category') && target['category'] !== '') {
-                    target['path'] = `${RegionalDataUrl}/${target['category']}/${value}`;
+                // only derive the path once a category has been set (a bare key has no URL shape)
+                if (( target['category'] ?? '' ) !== '') {
+                    target['path'] = buildRegionalDataPath(target['category'], value);
                 }
                 break;
             case 'locale':
@@ -573,16 +574,7 @@ const sanitizeProxiedAPI = {
                     console.error(`property 'method=${value}' of this object is not a valid value, possible values are: 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'`);
                     return;
                 }
-                // the path is based on category and key, regardless of method
-                // (PUT creation now also targets a per-item URL: /{category}/{key})
-                if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
-                    target['path'] = `${RegionalDataUrl}/${target['category']}/${target['key']}`;
-                }
-                else if (target.hasOwnProperty('category') && target['category'] !== '') {
-                    target['path'] = `${RegionalDataUrl}/${target['category']}`;
-                } else {
-                    target['path'] = `${RegionalDataUrl}`;
-                }
+                target['path'] = buildRegionalDataPath(target['category'] ?? '', target['key'] ?? '');
                 break;
             default:
                 console.error('unexpected property ' + prop + ' of type ' + typeof prop + ' on target of type ' + typeof target);

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -500,22 +500,15 @@ const sanitizeProxiedAPI = {
         }
         switch (prop) {
             case 'path':
-                // the path will be set based on the method, category and key parameters
-                if (target.hasOwnProperty('method') && target['method'] === 'PUT') {
-                    if (target.hasOwnProperty('category') && target['category'] !== '') {
-                        value = `${RegionalDataUrl}/${target['category']}`;
-                    } else {
-                        value = `${RegionalDataUrl}`;
-                    }
+                // the path is based on category and key parameters, regardless of method
+                // (PUT creation now also targets a per-item URL: /{category}/{key})
+                if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
+                    value = `${RegionalDataUrl}/${target['category']}/${target['key']}`;
+                }
+                else if (target.hasOwnProperty('category') && target['category'] !== '') {
+                    value = `${RegionalDataUrl}/${target['category']}`;
                 } else {
-                    if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
-                        value = `${RegionalDataUrl}/${target['category']}/${target['key']}`;
-                    }
-                    else if (target.hasOwnProperty('category') && target['category'] !== '') {
-                        value = `${RegionalDataUrl}/${target['category']}`;
-                    } else {
-                        value = `${RegionalDataUrl}`;
-                    }
+                    value = `${RegionalDataUrl}`;
                 }
                 break;
             case 'category':
@@ -523,15 +516,13 @@ const sanitizeProxiedAPI = {
                     console.error(`property 'category' of this object must be one of the values 'widerregion', 'nation', or 'diocese'`);
                     return;
                 }
-                if (target.hasOwnProperty('method') && target['method'] === 'PUT') {
+                // the path is based on category and key, regardless of method
+                // (PUT creation now also targets a per-item URL: /{category}/{key})
+                if (target.hasOwnProperty('key') && target['key'] !== '') {
+                    target['path'] = `${RegionalDataUrl}/${value}/${target['key']}`;
+                }
+                else {
                     target['path'] = `${RegionalDataUrl}/${value}`;
-                } else {
-                    if (target.hasOwnProperty('key') && target['key'] !== '') {
-                        target['path'] = `${RegionalDataUrl}/${value}/${target['key']}`;
-                    }
-                    else {
-                        target['path'] = `${RegionalDataUrl}/${value}`;
-                    }
                 }
                 break;
             case 'key':
@@ -565,12 +556,10 @@ const sanitizeProxiedAPI = {
                     return;
                 }
 
+                // the path is based on category and key, regardless of method
+                // (PUT creation now also targets a per-item URL: /{category}/{key})
                 if (target.hasOwnProperty('category') && target['category'] !== '') {
-                    if (target.hasOwnProperty('method') && target['method'] === 'PUT') {
-                        target['path'] = `${RegionalDataUrl}/${target['category']}`;
-                    } else {
-                        target['path'] = `${RegionalDataUrl}/${target['category']}/${value}`;
-                    }
+                    target['path'] = `${RegionalDataUrl}/${target['category']}/${value}`;
                 }
                 break;
             case 'locale':
@@ -584,19 +573,15 @@ const sanitizeProxiedAPI = {
                     console.error(`property 'method=${value}' of this object is not a valid value, possible values are: 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'`);
                     return;
                 }
-                if (value === 'PUT') {
-                    if (target.hasOwnProperty('category') && target['category'] !== '') {
-                        target['path'] = `${RegionalDataUrl}/${target['category']}`;
-                    }
+                // the path is based on category and key, regardless of method
+                // (PUT creation now also targets a per-item URL: /{category}/{key})
+                if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
+                    target['path'] = `${RegionalDataUrl}/${target['category']}/${target['key']}`;
+                }
+                else if (target.hasOwnProperty('category') && target['category'] !== '') {
+                    target['path'] = `${RegionalDataUrl}/${target['category']}`;
                 } else {
-                    if (target.hasOwnProperty('category') && target['category'] !== '' && target.hasOwnProperty('key') && target['key'] !== '') {
-                        target['path'] = `${RegionalDataUrl}/${target['category']}/${target['key']}`;
-                    }
-                    else if (target.hasOwnProperty('category') && target['category'] !== '') {
-                        target['path'] = `${RegionalDataUrl}/${target['category']}`;
-                    } else {
-                        target['path'] = `${RegionalDataUrl}`;
-                    }
+                    target['path'] = `${RegionalDataUrl}`;
                 }
                 break;
             default:


### PR DESCRIPTION
Companion to Liturgical-Calendar/LiturgicalCalendarAPI PUT-creation-paths PR (issue API#706). Merge after the API PR.

Note: e2e will go green once the API PR is merged (the e2e stack builds litcal-api from the API repo's development branch). See Liturgical-Calendar/LiturgicalCalendarAPI#713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test creation now saves by targeting the specific test name, improving reliability and reducing misrouted updates.
  * Proxy request routing has been corrected to generate paths consistently from the selected category and key (independent of HTTP method), preventing incorrect API calls when updating request details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->