### PR TITLE
Correct the E2E comment and stop swallowing calendar-select failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,15 @@ on:
     # Frontend-affecting paths only. NB: i18n/** is intentionally NOT listed —
     # translation-only PRs (e.g. Weblate) don't change E2E behaviour, so they
     # skip the ~7-min full-stack run. Any translation-driven regression is still
-    # caught by the nightly `schedule` run below. (E2E is not a required check,
-    # so excluding a PR here never leaves it stuck waiting on a missing status.)
+    # caught by the nightly `schedule` run below.
+    #
+    # "E2E (Playwright + full docker stack)" IS a required status check on
+    # `development`, so a PR excluded here would otherwise sit BLOCKED forever
+    # waiting on a context nothing ever reports. That is what
+    # e2e-required-skip.yml is for: it runs on the complement of this list and
+    # emits the same check name instantly. Exactly one of the two reports the
+    # required context for any given PR, so keep the two lists in sync — a path
+    # added here must also be added to that workflow's `paths-ignore`.
     paths:
       - 'assets/**'
       - 'includes/**'

--- a/admin-permissions.php
+++ b/admin-permissions.php
@@ -399,6 +399,8 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                 calendarScope: <?php echo json_encode(_('Calendar scope')); ?>,
                 calendarId: <?php echo json_encode(_('Calendar ID')); ?>,
                 selectCalendarId: <?php echo json_encode(_('Select calendar ID...')); ?>,
+                /** translators: shown in place of the calendar dropdown when the calendar list could not be loaded */
+                calendarIdLoadFailed: <?php echo json_encode(_('Could not load calendars — try reloading the page')); ?>,
                 testsNational: <?php echo json_encode(_('National Calendar Tests')); ?>,
                 testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests')); ?>,
                 testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests')); ?>,
@@ -428,6 +430,8 @@ if (!$isGlobalAdmin && !$isResourceAdmin) {
                     calendarScope: <?php echo json_encode(_('Calendar scope')); ?>,
                     calendarId: <?php echo json_encode(_('Calendar ID')); ?>,
                     selectCalendarId: <?php echo json_encode(_('Select calendar ID...')); ?>,
+                /** translators: shown in place of the calendar dropdown when the calendar list could not be loaded */
+                calendarIdLoadFailed: <?php echo json_encode(_('Could not load calendars — try reloading the page')); ?>,
                     testsNational: <?php echo json_encode(_('National Calendar Tests')); ?>,
                     testsDiocesan: <?php echo json_encode(_('Diocesan Calendar Tests')); ?>,
                     testsGeneralRoman: <?php echo json_encode(_('General Roman Calendar Tests')); ?>,

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -125,27 +125,48 @@ document.addEventListener('DOMContentLoaded', function() {
             NATIONAL_FILTER_TYPES.includes(objectType) ||
             DIOCESAN_FILTER_TYPES.includes(objectType)
         ) {
-            const client = await apiClientReady;
-            if (!client) return;
-            if (grantObjectType.value !== objectType) return; // scope changed again meanwhile
-            const filter = NATIONAL_FILTER_TYPES.includes(objectType)
-                ? CalendarSelectFilter.NATIONAL_CALENDARS
-                : CalendarSelectFilter.DIOCESAN_CALENDARS;
-            const calSelect = new CalendarSelect(LITCAL_LOCALE)
-                .filter(filter)
-                .allowNull(true)
-                .class('form-select')
-                .id('grantObjectId');
-            calSelect.appendTo(mount);
-            // CalendarSelect's allowNull adds an empty option that semantically
-            // means "no nation/diocese" = General Roman Calendar, which is not a
-            // valid national/diocesan object_id. Turn it into a disabled
-            // placeholder so the user must pick a concrete calendar.
-            const calNullOpt = mount.querySelector('#grantObjectId option[value=""]');
-            if (calNullOpt) {
-                calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
-                calNullOpt.disabled = true;
-                calNullOpt.selected = true;
+            // See permission-requests.js: an unhandled rejection here leaves the
+            // mount empty, which is indistinguishable from "still loading". Fail
+            // loudly and leave a visible, disabled control behind instead.
+            try {
+                const client = await apiClientReady;
+                if (!client) throw new Error('ApiClient initialization failed');
+                if (grantObjectType.value !== objectType) return; // scope changed again meanwhile
+                const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+                    ? CalendarSelectFilter.NATIONAL_CALENDARS
+                    : CalendarSelectFilter.DIOCESAN_CALENDARS;
+                const calSelect = new CalendarSelect(LITCAL_LOCALE)
+                    .filter(filter)
+                    .allowNull(true)
+                    .class('form-select')
+                    .id('grantObjectId');
+                calSelect.appendTo(mount);
+                // CalendarSelect's allowNull adds an empty option that semantically
+                // means "no nation/diocese" = General Roman Calendar, which is not a
+                // valid national/diocesan object_id. Turn it into a disabled
+                // placeholder so the user must pick a concrete calendar.
+                const calNullOpt = mount.querySelector('#grantObjectId option[value=""]');
+                if (calNullOpt) {
+                    calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+                    calNullOpt.disabled = true;
+                    calNullOpt.selected = true;
+                }
+            } catch (err) {
+                console.error(
+                    `[admin-permissions] Could not build the calendar select for object type "${objectType}":`,
+                    err
+                );
+                const failed = document.createElement('select');
+                failed.className = 'form-select is-invalid';
+                failed.id = 'grantObjectId';
+                failed.disabled = true;
+                failed.dataset.loadFailed = 'true';
+                const opt = document.createElement('option');
+                opt.value = '';
+                opt.textContent = config.i18n.calendarIdLoadFailed || 'Could not load calendars — try reloading the page';
+                opt.selected = true;
+                failed.appendChild(opt);
+                mount.appendChild(failed);
             }
         } else {
             mount.appendChild(buildStaticGrantObjectId(objectType));

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -516,9 +516,16 @@ document.addEventListener('DOMContentLoaded', () => {
         if (type === 'national_calendar' || type === 'diocesan_calendar') {
             // See permission-requests.js: swallowing a failure here leaves the
             // mount empty, which is indistinguishable from "still loading".
+            // A newer syncScopeIdField() may have run while we were awaiting, in
+            // which case it has already cleared the mount and rendered the control
+            // for the current scope. Appending anything now would stack a stale
+            // #testScopeId on top of it. Matches the guards in
+            // permission-requests.js and admin-permissions.js.
+            const isStale = () => document.getElementById('testScopeType')?.value !== type;
             try {
                 const client = await ApiClient.init(apiUrl).catch(() => null);
                 if (!client) throw new Error('ApiClient initialization failed');
+                if (isStale()) return;
                 const filter = type === 'national_calendar'
                     ? CalendarSelectFilter.NATIONAL_CALENDARS
                     : CalendarSelectFilter.DIOCESAN_CALENDARS;
@@ -526,6 +533,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 sel.appendTo(mount);
             } catch (err) {
                 console.error(`[admin-tests] Could not build the calendar select for scope type "${type}":`, err);
+                if (isStale()) return;
                 const failed = document.createElement('select');
                 failed.className = 'form-select is-invalid';
                 failed.id = 'testScopeId';

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -514,13 +514,30 @@ document.addEventListener('DOMContentLoaded', () => {
         const mount = document.getElementById('testScopeIdMount');
         mount.innerHTML = '';
         if (type === 'national_calendar' || type === 'diocesan_calendar') {
-            const client = await ApiClient.init(apiUrl).catch(() => null);
-            if (!client) return;
-            const filter = type === 'national_calendar'
-                ? CalendarSelectFilter.NATIONAL_CALENDARS
-                : CalendarSelectFilter.DIOCESAN_CALENDARS;
-            const sel = new CalendarSelect(config.locale).filter(filter).allowNull(true).class('form-select').id('testScopeId');
-            sel.appendTo(mount);
+            // See permission-requests.js: swallowing a failure here leaves the
+            // mount empty, which is indistinguishable from "still loading".
+            try {
+                const client = await ApiClient.init(apiUrl).catch(() => null);
+                if (!client) throw new Error('ApiClient initialization failed');
+                const filter = type === 'national_calendar'
+                    ? CalendarSelectFilter.NATIONAL_CALENDARS
+                    : CalendarSelectFilter.DIOCESAN_CALENDARS;
+                const sel = new CalendarSelect(config.locale).filter(filter).allowNull(true).class('form-select').id('testScopeId');
+                sel.appendTo(mount);
+            } catch (err) {
+                console.error(`[admin-tests] Could not build the calendar select for scope type "${type}":`, err);
+                const failed = document.createElement('select');
+                failed.className = 'form-select is-invalid';
+                failed.id = 'testScopeId';
+                failed.disabled = true;
+                failed.dataset.loadFailed = 'true';
+                const opt = document.createElement('option');
+                opt.value = '';
+                opt.textContent = 'Could not load calendars — try reloading the page';
+                opt.selected = true;
+                failed.appendChild(opt);
+                mount.appendChild(failed);
+            }
         }
     }
 

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -153,6 +153,30 @@ document.addEventListener('DOMContentLoaded', async function() {
     const DIOCESAN_FILTER_TYPES = ['diocesan_calendar', 'diocesan_calendar_test'];
 
     /**
+     * Build the stand-in control shown when the CalendarSelect cannot be built.
+     *
+     * It deliberately still carries `.perm-object-id`, so the control the rest of
+     * the form (and the E2E suite) waits for does appear. It is disabled and has
+     * no selectable value, so submit validation still blocks — but the failure
+     * now reads as "this broke" rather than as an element that never arrives.
+     * @returns {HTMLSelectElement} A disabled select carrying the failure notice
+     */
+    function buildObjectIdLoadFailure() {
+        const select = document.createElement('select');
+        select.className = 'form-select form-select-sm perm-object-id is-invalid';
+        select.required = true;
+        select.disabled = true;
+        select.dataset.loadFailed = 'true';
+
+        const opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = config.i18n.calendarIdLoadFailed || 'Could not load calendars — try reloading the page';
+        opt.selected = true;
+        select.appendChild(opt);
+        return select;
+    }
+
+    /**
      * Build a native <select class="form-select form-select-sm perm-object-id">
      * for the three non-calendar scopes (wider_region / GRC / GRC test).
      * @param {string} objectType - The currently selected object type
@@ -208,31 +232,45 @@ document.addEventListener('DOMContentLoaded', async function() {
             NATIONAL_FILTER_TYPES.includes(objectType) ||
             DIOCESAN_FILTER_TYPES.includes(objectType)
         ) {
-            const client = await apiClientReady;
-            if (!client) return; // init failed; leave empty (validation will block submit)
-            // Guard against a rapid scope change that already replaced the mount.
-            if (
-                !row.isConnected ||
-                row.querySelector('.perm-object-type').value !== objectType
-            ) return;
-            const filter = NATIONAL_FILTER_TYPES.includes(objectType)
-                ? CalendarSelectFilter.NATIONAL_CALENDARS
-                : CalendarSelectFilter.DIOCESAN_CALENDARS;
-            const calSelect = new CalendarSelect(LITCAL_LOCALE)
-                .filter(filter)
-                .allowNull(true)
-                .class('form-select form-select-sm perm-object-id');
-            calSelect.appendTo(mount);
-            // CalendarSelect's allowNull adds an empty option that semantically
-            // means "no nation/diocese" = General Roman Calendar, which is not a
-            // valid national/diocesan object_id. Turn it into a disabled
-            // placeholder so the user must pick a concrete calendar (Vatican
-            // included — it has its own national-style calendar).
-            const calNullOpt = mount.querySelector('.perm-object-id option[value=""]');
-            if (calNullOpt) {
-                calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
-                calNullOpt.disabled = true;
-                calNullOpt.selected = true;
+            // Everything from here can throw or reject: the API may be down, and
+            // CalendarSelect itself can fail while parsing calendar metadata. An
+            // unhandled rejection here leaves the mount empty, which looks
+            // identical to "still loading" — the control simply never appears and
+            // the only symptom is a Playwright waitFor timing out ten seconds
+            // later with nothing to point at. Fail loudly and visibly instead.
+            try {
+                const client = await apiClientReady;
+                if (!client) throw new Error('ApiClient initialization failed');
+                // Guard against a rapid scope change that already replaced the mount.
+                if (
+                    !row.isConnected ||
+                    row.querySelector('.perm-object-type').value !== objectType
+                ) return;
+                const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+                    ? CalendarSelectFilter.NATIONAL_CALENDARS
+                    : CalendarSelectFilter.DIOCESAN_CALENDARS;
+                const calSelect = new CalendarSelect(LITCAL_LOCALE)
+                    .filter(filter)
+                    .allowNull(true)
+                    .class('form-select form-select-sm perm-object-id');
+                calSelect.appendTo(mount);
+                // CalendarSelect's allowNull adds an empty option that semantically
+                // means "no nation/diocese" = General Roman Calendar, which is not a
+                // valid national/diocesan object_id. Turn it into a disabled
+                // placeholder so the user must pick a concrete calendar (Vatican
+                // included — it has its own national-style calendar).
+                const calNullOpt = mount.querySelector('.perm-object-id option[value=""]');
+                if (calNullOpt) {
+                    calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+                    calNullOpt.disabled = true;
+                    calNullOpt.selected = true;
+                }
+            } catch (err) {
+                console.error(
+                    `[permission-requests] Could not build the calendar select for object type "${objectType}":`,
+                    err
+                );
+                mount.appendChild(buildObjectIdLoadFailure());
             }
         } else {
             mount.appendChild(buildStaticObjectIdSelect(objectType));

--- a/permission-requests.php
+++ b/permission-requests.php
@@ -231,6 +231,8 @@ if (!$authHelper->emailVerified) {
                 calendarId: <?php echo json_encode(_('Calendar ID'), $jsonFlags); ?>,
                 selectCalendarScope: <?php echo json_encode(_('Select calendar scope...'), $jsonFlags); ?>,
                 selectCalendarId: <?php echo json_encode(_('Select calendar ID...'), $jsonFlags); ?>,
+                /** translators: shown in place of the calendar dropdown when the calendar list could not be loaded */
+                calendarIdLoadFailed: <?php echo json_encode(_('Could not load calendars — try reloading the page'), $jsonFlags); ?>,
                 // Object type display names
                 nationalCalendar: <?php echo json_encode(_('National Calendar'), $jsonFlags); ?>,
                 diocesanCalendar: <?php echo json_encode(_('Diocesan Calendar'), $jsonFlags); ?>,


### PR DESCRIPTION
Two loose ends from the E2E outage.

## 1. The comment in `e2e.yml` was wrong

Its header claimed:

> (E2E is not a required check, so excluding a PR here never leaves it stuck waiting on a missing status.)

**That is not true.** `E2E (Playwright + full docker stack)` is in the required contexts for `development`:

```
["CodeQL","Analyze (javascript-typescript)","E2E (Playwright + full docker stack)","PHP (…)","JS (eslint · typecheck)"]
```

…which is exactly why #429 and #430 both sat `BLOCKED` and had to go in with `--admin`.

The comment also undersold the design it belongs to. **`e2e-required-skip.yml` already solves this properly** — it runs on the complement of `e2e.yml`’s `paths` and reports the *same* check name instantly, so the context can be required *and* path-filtered without deadlocking translation/docs PRs. Exactly one of the two reports it for any given PR.

I verified the two lists are in sync — **18 entries each, no drift in either direction**. The comment now states that they must stay that way, since the whole scheme silently breaks if they drift.

No configuration changed: E2E stays required, which is what you want.

## 2. Calendar-select failures were invisible

This is why spec 12 was hard to read. With components-js 1.4.0 pinned, `new CalendarSelect(...)` threw while parsing calendar metadata:

```
Cannot read properties of undefined (reading calendar_id)
```

`syncRowObjectIdField` is `async` with no `try`/`catch`, so the rejection went nowhere. The mount was left empty — **indistinguishable from "still loading"** — and the only symptom was `requestAccess.ts:51`, `objectIdControl.waitFor({ state: "visible" })`, timing out ten seconds later with nothing to point at.

All three places that mount a `CalendarSelect` into a form now:

- **catch**, and `console.error` the object type plus the underlying error
- leave a **disabled `is-invalid` control** carrying the same class/id the rest of the form expects

| File | Control |
|------|---------|
| `assets/js/permission-requests.js` | `.perm-object-id` |
| `assets/js/admin-permissions.js` | `#grantObjectId` |
| `assets/js/admin-tests.js` | `#testScopeId` |

Submit validation still blocks — the control has no selectable value — but a failure now reads as a failure rather than as an element that never arrives. A future E2E run in this situation fails on a missing *option* with an error in the console, not on a bare timeout.

`await apiClientReady` returning falsy is folded into the same path instead of being a silent early `return`.

The message is translatable in the two pages that have an i18n bag; `admin-tests.js` has none (zero `config.i18n` references), so it keeps a literal.

## Verification

`eslint` on all three files, `php -l`, `composer lint`, `vitest` **119/119**, and both workflow files parse as valid YAML. This PR touches `assets/**` and `.github/workflows/e2e.yml`, so the real E2E suite runs on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar dropdown error handling across permissions, access requests, and administrative tests.
  * Displays a disabled, clearly marked control with reload guidance when calendars cannot be loaded.
  * Prevents blank or misleading calendar fields when initialization or rendering fails.
  * Added localized failure messages for a consistent experience.

* **Documentation**
  * Clarified that E2E checks are required for applicable pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->