### PR TITLE
Pin components-js at 2.1.0, drop the deprecated rite argument, roll examples forward

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Liturgical-Calendar/examples
-          ref: 04c7fa436bb049e59546267518ac3dd72bff58c4 # main @ 2026-07-07
+          ref: cbfc60f0ac20a7a16ccca4dd4deda0758f6b1059 # main @ 2026-08-10
           path: examples-src
           persist-credentials: false
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -58,13 +58,17 @@ if (!BaseUrl) {
 
         apiOptions.filter( ApiOptionsFilter.BASE_PATH ).appendTo('#requestParametersBasePath');
         apiOptions.filter( ApiOptionsFilter.ALL_PATHS ).appendTo('#requestParametersAllPaths');
-        // Passing riteSelect marks the rite as explicit, so it is emitted as a
-        // path segment (/calendar/ambrosian/...) rather than left implicit, and
+        // Linking the rite marks it as explicit, so it is emitted as a path
+        // segment (/calendar/ambrosian/...) rather than left implicit, and
         // rebuilds the calendar select whenever the rite changes. The Ambrosian
         // rite has no national tier and fixes Epiphany, Ascension, Corpus Christi
         // and the Eternal High Priest in its own books, so ApiOptions also
         // disables those four inputs for as long as it is selected.
-        apiOptions.linkToCalendarSelect( calendarSelect, riteSelect );
+        //
+        // Two calls rather than the deprecated second argument of
+        // linkToCalendarSelect(), which warns as of components-js 2.1.0. Order
+        // between them does not matter; whichever runs second completes the pair.
+        apiOptions.linkToCalendarSelect( calendarSelect ).linkToRiteSelect( riteSelect );
 
         const localeLabelAfter = document.querySelector('#localeLabelAfter');
         const acceptLabelAfter = document.querySelector('#acceptLabelAfter');

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -41,7 +41,7 @@ if (!BaseUrl) {
         .class('form-select')
         .insertAfter( apiOptions._calendarPathInput );
 
-        // Must be in the DOM before linkToCalendarSelect() below, which reads
+        // Must be in the DOM before linkToRiteSelect() below, which reads
         // this element to attach the rite-change listener.
         // No `text`: omitting it lets RiteSelect supply its own localized label
         // (Messages[lang].SELECT_A_RITE), so this reads "Seleziona un rito" on the

--- a/assets/js/liturgyOfAnyDay.js
+++ b/assets/js/liturgyOfAnyDay.js
@@ -139,11 +139,15 @@ const initializePage = async () => {
     // Create ApiOptions with only the locale input filter
     const apiOptions = new ApiOptions( lang )
         .filter( ApiOptionsFilter.LOCALE_ONLY )
-        // Passing riteSelect makes the rite an explicit part of the endpoint and
+        // Linking the rite makes it an explicit part of the endpoint and
         // rebuilds the calendar select whenever the rite changes: the Ambrosian
         // rite has no national tier and offers a different set of diocesan
         // calendars, so a selection from one rite is never carried into another.
-        .linkToCalendarSelect( calendarSelect, riteSelect );
+        //
+        // Two calls rather than the deprecated second argument of
+        // linkToCalendarSelect(), which warns as of components-js 2.1.0.
+        .linkToCalendarSelect( calendarSelect )
+        .linkToRiteSelect( riteSelect );
 
     // Configure the locale input before appending
     // Set defaultValue to currentLocale.language so it will be selected if available

--- a/assets/js/liturgyOfAnyDay.js
+++ b/assets/js/liturgyOfAnyDay.js
@@ -117,7 +117,7 @@ const initializePage = async () => {
     const lang = currentLocale.language;
 
     // Create RiteSelect component. It must exist in the DOM before it is passed
-    // to linkToCalendarSelect() below, which reads its element to attach the
+    // to linkToRiteSelect() below, which reads its element to attach the
     // rite-change listener.
     const riteSelect = new RiteSelect( lang )
         .class( 'form-select' )

--- a/examples.php
+++ b/examples.php
@@ -20,7 +20,7 @@ $JAVASCRIPT_EXAMPLE_CONTENTS = <<<EOT
 <script type="importmap">
     {
         "imports": {
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.0.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.1.0/+esm"
         }
     }
 </script>
@@ -73,7 +73,7 @@ $FULLCALENDAR_EXAMPLE_CONTENTS = <<<EOT
             "@fullcalendar/daygrid": "https://cdn.skypack.dev/@fullcalendar/daygrid@6.1.19",
             "@fullcalendar/list": "https://cdn.skypack.dev/@fullcalendar/list@6.1.19",
             "@fullcalendar/bootstrap5": "https://cdn.skypack.dev/@fullcalendar/bootstrap5@6.1.19",
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.0.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.1.0/+esm"
         }
     }
 </script>

--- a/layout/footer.php
+++ b/layout/footer.php
@@ -107,7 +107,7 @@ const NotificationTranslations = {
 $isDevelopment   = ( $_ENV['APP_ENV'] ?? 'production' ) === 'development';
 $componentsJsUrl = $isDevelopment
     ? './assets/components-js/index.js'
-    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.0.0/+esm';
+    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.1.0/+esm';
 
 $componentsJsImportMap = <<<SCRIPT
 <script type="importmap">


### PR DESCRIPTION
[2.1.0](https://github.com/Liturgical-Calendar/liturgy-components-js/releases/tag/v2.1.0) fixes **two path builder bugs that were manifesting on this site** — both of which turned out to live in the library, not here.

- The API explorer's calendar select **rendered blank on load**, then showed a hardcoded, unlocalized `GENERAL ROMAN` that stayed put after switching to the Ambrosian rite.
- Selecting a rite with no national tier while `/calendar/nation/` was active **hid the select for good**: `ApiOptions` forced the route back to `/calendar`, moving the filter off `NATIONAL_CALENDARS`, and nothing could unhide it from there.

2.1.0 also adds `ApiOptions.linkToRiteSelect()` and deprecates passing the rite select as the second argument of `linkToCalendarSelect()` — which both `index.js` and `liturgyOfAnyDay.js` were doing, so without this they would each print a deprecation warning on load:

```javascript
apiOptions.linkToCalendarSelect( calendarSelect ).linkToRiteSelect( riteSelect );
```

Order between the two calls doesn't matter; whichever runs second completes the pair.

## Also: rolls the deployed examples forward

`deploy.yaml` pins the examples repo to a commit SHA so staging and production stay reproducible. It was still on `04c7fa4` — main as of 2026-07-07, though authored 2025-11-29, since main hadn't moved in between — **nine commits behind**. Now `cbfc60f`.

Bumped in this PR rather than separately because the two have to agree: `examples.php` here loads components-js 2.1.0, and the examples repo's own import maps didn't until [examples#45](https://github.com/Liturgical-Calendar/examples/pull/45). Deploying one without the other would serve two different library versions across the same page set.

Beyond the two components-js bumps, rolling forward also brings:

- `API_INTERNAL_URL` honoured for server-side requests in the PHP example ([examples#42](https://github.com/Liturgical-Calendar/examples/pull/42)) — a real fix for the deployed copy
- phpcs linting for the PHP example ([examples#43](https://github.com/Liturgical-Calendar/examples/pull/43))
- rite selects in both JS examples, plus repair of the 1.4.0 pin that had left them **dead in the browser** — constructing a `CalendarSelect` threw on the Ambrosian diocese `lugano_ch` ([examples#44](https://github.com/Liturgical-Calendar/examples/pull/44))

**Development mode is unaffected by the pin** — `layout/footer.php` serves the local symlinked `dist/` there, so dev was already running this code. The three CDN pins govern staging and production.

## Verification

Loaded `index.php` and `liturgyOfAnyDay.php` in Chrome against the live API. **This is the first confirmation of these fixes outside jsdom.**

| | Result |
|---|--------|
| `index.php` on load | path `/calendar`, select shows **"Calendario Romano Generale"** — localized, not blank |
| after switching to Ambrosian | shows **"Calendario Ambrosiano"**, builds `/calendar/ambrosian`, temporal inputs greyed |
| from `/calendar/nation/` → Ambrosian | path falls back to `/calendar` and the select **stays visible** (`wrapperHidden: false`) |
| `liturgyOfAnyDay.php` | one set of controls, rite change issues `/calendar/ambrosian/2026`, 5 Ambrosian calendar options |
| both pages | **no deprecation warning** |

`yarn lint` clean, `yarn test:unit` 119 passed, `composer lint` clean (also enforced by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar and rite selection integration for more reliable behavior.

* **Updates**
  * Updated example pages and the production application to use the latest calendar components.
  * Development environments continue using the local component bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
