### PR TITLE
Pin components-js at 2.0.0 and offer a rite select on every calendar select

### DIFF
--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -9,11 +9,15 @@ import {
     ApiClient,
     CalendarSelect,
     CalendarSelectFilter,
+    RiteSelect,
 } from '@liturgical-calendar/components-js';
 
 // Initialize the API client once; CalendarSelect requires this to have resolved.
+// Since components-js 2.0.0 init() rejects on failure rather than resolving to
+// false, so the `instanceof` check it used to need is gone: the fulfilled value
+// is always a client. The catch still maps failure to false, which is what the
+// `if (!client)` guards below test for.
 const apiClientReady = ApiClient.init(BaseUrl)
-    .then(function(client) { return client instanceof ApiClient ? client : false; })
     .catch(function(err) {
         console.error('Failed to initialize ApiClient for permission fields:', err);
         return false;
@@ -132,9 +136,26 @@ document.addEventListener('DOMContentLoaded', function() {
                 const client = await apiClientReady;
                 if (!client) throw new Error('ApiClient initialization failed');
                 if (grantObjectType.value !== objectType) return; // scope changed again meanwhile
-                const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+                const isNational = NATIONAL_FILTER_TYPES.includes(objectType);
+                const filter = isNational
                     ? CalendarSelectFilter.NATIONAL_CALENDARS
                     : CalendarSelectFilter.DIOCESAN_CALENDARS;
+                // The Ambrosian rite has no national tier: a `nations` filtered select
+                // under it holds only the rite-level calendar and hides itself, which
+                // would strand the admin with no way to fill a required field. So the
+                // rite select is offered for diocesan scopes only, where the Ambrosian
+                // rite does have calendars (Lugano, Bergamo, Milano, Novara).
+                //
+                // It must be in the DOM before linkToRiteSelect() below, which attaches
+                // its change listener to this element.
+                let riteSelect = null;
+                if (!isNational) {
+                    riteSelect = new RiteSelect(LITCAL_LOCALE)
+                        .class('form-select mb-2')
+                        .id('grantObjectRite')
+                        .label({ class: 'form-label' });
+                    riteSelect.appendTo(mount);
+                }
                 const calSelect = new CalendarSelect(LITCAL_LOCALE)
                     .filter(filter)
                     .allowNull(true)
@@ -145,12 +166,22 @@ document.addEventListener('DOMContentLoaded', function() {
                 // means "no nation/diocese" = General Roman Calendar, which is not a
                 // valid national/diocesan object_id. Turn it into a disabled
                 // placeholder so the user must pick a concrete calendar.
-                const calNullOpt = mount.querySelector('#grantObjectId option[value=""]');
-                if (calNullOpt) {
-                    calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
-                    calNullOpt.disabled = true;
-                    calNullOpt.selected = true;
+                //
+                // Re-applied on every rite change: linkToRiteSelect() rebuilds the
+                // option list from scratch, which discards this customization.
+                const applyCalendarIdPlaceholder = () => {
+                    const calNullOpt = mount.querySelector('#grantObjectId option[value=""]');
+                    if (calNullOpt) {
+                        calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+                        calNullOpt.disabled = true;
+                        calNullOpt.selected = true;
+                    }
+                };
+                if (riteSelect) {
+                    calSelect.linkToRiteSelect(riteSelect);
+                    riteSelect._domElement.addEventListener('change', applyCalendarIdPlaceholder);
                 }
+                applyCalendarIdPlaceholder();
             } catch (err) {
                 console.error(
                     `[admin-permissions] Could not build the calendar select for object type "${objectType}":`,

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -7,6 +7,7 @@ import {
     ApiClient,
     CalendarSelect,
     CalendarSelectFilter,
+    RiteSelect,
 } from '@liturgical-calendar/components-js';
 import { AssertionsBuilder, TestType, AssertType } from './AssertionsBuilder.js';
 
@@ -202,7 +203,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('filterTestScope').addEventListener('input', renderTableRows);
 
     // Expose internals for later tasks (editor/delete wiring appended below).
-    window.__adminTests = { state, fetchJson, deriveScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, ApiClient };
+    window.__adminTests = { state, fetchJson, deriveScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, RiteSelect, ApiClient };
 
     // ---- editor -----------------------------------------------------------
 
@@ -526,11 +527,28 @@ document.addEventListener('DOMContentLoaded', () => {
                 const client = await ApiClient.init(apiUrl).catch(() => null);
                 if (!client) throw new Error('ApiClient initialization failed');
                 if (isStale()) return;
-                const filter = type === 'national_calendar'
+                const isNational = type === 'national_calendar';
+                const filter = isNational
                     ? CalendarSelectFilter.NATIONAL_CALENDARS
                     : CalendarSelectFilter.DIOCESAN_CALENDARS;
+                // The Ambrosian rite has no national tier: a `nations` filtered select
+                // under it holds only the rite-level calendar and hides itself, which
+                // would strand the admin with no way to fill a required field. So the
+                // rite select is offered for diocesan scopes only, where the Ambrosian
+                // rite does have calendars (Lugano, Bergamo, Milano, Novara).
+                //
+                // It must be in the DOM before linkToRiteSelect() below, which attaches
+                // its change listener to this element.
+                let riteSelect = null;
+                if (!isNational) {
+                    riteSelect = new RiteSelect(config.locale).class('form-select mb-2').id('testScopeRite');
+                    riteSelect.appendTo(mount);
+                }
                 const sel = new CalendarSelect(config.locale).filter(filter).allowNull(true).class('form-select').id('testScopeId');
                 sel.appendTo(mount);
+                if (riteSelect) {
+                    sel.linkToRiteSelect(riteSelect);
+                }
             } catch (err) {
                 console.error(`[admin-tests] Could not build the calendar select for scope type "${type}":`, err);
                 if (isStale()) return;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -9,96 +9,99 @@ Input.setGlobalWrapperClass('form-group col col-md-3');
 if (!BaseUrl) {
     console.error('BaseUrl is falsy, cannot initialize ApiClient');
 } else {
-    ApiClient.init(BaseUrl).then(apiClient => {
-        if (false === apiClient || false === apiClient instanceof ApiClient) {
-            alert('Error initializing the Liturgical Calendar API Client');
-        } else {
-            const apiOptions = (new ApiOptions( LITCAL_LOCALE ));
-            apiOptions._localeInput.defaultValue('la').class('form-select requestOption').id('RequestOptionLocale');
-            apiOptions._acceptHeaderInput.asReturnTypeParam().id('RequestOptionReturnType');
-            apiOptions._yearInput.class('form-control').id('RequestOptionYear');
-            apiOptions._yearTypeInput.id('RequestOptionYearType');
-            apiOptions._calendarPathInput.id('APICalendarRouteSelect').class('form-select');
-            apiOptions._epiphanyInput.id('RequestOptionEpiphany').class('form-select requestOption');
-            apiOptions._ascensionInput.id('RequestOptionAscension').class('form-select requestOption');
-            apiOptions._corpusChristiInput.id('RequestOptionCorpusChristi').class('form-select requestOption');
-            apiOptions._eternalHighPriestInput.id('RequestOptionEternalHighPriest').class('form-select requestOption');
-            apiOptions._ascensionInput.wrapperClass('form-group col col-md-2');
-            apiOptions._corpusChristiInput.wrapperClass('form-group col col-md-2');
-            apiOptions._eternalHighPriestInput.wrapperClass('form-group col col-md-2');
-            apiOptions.filter( ApiOptionsFilter.PATH_BUILDER ).appendTo('#pathBuilder');
+    // No parameter: this page builds a PathBuilder and never fetches, so it needs
+    // init() only for its side effect of loading the calendar metadata that
+    // CalendarSelect and ApiOptions read. The client itself was previously
+    // referenced solely by the instanceof guard removed below.
+    ApiClient.init(BaseUrl).then(() => {
+        const apiOptions = (new ApiOptions( LITCAL_LOCALE ));
+        apiOptions._localeInput.defaultValue('la').class('form-select requestOption').id('RequestOptionLocale');
+        apiOptions._acceptHeaderInput.asReturnTypeParam().id('RequestOptionReturnType');
+        apiOptions._yearInput.class('form-control').id('RequestOptionYear');
+        apiOptions._yearTypeInput.id('RequestOptionYearType');
+        apiOptions._calendarPathInput.id('APICalendarRouteSelect').class('form-select');
+        apiOptions._epiphanyInput.id('RequestOptionEpiphany').class('form-select requestOption');
+        apiOptions._ascensionInput.id('RequestOptionAscension').class('form-select requestOption');
+        apiOptions._corpusChristiInput.id('RequestOptionCorpusChristi').class('form-select requestOption');
+        apiOptions._eternalHighPriestInput.id('RequestOptionEternalHighPriest').class('form-select requestOption');
+        apiOptions._ascensionInput.wrapperClass('form-group col col-md-2');
+        apiOptions._corpusChristiInput.wrapperClass('form-group col col-md-2');
+        apiOptions._eternalHighPriestInput.wrapperClass('form-group col col-md-2');
+        apiOptions.filter( ApiOptionsFilter.PATH_BUILDER ).appendTo('#pathBuilder');
 
-            const calendarSelect = (new CalendarSelect( LITCAL_LOCALE )).allowNull();
-            calendarSelect.label({
+        const calendarSelect = (new CalendarSelect( LITCAL_LOCALE )).allowNull();
+        calendarSelect.label({
+            class: 'form-label mb-1',
+            id: 'calendarSelectLabel',
+            text: 'Select a calendar'
+        }).wrapper({
+            class: 'form-group col col-md-3',
+            id: 'calendarSelectWrapper'
+        }).id('APICalendarSelect')
+        .class('form-select')
+        .insertAfter( apiOptions._calendarPathInput );
+
+        // Must be in the DOM before linkToCalendarSelect() below, which reads
+        // this element to attach the rite-change listener.
+        // No `text`: omitting it lets RiteSelect supply its own localized label
+        // (Messages[lang].SELECT_A_RITE), so this reads "Seleziona un rito" on the
+        // Italian page rather than the hardcoded English used for the calendar
+        // label below. Note the library only translates this key for en and it so
+        // far; every other locale still falls back to English.
+        const riteSelect = (new RiteSelect( LITCAL_LOCALE ))
+            .label({
                 class: 'form-label mb-1',
-                id: 'calendarSelectLabel',
-                text: 'Select a calendar'
-            }).wrapper({
-                class: 'form-group col col-md-3',
-                id: 'calendarSelectWrapper'
-            }).id('APICalendarSelect')
-            .class('form-select')
-            .insertAfter( apiOptions._calendarPathInput );
+                id: 'riteSelectLabel'
+            }).id('APIRiteSelect')
+            .class('form-select');
+        riteSelect.appendTo('#riteSelectWrapper');
 
-            // Must be in the DOM before linkToCalendarSelect() below, which reads
-            // this element to attach the rite-change listener.
-            // No `text`: omitting it lets RiteSelect supply its own localized label
-            // (Messages[lang].SELECT_A_RITE), so this reads "Seleziona un rito" on the
-            // Italian page rather than the hardcoded English used for the calendar
-            // label below. Note the library only translates this key for en and it so
-            // far; every other locale still falls back to English.
-            const riteSelect = (new RiteSelect( LITCAL_LOCALE ))
-                .label({
-                    class: 'form-label mb-1',
-                    id: 'riteSelectLabel'
-                }).id('APIRiteSelect')
-                .class('form-select');
-            riteSelect.appendTo('#riteSelectWrapper');
+        apiOptions.filter( ApiOptionsFilter.BASE_PATH ).appendTo('#requestParametersBasePath');
+        apiOptions.filter( ApiOptionsFilter.ALL_PATHS ).appendTo('#requestParametersAllPaths');
+        // Passing riteSelect marks the rite as explicit, so it is emitted as a
+        // path segment (/calendar/ambrosian/...) rather than left implicit, and
+        // rebuilds the calendar select whenever the rite changes. The Ambrosian
+        // rite has no national tier and fixes Epiphany, Ascension, Corpus Christi
+        // and the Eternal High Priest in its own books, so ApiOptions also
+        // disables those four inputs for as long as it is selected.
+        apiOptions.linkToCalendarSelect( calendarSelect, riteSelect );
 
-            apiOptions.filter( ApiOptionsFilter.BASE_PATH ).appendTo('#requestParametersBasePath');
-            apiOptions.filter( ApiOptionsFilter.ALL_PATHS ).appendTo('#requestParametersAllPaths');
-            // Passing riteSelect marks the rite as explicit, so it is emitted as a
-            // path segment (/calendar/ambrosian/...) rather than left implicit, and
-            // rebuilds the calendar select whenever the rite changes. The Ambrosian
-            // rite has no national tier and fixes Epiphany, Ascension, Corpus Christi
-            // and the Eternal High Priest in its own books, so ApiOptions also
-            // disables those four inputs for as long as it is selected.
-            apiOptions.linkToCalendarSelect( calendarSelect, riteSelect );
+        const localeLabelAfter = document.querySelector('#localeLabelAfter');
+        const acceptLabelAfter = document.querySelector('#acceptLabelAfter');
+        const yearLabelAfter = document.querySelector('#yearLabelAfter');
+        apiOptions._localeInput._labelElement.insertAdjacentElement('beforeend', localeLabelAfter);
+        apiOptions._acceptHeaderInput._labelElement.insertAdjacentElement('beforeend', acceptLabelAfter);
+        apiOptions._yearInput._labelElement.insertAdjacentElement('beforeend', yearLabelAfter);
 
-            const localeLabelAfter = document.querySelector('#localeLabelAfter');
-            const acceptLabelAfter = document.querySelector('#acceptLabelAfter');
-            const yearLabelAfter = document.querySelector('#yearLabelAfter');
-            apiOptions._localeInput._labelElement.insertAdjacentElement('beforeend', localeLabelAfter);
-            apiOptions._acceptHeaderInput._labelElement.insertAdjacentElement('beforeend', acceptLabelAfter);
-            apiOptions._yearInput._labelElement.insertAdjacentElement('beforeend', yearLabelAfter);
+        const pathBuilder = new PathBuilder(apiOptions, calendarSelect);
+        pathBuilder.id('requestUrlBuilder')
+            .class('row ps-2')
+            .pathWrapperClass('col col-md-8 border border-secondary rounded bg-light d-flex align-items-center')
+            .buttonWrapperClass('col col-md-3')
+            .buttonClass('btn btn-primary')
+            .replace('#pathBuilderComponent');
 
-            const pathBuilder = new PathBuilder(apiOptions, calendarSelect);
-            pathBuilder.id('requestUrlBuilder')
-                .class('row ps-2')
-                .pathWrapperClass('col col-md-8 border border-secondary rounded bg-light d-flex align-items-center')
-                .buttonWrapperClass('col col-md-3')
-                .buttonClass('btn btn-primary')
-                .replace('#pathBuilderComponent');
+        $('#holydays_of_obligation').multiselect({
+            buttonWidth: '100%',
+            buttonClass: 'form-select',
+            templates: {
+                button: '<button type="button" class="multiselect dropdown-toggle" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span></button>'
+            },
+        });
+        calendarSelect._domElement.addEventListener('change', (ev) => {
+            $('#holydays_of_obligation').multiselect('rebuild');
+            if (ev.target.value === '') {
+                $('#holydays_of_obligation').multiselect('deselectAll', false).multiselect('selectAll', false).parent().find('button.multiselect').removeAttr('style');
+            } else {
+                $('#holydays_of_obligation').parent().find('button.multiselect').css('background-color', '#e9ecef');
+            }
+        });
 
-            $('#holydays_of_obligation').multiselect({
-                buttonWidth: '100%',
-                buttonClass: 'form-select',
-                templates: {
-                    button: '<button type="button" class="multiselect dropdown-toggle" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span></button>'
-                },
-            });
-            calendarSelect._domElement.addEventListener('change', (ev) => {
-                $('#holydays_of_obligation').multiselect('rebuild');
-                if (ev.target.value === '') {
-                    $('#holydays_of_obligation').multiselect('deselectAll', false).multiselect('selectAll', false).parent().find('button.multiselect').removeAttr('style');
-                } else {
-                    $('#holydays_of_obligation').parent().find('button.multiselect').css('background-color', '#e9ecef');
-                }
-            });
-
-        }
     }).catch( err => {
-        console.error('Error initializing the Liturgical Calendar API Client:', err);
+        // Since components-js 2.0.0 init() rejects rather than resolving to false,
+        // so the `apiClient instanceof ApiClient` guard this page used to need is
+        // gone. This also catches anything thrown while building the controls above.
+        console.error('Could not set up the Liturgical Calendar API explorer:', err);
     });
 }
 

--- a/assets/js/liturgyOfAnyDay.js
+++ b/assets/js/liturgyOfAnyDay.js
@@ -108,12 +108,10 @@ const translations = {
  */
 const initializePage = async () => {
     // Initialize ApiClient with the API URL from the global BaseUrl
+    // Since components-js 2.0.0 init() rejects rather than resolving to false, so
+    // the `instanceof` guard this used to need is gone; startPage() below catches
+    // the rejection.
     const apiClient = await ApiClient.init( BaseUrl );
-
-    if ( !( apiClient instanceof ApiClient ) ) {
-        console.error( 'Failed to initialize ApiClient' );
-        return;
-    }
 
     // Get the base language for translations
     const lang = currentLocale.language;
@@ -216,19 +214,40 @@ const initializePage = async () => {
 
     liturgyOfAnyDay.appendTo( '#liturgyOfAnyDayContainer' );
 
-    // Have ApiClient listen to CalendarSelect and ApiOptions
-    // This automatically handles Accept-Language headers based on locale selection
-    apiClient.listenTo( calendarSelect ).listenTo( apiOptions );
+    // Have ApiClient listen to CalendarSelect, RiteSelect and ApiOptions
+    // This automatically handles Accept-Language headers based on locale selection.
+    //
+    // riteSelect has to be wired here as well as passed to linkToCalendarSelect()
+    // above: that call rebuilds the calendar select on a rite change, but only the
+    // client turns the rite into a path segment. Without it the page offered a rite
+    // select that changed the calendar list while every request still went to
+    // /calendar/roman/.
+    apiClient.listenTo( calendarSelect ).listenTo( riteSelect ).listenTo( apiOptions );
 
     // Initial fetch - fetch the General Roman Calendar
     // Note: LiturgyOfAnyDay.listenTo() already configured ApiClient with the correct
     // year_type (LITURGICAL for Dec 31st to include vigil masses, CIVIL otherwise)
-    apiClient.fetchCalendar( selectedLocale );
+    //
+    // Since components-js 2.0.0 the fetch methods reject instead of logging and
+    // swallowing, so this promise is handled rather than left bare.
+    apiClient.fetchCalendar( selectedLocale ).catch( error => {
+        console.error( `Could not load the calendar: ${error.message}` );
+    } );
 };
 
-// Initialize when DOM is ready
+// Initialize when DOM is ready.
+//
+// initializePage() is async and, since components-js 2.0.0, ApiClient.init() and
+// the fetch methods reject on failure, so the returned promise is handled here
+// rather than left to surface as an unhandled rejection.
+const startPage = () => {
+    initializePage().catch( error => {
+        console.error( `Could not initialize the liturgy of any day page: ${error.message}` );
+    } );
+};
+
 if ( document.readyState === 'loading' ) {
-    document.addEventListener( 'DOMContentLoaded', initializePage );
+    document.addEventListener( 'DOMContentLoaded', startPage );
 } else {
-    initializePage();
+    startPage();
 }

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -9,11 +9,15 @@ import {
     ApiClient,
     CalendarSelect,
     CalendarSelectFilter,
+    RiteSelect,
 } from '@liturgical-calendar/components-js';
 
 // Initialize the API client once; CalendarSelect requires this to have resolved.
+// Since components-js 2.0.0 init() rejects on failure rather than resolving to
+// false, so the `instanceof` check it used to need is gone: the fulfilled value
+// is always a client. The catch still maps failure to false, which is what the
+// `if (!client)` guards below test for.
 const apiClientReady = ApiClient.init(BaseUrl)
-    .then(function(client) { return client instanceof ApiClient ? client : false; })
     .catch(function(err) {
         console.error('Failed to initialize ApiClient for permission fields:', err);
         return false;
@@ -246,9 +250,24 @@ document.addEventListener('DOMContentLoaded', async function() {
                     !row.isConnected ||
                     row.querySelector('.perm-object-type').value !== objectType
                 ) return;
-                const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+                const isNational = NATIONAL_FILTER_TYPES.includes(objectType);
+                const filter = isNational
                     ? CalendarSelectFilter.NATIONAL_CALENDARS
                     : CalendarSelectFilter.DIOCESAN_CALENDARS;
+                // The Ambrosian rite has no national tier: a `nations` filtered select
+                // under it holds only the rite-level calendar and hides itself, which
+                // would strand the admin with no way to fill a required field. So the
+                // rite select is offered for diocesan scopes only, where the Ambrosian
+                // rite does have calendars (Lugano, Bergamo, Milano, Novara).
+                //
+                // It must be in the DOM before linkToRiteSelect() below, which attaches
+                // its change listener to this element.
+                let riteSelect = null;
+                if (!isNational) {
+                    riteSelect = new RiteSelect(LITCAL_LOCALE)
+                        .class('form-select form-select-sm mb-2 perm-object-rite');
+                    riteSelect.appendTo(mount);
+                }
                 const calSelect = new CalendarSelect(LITCAL_LOCALE)
                     .filter(filter)
                     .allowNull(true)
@@ -259,12 +278,22 @@ document.addEventListener('DOMContentLoaded', async function() {
                 // valid national/diocesan object_id. Turn it into a disabled
                 // placeholder so the user must pick a concrete calendar (Vatican
                 // included — it has its own national-style calendar).
-                const calNullOpt = mount.querySelector('.perm-object-id option[value=""]');
-                if (calNullOpt) {
-                    calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
-                    calNullOpt.disabled = true;
-                    calNullOpt.selected = true;
+                //
+                // Re-applied on every rite change: linkToRiteSelect() rebuilds the
+                // option list from scratch, which discards this customization.
+                const applyCalendarIdPlaceholder = () => {
+                    const calNullOpt = mount.querySelector('.perm-object-id option[value=""]');
+                    if (calNullOpt) {
+                        calNullOpt.textContent = config.i18n.selectCalendarId || 'Select calendar ID...';
+                        calNullOpt.disabled = true;
+                        calNullOpt.selected = true;
+                    }
+                };
+                if (riteSelect) {
+                    calSelect.linkToRiteSelect(riteSelect);
+                    riteSelect._domElement.addEventListener('change', applyCalendarIdPlaceholder);
                 }
+                applyCalendarIdPlaceholder();
             } catch (err) {
                 console.error(
                     `[permission-requests] Could not build the calendar select for object type "${objectType}":`,

--- a/examples.php
+++ b/examples.php
@@ -20,7 +20,7 @@ $JAVASCRIPT_EXAMPLE_CONTENTS = <<<EOT
 <script type="importmap">
     {
         "imports": {
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.5.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.0.0/+esm"
         }
     }
 </script>
@@ -73,7 +73,7 @@ $FULLCALENDAR_EXAMPLE_CONTENTS = <<<EOT
             "@fullcalendar/daygrid": "https://cdn.skypack.dev/@fullcalendar/daygrid@6.1.19",
             "@fullcalendar/list": "https://cdn.skypack.dev/@fullcalendar/list@6.1.19",
             "@fullcalendar/bootstrap5": "https://cdn.skypack.dev/@fullcalendar/bootstrap5@6.1.19",
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.5.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.0.0/+esm"
         }
     }
 </script>

--- a/layout/footer.php
+++ b/layout/footer.php
@@ -107,7 +107,7 @@ const NotificationTranslations = {
 $isDevelopment   = ( $_ENV['APP_ENV'] ?? 'production' ) === 'development';
 $componentsJsUrl = $isDevelopment
     ? './assets/components-js/index.js'
-    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@1.5.0/+esm';
+    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.0.0/+esm';
 
 $componentsJsImportMap = <<<SCRIPT
 <script type="importmap">

--- a/liturgyOfAnyDay.php
+++ b/liturgyOfAnyDay.php
@@ -38,6 +38,10 @@ include_once 'includes/common.php';
         </div>
         <?php include_once('./layout/footer.php'); ?>
         <script nomodule defer src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
-        <script type="module" src="assets/js/liturgyOfAnyDay.js"></script>
+        <?php /* assets/js/liturgyOfAnyDay.js is injected by layout/footer.php, which
+                 appends a filemtime cache-buster. Including it here as well loaded it
+                 under two different URLs — "…js" and "…js?v=…" — which the module
+                 registry treats as two modules, so the page initialized twice and
+                 rendered a second rite select, calendar select and widget. */ ?>
 </body>
 </html>


### PR DESCRIPTION
Pins the CDN import from `1.5.0` to `2.0.0` in `examples.php` and `layout/footer.php`. **Development mode is unaffected** — `footer.php` serves a local, untracked `assets/components-js/` copy, so the pin governs production only.

## Rite selects on the three admin scope pickers

`admin-tests.js`, `admin-permissions.js` and `permission-requests.js` each mount a `CalendarSelect` with no `ApiOptions` — exactly the case 2.0.0's `CalendarSelect.linkToRiteSelect()` was added for.

**Offered for diocesan scopes only.** Verified against 2.0.0 in Chrome:

| Filter | Roman | Ambrosian |
|--------|-------|-----------|
| `NATIONAL_CALENDARS` | 7 options, visible | **1 option, hidden** |
| `DIOCESAN_CALENDARS` | 13 options | 5 options (Lugano, Bergamo, Milano, Novara) |

A `nations` filtered select under the Ambrosian rite drops to the rite-level calendar — not a valid national `object_id` — and hides itself. On a national scope a rite select would therefore let an admin hide the one field the form requires. Diocesan scopes have real calendars, so the control has something to do there.

`linkToRiteSelect()` rebuilds the option list from scratch, which **discarded the disabled "Select calendar ID..." placeholder** the two permission screens install over `allowNull`'s empty option. That is now a function, re-applied on every rite change — confirmed surviving Roman → Ambrosian → Roman.

E2E selectors are unaffected: the rite select carries its own class (`.perm-object-rite`), so `.perm-object-id` still resolves to exactly one element.

## Two bugs found while wiring

- **`liturgyOfAnyDay.js` had a rite select that did nothing to the request.** It built a `RiteSelect` and passed it to `linkToCalendarSelect()`, but never to the client — so the calendar list rebuilt while every request still went to `/calendar/roman/`. Now also `.listenTo(riteSelect)`.
- **The page initialized twice.** `liturgyOfAnyDay.php` included `assets/js/liturgyOfAnyDay.js` directly while `layout/footer.php` was already injecting it with a `filemtime` cache-buster. Two URLs for one module = two module instances = two rite selects, two calendar selects, two widgets. Screenshot evidence in the commit history; the manual include is gone.

## 2.0.0 migration

`init()` rejects instead of resolving to `false`, so the dead `instanceof ApiClient` guards are gone from `index.js` and `liturgyOfAnyDay.js`, along with the `client instanceof ApiClient ? client : false` wrappers in the two permission modules. `index.js` turns out never to have used the client for anything else — it builds a `PathBuilder` and never fetches — so its `then()` takes no parameter now (eslint caught this). The fetch methods reject instead of logging and swallowing, so `liturgyOfAnyDay`'s initial fetch and its async entry point handle their own promises.

## Verification

- `yarn lint` clean, `yarn test:unit` 119 passed, `composer lint` clean
- Liturgy-of-any-day page loaded in Chrome against the live API: one set of controls, and switching rite issues `/calendar/ambrosian/2026` with the calendar list rebuilt to 5 Ambrosian options

The admin pages were **not** exercised end-to-end — they need admin auth and OpenFGA. Their component wiring was verified in isolation against the 2.0.0 CDN build.

## Not covered

`usage.php` uses **liturgy-components-php**, which has no rite support at all — zero files mention Rite or Ambrosian. It is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rite selection for diocesan calendar and permission fields, with calendars updating accordingly.
  * National scopes continue to show calendar selection without a rite selector.

* **Bug Fixes**
  * Improved application startup and error handling when loading calendar data and configuration.
  * Prevented duplicate loading and repeated initialization of the “Liturgy of Any Day” page.

* **Chores**
  * Updated production and example pages to use the latest calendar components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->