### PR TITLE
Bump OpenFGA to v1.18.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
   # OpenFGA - Fine-grained authorization engine (Google Zanzibar implementation)
   # ============================================================================
   openfga-migrate:
-    image: openfga/openfga:v1.8.12
+    image: openfga/openfga:v1.18.2
     command: migrate
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres
@@ -213,7 +213,7 @@ services:
 
   openfga:
     restart: unless-stopped
-    image: openfga/openfga:v1.8.12
+    image: openfga/openfga:v1.18.2
     command: run
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres


### PR DESCRIPTION
Local dev stack only; keeps this repo's pin in step with LiturgicalCalendarAPI. Verified the migrate one-shot applies Postgres migration 006 (`add_collate_index`) and `openfga` reaches healthy on v1.18.2.

Note: the API repo's companion PR (Liturgical-Calendar/LiturgicalCalendarAPI#756) also modifies `docker-compose.yml` in that repo (unrelated `authz-seed` service work from a separate in-flight PR there), just flagging for awareness — no overlap with this repo's file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenFGA services to version 1.18.2 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->