### PR TITLE
Drop the stale js-yaml resolutions override

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "vitest": "^4.1.10"
   },
   "resolutions": {
-    "js-yaml": "^4.2.0",
     "markdown-it": "^14.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,14 +1489,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.2.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:5.2.2":
+  version: 5.2.2
+  resolution: "js-yaml@npm:5.2.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+    js-yaml: bin/js-yaml.mjs
+  checksum: 10c0/e8ded203b235b3d562818c67bf362122abbcee89e507b62bddcdd3085b2f2dd866071e5e78f8e617d41d1a0c0baa1cec12a8fdec5859c571bf862adf585e2684
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #414. Resolves Dependabot alert [#68](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/security/dependabot/68).

> **Note:** the branch name (`chore/bump-js-yaml-4.3.1`) is stale. The first push bumped the override to
> `^4.3.1`; investigation showed removing it is the correct fix, and the commit was amended. GitHub does not
> allow renaming a PR head branch, so the name stays.

## The override is what caused the alert

The `"resolutions": { "js-yaml": "^4.2.0" }` entry dates from
[GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68), when every published
`markdownlint-cli2` release hard-pinned the vulnerable js-yaml 4.1.1 and the override was the only way to
reach a patched 4.2.0. That is no longer true — `markdownlint-cli2@0.23.2` pins `js-yaml: "npm:5.2.2"`
itself:

```text
"markdownlint-cli2@npm:^0.23.2":
  dependencies:
    js-yaml: "npm:5.2.2"
```

So the override protects nothing. It only holds the tree down on the 4.x line upstream has already left —
and that downward pin is precisely what produced the new alert. js-yaml 4.3.0 resolves `!!omap` in quadratic
time ([GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), high, vulnerable range
`>= 4.0.0, < 4.3.1`).

Removing the override is strictly better than pinning forward to 4.3.1: js-yaml resolves to 5.2.2, outside
every vulnerable range, and we stop tracking a line we have no reason to be on.

```text
- js-yaml@npm:4.3.0
+ js-yaml@npm:5.2.2   (via npm:5.2.2 — markdownlint-cli2's own pin)
```

## This was already flagged

`.github/workflows/js-yaml-resolution-reminder.yml` exists to watch for exactly this condition and filed
#414. Its staleness check reads the constraint from `yarn.lock` and yields `stale:5.2.2`, i.e. drop the
override. The issue auto-closes on the next run once the entry is gone.

## Exposure

Tooling-only either way. `package.json` declares no runtime dependencies — the npm tree is entirely dev
tooling (markdownlint, ESLint, Playwright, vitest), while the shipped frontend is PHP plus browser JS via
import map. Dependabot reports the scope as `runtime` because it could not attribute the transitive edge to
a dev root (`relationship: inconclusive`).

## Verification

```text
yarn why js-yaml           → markdownlint-cli2@0.23.2 → js-yaml@npm:5.2.2 (via npm:5.2.2)
grep -c '^"js-yaml' yarn.lock → 1  (single entry, no duplicates)
yarn lint:md               → 44 files, 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)