### PR TITLE
Bump the components-js CDN pin to 1.5.0 and add the RiteSelect

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,4 +1,4 @@
-import { ApiClient, CalendarSelect, ApiOptions, Input, ApiOptionsFilter, PathBuilder } from '@liturgical-calendar/components-js';
+import { ApiClient, CalendarSelect, RiteSelect, ApiOptions, Input, ApiOptionsFilter, PathBuilder } from '@liturgical-calendar/components-js';
 
 Input.setGlobalInputClass('form-select');
 Input.setGlobalLabelClass('form-label mb-1');
@@ -40,9 +40,30 @@ if (!BaseUrl) {
             .class('form-select')
             .insertAfter( apiOptions._calendarPathInput );
 
+            // Must be in the DOM before linkToCalendarSelect() below, which reads
+            // this element to attach the rite-change listener.
+            // No `text`: omitting it lets RiteSelect supply its own localized label
+            // (Messages[lang].SELECT_A_RITE), so this reads "Seleziona un rito" on the
+            // Italian page rather than the hardcoded English used for the calendar
+            // label below. Note the library only translates this key for en and it so
+            // far; every other locale still falls back to English.
+            const riteSelect = (new RiteSelect( LITCAL_LOCALE ))
+                .label({
+                    class: 'form-label mb-1',
+                    id: 'riteSelectLabel'
+                }).id('APIRiteSelect')
+                .class('form-select');
+            riteSelect.appendTo('#riteSelectWrapper');
+
             apiOptions.filter( ApiOptionsFilter.BASE_PATH ).appendTo('#requestParametersBasePath');
             apiOptions.filter( ApiOptionsFilter.ALL_PATHS ).appendTo('#requestParametersAllPaths');
-            apiOptions.linkToCalendarSelect( calendarSelect );
+            // Passing riteSelect marks the rite as explicit, so it is emitted as a
+            // path segment (/calendar/ambrosian/...) rather than left implicit, and
+            // rebuilds the calendar select whenever the rite changes. The Ambrosian
+            // rite has no national tier and fixes Epiphany, Ascension, Corpus Christi
+            // and the Eternal High Priest in its own books, so ApiOptions also
+            // disables those four inputs for as long as it is selected.
+            apiOptions.linkToCalendarSelect( calendarSelect, riteSelect );
 
             const localeLabelAfter = document.querySelector('#localeLabelAfter');
             const acceptLabelAfter = document.querySelector('#acceptLabelAfter');

--- a/assets/js/liturgyOfAnyDay.js
+++ b/assets/js/liturgyOfAnyDay.js
@@ -9,6 +9,7 @@
 import {
     ApiClient,
     CalendarSelect,
+    RiteSelect,
     ApiOptions,
     ApiOptionsFilter,
     LiturgyOfAnyDay
@@ -29,6 +30,20 @@ const translations = {
         sk: 'Vyberte kalendár',
         vi: 'Chọn lịch',
         id: 'Pilih kalender'
+    },
+    selectRite: {
+        en: 'Select a rite',
+        it: 'Seleziona un rito',
+        es: 'Seleccionar un rito',
+        fr: 'Sélectionner un rite',
+        de: 'Ritus auswählen',
+        pt: 'Selecionar um rito',
+        nl: 'Selecteer een ritus',
+        la: 'Elige ritum',
+        hu: 'Válasszon rítust',
+        sk: 'Vyberte rítus',
+        vi: 'Chọn nghi lễ',
+        id: 'Pilih ritus'
     },
     language: {
         en: 'Language',
@@ -103,6 +118,15 @@ const initializePage = async () => {
     // Get the base language for translations
     const lang = currentLocale.language;
 
+    // Create RiteSelect component. It must exist in the DOM before it is passed
+    // to linkToCalendarSelect() below, which reads its element to attach the
+    // rite-change listener.
+    const riteSelect = new RiteSelect( lang )
+        .class( 'form-select' )
+        .id( 'riteSelect' )
+        .label( { text: translations.selectRite[ lang ] || translations.selectRite.en, class: 'form-label' } );
+    riteSelect.appendTo( '#riteSelectContainer' );
+
     // Create CalendarSelect component
     const calendarSelect = new CalendarSelect( lang )
         .class( 'form-select' )
@@ -117,7 +141,11 @@ const initializePage = async () => {
     // Create ApiOptions with only the locale input filter
     const apiOptions = new ApiOptions( lang )
         .filter( ApiOptionsFilter.LOCALE_ONLY )
-        .linkToCalendarSelect( calendarSelect );
+        // Passing riteSelect makes the rite an explicit part of the endpoint and
+        // rebuilds the calendar select whenever the rite changes: the Ambrosian
+        // rite has no national tier and offers a different set of diocesan
+        // calendars, so a selection from one rite is never carried into another.
+        .linkToCalendarSelect( calendarSelect, riteSelect );
 
     // Configure the locale input before appending
     // Set defaultValue to currentLocale.language so it will be selected if available

--- a/examples.php
+++ b/examples.php
@@ -20,7 +20,7 @@ $JAVASCRIPT_EXAMPLE_CONTENTS = <<<EOT
 <script type="importmap">
     {
         "imports": {
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.4.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.5.0/+esm"
         }
     }
 </script>
@@ -73,7 +73,7 @@ $FULLCALENDAR_EXAMPLE_CONTENTS = <<<EOT
             "@fullcalendar/daygrid": "https://cdn.skypack.dev/@fullcalendar/daygrid@6.1.19",
             "@fullcalendar/list": "https://cdn.skypack.dev/@fullcalendar/list@6.1.19",
             "@fullcalendar/bootstrap5": "https://cdn.skypack.dev/@fullcalendar/bootstrap5@6.1.19",
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.4.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.5.0/+esm"
         }
     }
 </script>

--- a/index.php
+++ b/index.php
@@ -92,6 +92,10 @@ $formLabelB = sprintf(
                         <h5 class="fw-bold"><?php
                             echo _('Path builder');
                         ?></h5>
+                        <!-- RiteSelect is rendered here by JS. It sits before the
+                             inputs that ApiOptions appends to this row, so the rite
+                             is chosen first and the rest of the path follows from it. -->
+                        <div class="form-group col col-md-3" id="riteSelectWrapper"></div>
                     </div>
                     <div class="row" id="requestParametersAllPaths">
                         <h5 class="fw-bold"><?php echo $formLabelB; ?></h5>

--- a/layout/footer.php
+++ b/layout/footer.php
@@ -107,7 +107,7 @@ const NotificationTranslations = {
 $isDevelopment   = ( $_ENV['APP_ENV'] ?? 'production' ) === 'development';
 $componentsJsUrl = $isDevelopment
     ? './assets/components-js/index.js'
-    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.4.0/+esm';
+    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.5.0/+esm';
 
 $componentsJsImportMap = <<<SCRIPT
 <script type="importmap">

--- a/liturgyOfAnyDay.php
+++ b/liturgyOfAnyDay.php
@@ -26,6 +26,8 @@ include_once 'includes/common.php';
         <h3 class="h3 mb-2 text-gray-800"><?php echo _('Liturgy of any day'); ?></h3>
         <div class="container">
             <div class="row">
+                <!-- RiteSelect will be rendered here by JS -->
+                <div class="form-group col-md" id="riteSelectContainer"></div>
                 <!-- CalendarSelect will be rendered here by JS -->
                 <div class="form-group col-md" id="calendarSelectContainer"></div>
                 <!-- LocaleInput from ApiOptions will be rendered here by JS -->


### PR DESCRIPTION
Two related changes: the CDN pin was stale, and 1.5.0 carries `RiteSelect`, which the frontend did not use.

## 1. CDN pin 1.4.0 → 1.5.0

All three import maps still pointed at **1.4.0**, so nothing released since then reached the site — including the `CalendarSelect` crash on diocesan calendars with an undefined national calendar (`lugano_ch`), fixed in 1.5.0.

| File | Line | Context |
|------|------|---------|
| `examples.php` | 23 | JavaScript example import map |
| `examples.php` | 76 | FullCalendar example import map |
| `layout/footer.php` | 110 | production branch of the dev/prod switch |

The development branch of that switch loads the local symlink and was unaffected. No `components-js@1.4` reference remains. Verified the new URL serves (`HTTP/2 200`) and contains `RiteSelect`.

## 2. RiteSelect in the two public forms

`assets/js/index.js` (API explorer) and `assets/js/liturgyOfAnyDay.js`. Both already use a single `none`-filtered `CalendarSelect`, which is exactly what `linkToCalendarSelect( calendarSelect, riteSelect )` accepts — **no restructuring into paired nation/diocese selects was needed**. Each page gains a container div, since `RiteSelect` only offers `appendTo()`.

Passing the riteSelect does three things: marks the rite explicit so it is emitted as a path segment, rebuilds the calendar select on rite change, and disables the four temporal options the Ambrosian rite fixes in its own books.

### Verified in a browser against a local API

Switching to the Ambrosian rite:

| | Roman | Ambrosian |
|---|---|---|
| Path builder | `/calendar/roman` | `/calendar/ambrosian` |
| Calendar options | 18 | 4 — Milano, Bergamo, Novara, Lugano |
| Selected calendar | — | reset to empty |
| epiphany / ascension / corpus_christi / eternal_high_priest | enabled | **disabled** |

All of it reverses on switching back. No console errors.

## Labels, and a small upstream gap

`liturgyOfAnyDay.js` carries its own translation map, so `selectRite` is added there beside `selectCalendar`, covering the same twelve languages.

`index.js` has no such map and hardcodes English for its calendar label. Rather than add a *second* English string to an otherwise fully translated page, the rite label omits `text` and lets `RiteSelect` supply `Messages[lang].SELECT_A_RITE` — so it renders "Seleziona un rito" on the Italian page.

Worth flagging upstream: **the library only translates `SELECT_A_RITE` for `en` and `it`** — the other eleven locales fall back to English. Cheap fix in components-js if you want it.

## Admin forms deliberately untouched

You asked for the admin forms too. They are genuinely blocked, not skipped:

- **`permission-requests.js`, `admin-permissions.js`, `admin-tests.js`** build `NATIONAL_CALENDARS`/`DIOCESAN_CALENDARS`-filtered selects with no `ApiOptions`. `linkToCalendarSelect` accepts only a `none`-filtered single select or a `[nations, dioceses]` pair, so a lone filtered select fits neither. `RiteSelect` emits no events of its own, and rite-aware rebuilding runs through `CalendarSelect._applyRite()`, which is internal. Wiring these would mean either reaching into private API or adding a public `CalendarSelect.linkToRiteSelect()` to components-js.
- **`usage.php`** uses the **PHP** component library (`LiturgicalCalendar\Components\CalendarSelect`), which has no `RiteSelect` at all.

Happy to open a components-js issue for the public linking API if the admin forms should become rite-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)