### PR TITLE
Fix stale E2E sourcedata path + capture full stack logs on failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -212,8 +212,27 @@ jobs:
           retention-days: 7
 
       - name: Dump stack logs on failure
+        # `--tail 400` on a single combined stream only shows the last few minutes of a
+        # ~20+ minute job — it missed the early-suite failure window entirely on the run
+        # that first surfaced this gap. Capture the FULL, untruncated log per service to
+        # a file (so it's not bounded by the Actions log viewer either) and still print a
+        # short combined tail for a quick glance in the step output.
         if: failure()
-        run: docker compose logs --no-color --tail 400
+        run: |
+          mkdir -p docker-logs
+          for svc in $(docker compose config --services); do
+            docker compose logs --no-color --timestamps "$svc" > "docker-logs/${svc}.log" 2>&1 || true
+          done
+          echo "--- last 400 lines (combined, quick glance; see docker-compose-logs artifact for full history) ---"
+          docker compose logs --no-color --tail 400
+
+      - name: Upload docker stack logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-compose-logs
+          path: docker-logs/
+          retention-days: 7
 
       - name: Tear down
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,8 +235,53 @@ services:
       openfga-migrate:
         condition: service_completed_successfully
 
+  # Seeds the OpenFGA store + authorization model from cdcf-infra, which owns
+  # every model on the shared umbrella instance. Mirrors LiturgicalCalendarAPI's
+  # docker-compose.yml (authz-seed, added in 854032f2) — that repo intentionally
+  # keeps no model file: a second copy is what let a stale model silently revert
+  # the deployed one in August 2026. This stack keeps none either.
+  authz-seed:
+    image: alpine:3.21
+    restart: "no"
+    environment:
+      CDCF_INFRA_REF: "${CDCF_INFRA_REF:-main}"
+      # cdcf-infra's setup-openfga.sh requires a non-empty preshared key in the
+      # .env.local it sources regardless of target — it's only ever used as a
+      # single Bearer token, while OPENFGA_AUTHN_PRESHARED_KEYS is OpenFGA's own
+      # comma-separated list (<key1>[,<key2>]); the entrypoint below trims to
+      # the first key before writing .env.local. This stack's default
+      # OPENFGA_AUTHN_METHOD=none makes OpenFGA ignore the token entirely, so a
+      # placeholder is fine for local dev.
+      OPENFGA_PRESHARED_KEY: "${OPENFGA_AUTHN_PRESHARED_KEYS:-local-dev-preshared-key}"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        apk add --no-cache bash curl jq git >/dev/null
+        rm -rf /tmp/cdcf-infra
+        git clone --depth 1 --branch "$$CDCF_INFRA_REF" \
+          https://github.com/CatholicOS/cdcf-infra.git /tmp/cdcf-infra
+        cd /tmp/cdcf-infra/auth
+        OPENFGA_PRESHARED_KEY="$${OPENFGA_PRESHARED_KEY%%,*}"
+        cat > .env.local <<EOF
+        OPENFGA_API_URL=http://openfga:8080
+        OPENFGA_INTERNAL_URL=http://openfga:8080
+        OPENFGA_PRESHARED_KEY=$$OPENFGA_PRESHARED_KEY
+        EOF
+        ./setup-openfga.sh --target local --create-litcal-store
+    networks:
+      - litcal
+    depends_on:
+      openfga:
+        condition: service_healthy
+
   # OpenFGA Setup — create store and load authorization model from the API image.
   # The API image bundles curl and jq, so no runtime install is needed here.
+  # Since 854032f2 upstream, setup-openfga.sh only READS BACK an existing model
+  # (it no longer loads one) — so this must wait for authz-seed to have actually
+  # finished seeding it, not merely started, or it fails with "has no
+  # authorization model" (see frontend-e2e-diagnosis.md, "Fix attempt").
   openfga-setup:
     image: litcal-api:latest
     environment:
@@ -247,6 +292,8 @@ services:
     depends_on:
       openfga:
         condition: service_healthy
+      authz-seed:
+        condition: service_completed_successfully
 
   # ============================================================================
   # LiturgicalCalendar Application Services

--- a/e2e/rbac/10-scoped-data-editing.spec.ts
+++ b/e2e/rbac/10-scoped-data-editing.spec.ts
@@ -61,7 +61,7 @@ const API_REPO = process.env.API_REPO_PATH || path.resolve(__dirname, '../../../
  * (i18n limited to it_IT).
  */
 function buildItNationalPayload(): Record<string, unknown> {
-    const itDir = path.join(API_REPO, 'jsondata', 'sourcedata', 'calendars', 'nations', 'IT');
+    const itDir = path.join(API_REPO, 'jsondata', 'sourcedata', 'rite', 'roman', 'calendars', 'nations', 'IT');
     const def = JSON.parse(fs.readFileSync(path.join(itDir, 'IT.json'), 'utf8'));
     const i18nIt = JSON.parse(fs.readFileSync(path.join(itDir, 'i18n', 'it_IT.json'), 'utf8'));
     return {

--- a/e2e/rbac/11-session-resilience.spec.ts
+++ b/e2e/rbac/11-session-resilience.spec.ts
@@ -68,7 +68,7 @@ const API_REPO = process.env.API_REPO_PATH || path.resolve(__dirname, '../../../
  * of the existing definition. Copied from scenario 10.
  */
 function buildItNationalPayload(): Record<string, unknown> {
-    const itDir = path.join(API_REPO, 'jsondata', 'sourcedata', 'calendars', 'nations', 'IT');
+    const itDir = path.join(API_REPO, 'jsondata', 'sourcedata', 'rite', 'roman', 'calendars', 'nations', 'IT');
     const def = JSON.parse(fs.readFileSync(path.join(itDir, 'IT.json'), 'utf8'));
     const i18nIt = JSON.parse(fs.readFileSync(path.join(itDir, 'i18n', 'it_IT.json'), 'utf8'));
     return {


### PR DESCRIPTION
## Summary
- Fix `e2e/rbac/10-scoped-data-editing.spec.ts` and `e2e/rbac/11-session-resilience.spec.ts`, which still hardcoded the pre-`rite`-partition sourcedata path (`jsondata/sourcedata/calendars/nations/IT`). API PR #737 (commit `42aadda13`) moved this to `jsondata/sourcedata/rite/roman/calendars/nations/IT` — verified against the current `LiturgicalCalendarAPI` checkout (old path absent, new path present). This is the confirmed cause of the deterministic ENOENT failures (tests 10, 11c) on every nightly `E2E` run since the API's `development` picked up the move. `cleanup.ts` / `fixtures.ts` operate on the whole `jsondata/sourcedata/` tree, not a hardcoded subpath, so no change needed there.
- Widen the on-failure docker stack log capture in `.github/workflows/e2e.yml`: `docker compose logs --tail 400` on a single combined stream only showed the last few minutes of a 20+ minute job and missed the early-suite failure window entirely on the run that first surfaced this gap. Now each service's full untruncated log is written to a file and uploaded as a `docker-compose-logs` artifact (7-day retention), plus a short combined tail is still printed for a quick glance in the step output. Playwright tracing (`trace: 'on-first-retry'`) and the `playwright-report`/`test-results` artifact upload were already in place and needed no change.

## Context
This PR exists to get a real CI run with proper diagnostics for a second, unconfirmed failure mode (tests 1–9, 12 time out waiting for `.perm-object-id` while `GET /calendars` returns 200 server-side — suspected client-side incompatibility with a new diocesan `rite` field from API commit `13efc9c2`). Do not merge until that's resolved.

## Test plan
- [ ] `E2E (Playwright + full docker stack)` required check passes on this PR
- [ ] If it still fails, download the `playwright-report` / `docker-compose-logs` artifacts and confirm the client-side root cause via trace/console/network capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Italian national calendar data paths to ensure end-to-end tests for scoped editing and session resilience use the correct fixtures.

* **Chores**
  * Improved failure diagnostics by capturing complete, timestamped logs from all Compose services.
  * Preserved full logs as downloadable failure artifacts for seven days while retaining a concise workflow summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->