### PR TITLE
fix: take components v4.2 and add a rite selector to the subscription URL builder

### DIFF
--- a/.claude/commands/coderabbit.md
+++ b/.claude/commands/coderabbit.md
@@ -3,14 +3,14 @@
 1. Run `coderabbit --plain` and allow it to complete its analysis (can run in background).
 
 2. Evaluate the reported issues:
-   - Fix all major and critical issues
-   - Fix minor nits only if they are clearly beneficial
+    - Fix all major and critical issues
+    - Fix minor nits only if they are clearly beneficial
 
 3. After implementing changes, re-run CodeRabbit CLI to verify:
-   - All critical issues are resolved
-   - No new bugs were introduced
+    - All critical issues are resolved
+    - No new bugs were introduced
 
 4. Iteration limit:
-   - Maximum of four iterations
-   - If the fourth run shows no critical issues, skip remaining nits
-   - Provide a summary of completed changes and rationale
+    - Maximum of four iterations
+    - If the fourth run shows no critical issues, skip remaining nits
+    - Provide a summary of completed changes and rationale

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Liturgical-Calendar/examples
-          ref: cbfc60f0ac20a7a16ccca4dd4deda0758f6b1059 # main @ 2026-08-10
+          ref: 1b7604facd70bd6da10f24dfc1c3589d914d1332 # main @ 2026-08-11
           path: examples-src
           persist-credentials: false
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,8 @@
+# 4, to agree with prettier's tabWidth (see .prettierrc) and with the 4-space
+# indentation PSR-12 and the JS sources already use. Left at the default 2, the
+# two tools fight over every nested list `yarn format:md` touches.
+MD007:
+  indent: 4
 MD013:
   line_length: 180
   code_blocks: false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "tabWidth": 4,
+    "singleQuote": true
+}

--- a/.serena/.markdownlint.yml
+++ b/.serena/.markdownlint.yml
@@ -1,6 +1,11 @@
 # Relax markdownlint rules for Serena memory files only.
 # Memories are AI-consumed structured notes — long lines, language-less
 # fence blocks for plain output, and dense tables are intentional.
+#
+# Inherits the repo config rather than replacing it: markdownlint-cli2 applies
+# the nearest config only, so without this the repo's MD007 indent would revert
+# to the default 2 here and fight `yarn format:md`.
+extends: ../.markdownlint.yaml
 MD013: false  # line-length
 MD040: false  # fenced-code-language
 MD060: false  # table-column-style

--- a/.serena/memories/code_style_and_conventions.md
+++ b/.serena/memories/code_style_and_conventions.md
@@ -40,8 +40,8 @@ sprintf(_('There are %d items at %s.'), $count, $url);
 ```javascript
 const response = await fetch(apiUrl, {
     method: 'POST',
-    headers: { 'Accept': 'application/json' },
-    credentials: 'include'           // sends HttpOnly cookies
+    headers: { Accept: 'application/json' },
+    credentials: 'include', // sends HttpOnly cookies
 });
 ```
 
@@ -49,8 +49,8 @@ const response = await fetch(apiUrl, {
 
 ```javascript
 const response = await fetch(MetadataUrl, {
-    headers: { 'Accept': 'application/json' },
-    credentials: 'omit'              // REQUIRED — API returns wildcard CORS
+    headers: { Accept: 'application/json' },
+    credentials: 'omit', // REQUIRED — API returns wildcard CORS
 });
 ```
 
@@ -79,11 +79,11 @@ Why: public endpoints return `Access-Control-Allow-Origin: *` which is incompati
 
 When `ApiClient` listens to `ApiOptions`, `Accept-Language` is set automatically from `_localeInput`.
 
-| Mode                                | Vatican meaning            |
-|-------------------------------------|----------------------------|
-| CalendarSelect standalone           | General Roman Calendar (user's locale, NOT forced Latin) |
-| With PathBuilder, `/calendar`       | General Roman Calendar      |
-| With PathBuilder, `/calendar/nation/VA` | Vatican (Latin)         |
+| Mode                                    | Vatican meaning                                          |
+| --------------------------------------- | -------------------------------------------------------- |
+| CalendarSelect standalone               | General Roman Calendar (user's locale, NOT forced Latin) |
+| With PathBuilder, `/calendar`           | General Roman Calendar                                   |
+| With PathBuilder, `/calendar/nation/VA` | Vatican (Latin)                                          |
 
 ## Naming
 

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -16,7 +16,7 @@ PHP-based **website frontend** that presents data from the Liturgical Calendar A
 
 - **PHP >= 8.4** (composer package `liturgical-calendar/frontend`, namespace `LiturgicalCalendar\Frontend\` → `src/`)
 - Bootstrap UI theme, vanilla ES6+ JavaScript (no SPA framework)
-- **liturgy-components-js** (sister project) — frontend components, loaded via npm CDNs (jsDelivr, cdnjs, unpkg, skypack) or local symlink in dev
+- **liturgy-components-js** (sister project) — frontend components, loaded via npm CDNs (jsDelivr, cdnjs, unpkg, skypack) or local symlink in dev; used for all frontend pages; the PHP library (`liturgical-calendar/components`) is a dependency solely for the embedded example in `examples/php/index.php`
 - PHP deps: `liturgical-calendar/components` ^4.2, `vlucas/phpdotenv`, `monolog/monolog`, `symfony/cache`, `guzzlehttp/guzzle`, `firebase/php-jwt`
 - Quality: PHPUnit 11/12, PHPStan **level 7**, PHP_CodeSniffer (PSR-12, modified)
 - E2E tests: **Playwright** + TypeScript

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -17,7 +17,7 @@ PHP-based **website frontend** that presents data from the Liturgical Calendar A
 - **PHP >= 8.4** (composer package `liturgical-calendar/frontend`, namespace `LiturgicalCalendar\Frontend\` → `src/`)
 - Bootstrap UI theme, vanilla ES6+ JavaScript (no SPA framework)
 - **liturgy-components-js** (sister project) — frontend components, loaded via npm CDNs (jsDelivr, cdnjs, unpkg, skypack) or local symlink in dev
-- PHP deps: `liturgical-calendar/components` ^3.3, `vlucas/phpdotenv`, `monolog/monolog`, `symfony/cache`, `guzzlehttp/guzzle`, `firebase/php-jwt`
+- PHP deps: `liturgical-calendar/components` ^4.2, `vlucas/phpdotenv`, `monolog/monolog`, `symfony/cache`, `guzzlehttp/guzzle`, `firebase/php-jwt`
 - Quality: PHPUnit 11/12, PHPStan **level 7**, PHP_CodeSniffer (PSR-12, modified)
 - E2E tests: **Playwright** + TypeScript
 - Node tooling: Yarn 4 (PnP), Node >=22; ESLint, prettier, markdownlint-cli2

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -56,9 +56,9 @@ PSR-4 root for `LiturgicalCalendar\Frontend\` namespace. Includes `Utilities` (w
 ## Auth flow (cookie-only JWT)
 
 - `assets/js/auth.js` — client module
-  - `Auth.checkAuthAsync()` — server-verified, async (preferred for UI gating)
-  - `Auth.isAuthenticated()` — sync, cached (may be stale)
-  - Deprecated: `getToken()`, `setToken()`, `getPayload()`, `setRefreshToken()` (HttpOnly = JS can't see tokens)
+    - `Auth.checkAuthAsync()` — server-verified, async (preferred for UI gating)
+    - `Auth.isAuthenticated()` — sync, cached (may be stale)
+    - Deprecated: `getToken()`, `setToken()`, `getPayload()`, `setRefreshToken()` (HttpOnly = JS can't see tokens)
 - `includes/login-modal.php` — login UI
 - `layout/header.php` — auth status in navbar
 - `data-requires-auth` attribute marks protected UI elements
@@ -67,8 +67,8 @@ PSR-4 root for `LiturgicalCalendar\Frontend\` namespace. Includes `Utilities` (w
 ## Security headers (hybrid PHP + nginx)
 
 - **PHP** (`includes/common.php` ~lines 57–83) sets dynamic headers needing env data:
-  - `Content-Security-Policy` (includes API URL)
-  - `Strict-Transport-Security` (when HTTPS detected)
+    - `Content-Security-Policy` (includes API URL)
+    - `Strict-Transport-Security` (when HTTPS detected)
 - **nginx** should set static headers: `X-Frame-Options DENY`, `X-Content-Type-Options nosniff`, `X-XSS-Protection 1; mode=block`, `Referrer-Policy strict-origin-when-cross-origin`, `Permissions-Policy geolocation=()…`
 - CSP `connect-src` allows: self, API URL, api.github.com, raw.githubusercontent.com (CLDR data), CDN domains for source maps + dynamic ESM imports
 
@@ -78,10 +78,10 @@ Playwright. `e2e/tsconfig.json` for TypeScript. Reports → `playwright-report/`
 
 ## Schema differences for calendar editors
 
-| Calendar Type | Allowed Actions                                                      |
-|---------------|----------------------------------------------------------------------|
-| National      | `setProperty`, `createNew`, `moveFeast`, `makeDoctor`, `makePatron`  |
-| Wider Region  | `createNew`, `makePatron` only                                       |
-| Diocesan      | `createNew`, `makePatron` only                                       |
+| Calendar Type | Allowed Actions                                                     |
+| ------------- | ------------------------------------------------------------------- |
+| National      | `setProperty`, `createNew`, `moveFeast`, `makeDoctor`, `makePatron` |
+| Wider Region  | `createNew`, `makePatron` only                                      |
+| Diocesan      | `createNew`, `makePatron` only                                      |
 
 WiderRegion names MUST be one of: `Americas`, `Europe`, `Asia`, `Africa`, `Oceania`.

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -4,51 +4,51 @@ Run before declaring done / committing:
 
 1. **The all-in-one pre-commit oneliner** (from CLAUDE.md)
 
-   ```bash
-   composer parallel-lint && composer lint:fix && composer analyse && composer lint:md:fix && yarn typecheck && yarn format:md
-   ```
+    ```bash
+    composer parallel-lint && composer lint:fix && composer analyse && composer lint:md:fix && yarn typecheck && yarn format:md
+    ```
 
-   Or step-by-step:
+    Or step-by-step:
 
 2. **PHP**
 
-   ```bash
-   composer parallel-lint   # syntax check
-   composer lint:fix        # phpcbf (auto-fix style)
-   composer lint            # phpcs verification (won't fail loud — read output)
-   composer analyse         # phpstan level 7
-   composer test            # phpunit (if applicable)
-   ```
+    ```bash
+    composer parallel-lint   # syntax check
+    composer lint:fix        # phpcbf (auto-fix style)
+    composer lint            # phpcs verification (won't fail loud — read output)
+    composer analyse         # phpstan level 7
+    composer test            # phpunit (if applicable)
+    ```
 
 3. **Markdown**
 
-   ```bash
-   composer lint:md
-   composer lint:md:fix
-   yarn format:md           # prettier table alignment
-   ```
+    ```bash
+    composer lint:md
+    composer lint:md:fix
+    yarn format:md           # prettier table alignment
+    ```
 
 4. **JS / TS**
 
-   ```bash
-   yarn lint                # eslint
-   yarn typecheck           # tsc on e2e/
-   ```
+    ```bash
+    yarn lint                # eslint
+    yarn typecheck           # tsc on e2e/
+    ```
 
 5. **E2E (Playwright) — for UI changes**
 
-   ```bash
-   yarn test:ci:chromium    # auto-starts servers
-   ```
+    ```bash
+    yarn test:ci:chromium    # auto-starts servers
+    ```
 
 6. **Manual UI smoke test (rule from system prompt)** — actually start the dev server and exercise the feature in a browser:
 
-   ```bash
-   php -S localhost:3000
-   # browse to http://localhost:3000
-   ```
+    ```bash
+    php -S localhost:3000
+    # browse to http://localhost:3000
+    ```
 
-   Type-check / unit tests verify code, NOT feature behavior.
+    Type-check / unit tests verify code, NOT feature behavior.
 
 ## Pre-commit (CaptainHook) — DO NOT BYPASS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,8 @@ API requests use `credentials: 'include'` - the API reads tokens from HttpOnly c
 ```javascript
 const response = await fetch(apiUrl, {
     method: 'POST',
-    headers: { 'Accept': 'application/json' },
-    credentials: 'include'  // Sends HttpOnly cookies automatically
+    headers: { Accept: 'application/json' },
+    credentials: 'include', // Sends HttpOnly cookies automatically
 });
 ```
 
@@ -170,8 +170,8 @@ const response = await fetch(apiUrl, {
 
 ```javascript
 const response = await fetch(MetadataUrl, {
-    headers: { 'Accept': 'application/json' },
-    credentials: 'omit'  // Required: API returns Access-Control-Allow-Origin: *
+    headers: { Accept: 'application/json' },
+    credentials: 'omit', // Required: API returns Access-Control-Allow-Origin: *
 });
 ```
 
@@ -227,11 +227,11 @@ TEST_PASSWORD=your_test_password
 
 ### Calendar Schema Differences
 
-| Calendar Type | Allowed Actions                                                      |
-|---------------|----------------------------------------------------------------------|
-| National      | `setProperty`, `createNew`, `moveFeast`, `makeDoctor`, `makePatron`  |
-| Wider Region  | `createNew`, `makePatron` only                                       |
-| Diocesan      | `createNew`, `makePatron` only                                       |
+| Calendar Type | Allowed Actions                                                     |
+| ------------- | ------------------------------------------------------------------- |
+| National      | `setProperty`, `createNew`, `moveFeast`, `makeDoctor`, `makePatron` |
+| Wider Region  | `createNew`, `makePatron` only                                      |
+| Diocesan      | `createNew`, `makePatron` only                                      |
 
 WiderRegion names must be: `Americas`, `Europe`, `Asia`, `Africa`, or `Oceania`.
 
@@ -286,18 +286,18 @@ Notes:
 - `litcal-api` healthcheck (`GET /calendars`) doesn't depend on Zitadel, so it
   reports healthy even when its PAT is invalid. Verify Zitadel auth explicitly:
 
-  ```bash
-  docker compose exec litcal-api bash -c '
-    curl -sS -X POST http://zitadel:8080/management/v1/users/_search \
-      -H "Authorization: Bearer $ZITADEL_MACHINE_TOKEN" \
-      -H "Host: localhost" \
-      -H "Content-Type: application/json" \
-      -d "{\"limit\":1}" | head -c 200
-  '
-  ```
+    ```bash
+    docker compose exec litcal-api bash -c '
+      curl -sS -X POST http://zitadel:8080/management/v1/users/_search \
+        -H "Authorization: Bearer $ZITADEL_MACHINE_TOKEN" \
+        -H "Host: localhost" \
+        -H "Content-Type: application/json" \
+        -d "{\"limit\":1}" | head -c 200
+    '
+    ```
 
-  A 401 / `Errors.Token.Invalid` means the PAT is stale and you need
-  `--force-secrets`.
+    A 401 / `Errors.Token.Invalid` means the PAT is stale and you need
+    `--force-secrets`.
 
 ### After re-running `setup-zitadel.sh`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,29 @@ When `ApiClient` listens to `ApiOptions`, the `Accept-Language` header is set au
 - **CalendarSelect standalone**: Vatican = General Roman Calendar (user's locale, not forced Latin)
 - **With PathBuilder**: `/calendar` = General Roman, `/calendar/nation/VA` = Vatican (Latin)
 
+### Rite awareness
+
+The API routes a rite as a bare path segment between `calendar` and any nation or diocese pair —
+`/calendar/ambrosian/diocese/lugano_ch`. There is no `/calendar/rite/{rite}` spelling and no query
+parameter.
+
+`usage.php` emits the segment for **every** rite, `roman` included, so users transition onto
+rite-explicit URLs. The implicit spelling keeps resolving, so subscription URLs already pasted into
+calendar apps are unaffected.
+
+The Ambrosian rite has no national tier and its own set of diocesan calendars (`milano_it`, `bergam_it`,
+`novara_it`, `lugano_ch`), so a `CalendarSelect` must be linked to a `RiteSelect` — via
+`calendarSelect.linkToRiteSelect(riteSelect)`, or `ApiOptions.linkToCalendarSelect().linkToRiteSelect()`
+when an `ApiOptions` form is already present — to repartition its list when the rite changes.
+
+### PHP vs JS components
+
+Frontend pages use **liturgy-components-js**. The PHP library (`liturgical-calendar/components`) is a
+dependency solely for the embedded PHP example: `examples/php/index.php` detects that it is being included
+rather than requested directly, skips its own autoloader and its own `ApiClient` singleton, and resolves
+both from the host. `includes/common.php` therefore keeps its `ApiClient::getInstance()` bootstrap, gated
+to `examples.php`. Do not remove the composer dependency — the example crashes without it.
+
 ## E2E Tests (Playwright)
 
 Test files in `e2e/` verify form submissions match API contracts.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **Code quality**
 
-| MAIN                                         | DEVELOPMENT                                |
-|:--------------------------------------------:|:------------------------------------------:|
+|                     MAIN                     |                DEVELOPMENT                 |
+| :------------------------------------------: | :----------------------------------------: |
 | [![CodeFactor][cf-main-badge]][cf-main-link] | [![CodeFactor][cf-dev-badge]][cf-dev-link] |
 
 This is the frontend website for the Liturgical Calendar API, using bootstrap theming.
@@ -55,8 +55,8 @@ Then navigate to `localhost:3000` in your browser, and you should see a running 
 This application uses a **hybrid approach** for security headers:
 
 - **PHP** sets dynamic headers that require environment variables (see `includes/common.php:57-83`)
-  - `Content-Security-Policy` (includes dynamic API URL from `.env`)
-  - `Strict-Transport-Security` (requires HTTPS detection)
+    - `Content-Security-Policy` (includes dynamic API URL from `.env`)
+    - `Strict-Transport-Security` (requires HTTPS detection)
 
 - **nginx** should set static security headers for better performance
 
@@ -139,11 +139,11 @@ The application uses **HttpOnly cookie-based JWT authentication** for secure tok
 
 **Security Features:**
 
-| Flag       | Purpose                                              |
-|------------|------------------------------------------------------|
-| `HttpOnly` | Prevents JavaScript access (XSS protection)          |
-| `SameSite` | Prevents cross-site request forgery (CSRF protection)|
-| `Secure`   | Cookie only sent over HTTPS (when HTTPS detected)    |
+| Flag       | Purpose                                               |
+| ---------- | ----------------------------------------------------- |
+| `HttpOnly` | Prevents JavaScript access (XSS protection)           |
+| `SameSite` | Prevents cross-site request forgery (CSRF protection) |
+| `Secure`   | Cookie only sent over HTTPS (when HTTPS detected)     |
 
 **Client-Side Authentication API (`assets/js/auth.js`):**
 
@@ -162,7 +162,7 @@ if (Auth.isAuthenticated()) {
 // Make authenticated requests (cookies sent automatically)
 const response = await fetch('/api/endpoint', {
     method: 'POST',
-    credentials: 'include'  // Required for HttpOnly cookies
+    credentials: 'include', // Required for HttpOnly cookies
 });
 ```
 

--- a/assets/js/__tests__/subscriptionUrl.test.js
+++ b/assets/js/__tests__/subscriptionUrl.test.js
@@ -65,10 +65,6 @@ describe('CurrentEndpoint.serialize', () => {
 describe('CurrentEndpoint rite segment', () => {
     beforeEach(reset);
 
-    it('defaults to the roman rite', () => {
-        expect(CurrentEndpoint.rite).toBe('roman');
-    });
-
     it('emits the roman segment explicitly', () => {
         expect(CurrentEndpoint.serialize()).toBe(
             'https://example.test/calendar/roman?return_type=ICS&year_type=CIVIL',

--- a/assets/js/__tests__/subscriptionUrl.test.js
+++ b/assets/js/__tests__/subscriptionUrl.test.js
@@ -7,6 +7,7 @@ import {
 
 const reset = () => {
     CurrentEndpoint.apiBase = 'https://example.test/calendar';
+    CurrentEndpoint.rite = 'roman';
     CurrentEndpoint.calendarType = null;
     CurrentEndpoint.calendarId = null;
     CurrentEndpoint.calendarYear = null;
@@ -24,7 +25,7 @@ describe('CurrentEndpoint.serialize', () => {
 
     it('emits the bare base with its query parameters when nothing is selected', () => {
         expect(CurrentEndpoint.serialize()).toBe(
-            'https://example.test/calendar?return_type=ICS&year_type=CIVIL',
+            'https://example.test/calendar/roman?return_type=ICS&year_type=CIVIL',
         );
     });
 
@@ -32,7 +33,7 @@ describe('CurrentEndpoint.serialize', () => {
         CurrentEndpoint.calendarType = CalendarType.NATIONAL;
         CurrentEndpoint.calendarId = 'IT';
         expect(CurrentEndpoint.serialize()).toBe(
-            'https://example.test/calendar/nation/IT?return_type=ICS&year_type=CIVIL',
+            'https://example.test/calendar/roman/nation/IT?return_type=ICS&year_type=CIVIL',
         );
     });
 
@@ -40,7 +41,7 @@ describe('CurrentEndpoint.serialize', () => {
         CurrentEndpoint.calendarType = CalendarType.DIOCESAN;
         CurrentEndpoint.calendarId = 'romamo_it';
         expect(CurrentEndpoint.serialize()).toBe(
-            'https://example.test/calendar/diocese/romamo_it?return_type=ICS&year_type=CIVIL',
+            'https://example.test/calendar/roman/diocese/romamo_it?return_type=ICS&year_type=CIVIL',
         );
     });
 
@@ -48,7 +49,7 @@ describe('CurrentEndpoint.serialize', () => {
         CurrentEndpoint.calendarType = CalendarType.NATIONAL;
         CurrentEndpoint.calendarId = null;
         expect(CurrentEndpoint.serialize()).toBe(
-            'https://example.test/calendar?return_type=ICS&year_type=CIVIL',
+            'https://example.test/calendar/roman?return_type=ICS&year_type=CIVIL',
         );
     });
 
@@ -56,7 +57,54 @@ describe('CurrentEndpoint.serialize', () => {
         RequestPayload.locale = '';
         RequestPayload.epiphany = 'JAN6';
         expect(CurrentEndpoint.serialize()).toBe(
-            'https://example.test/calendar?epiphany=JAN6&return_type=ICS&year_type=CIVIL',
+            'https://example.test/calendar/roman?epiphany=JAN6&return_type=ICS&year_type=CIVIL',
+        );
+    });
+});
+
+describe('CurrentEndpoint rite segment', () => {
+    beforeEach(reset);
+
+    it('defaults to the roman rite', () => {
+        expect(CurrentEndpoint.rite).toBe('roman');
+    });
+
+    it('emits the roman segment explicitly', () => {
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/roman?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits the rite before a national calendar', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = 'IT';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/roman/nation/IT?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits the ambrosian rite before a diocesan calendar', () => {
+        CurrentEndpoint.rite = 'ambrosian';
+        CurrentEndpoint.calendarType = CalendarType.DIOCESAN;
+        CurrentEndpoint.calendarId = 'lugano_ch';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/ambrosian/diocese/lugano_ch?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits the rite alone for the ambrosian rite-level calendar', () => {
+        CurrentEndpoint.rite = 'ambrosian';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/ambrosian?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('keeps the year after the calendar segment', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = 'IT';
+        CurrentEndpoint.calendarYear = 2026;
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/roman/nation/IT/2026?return_type=ICS&year_type=CIVIL',
         );
     });
 });

--- a/assets/js/__tests__/subscriptionUrl.test.js
+++ b/assets/js/__tests__/subscriptionUrl.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    CalendarType,
+    RequestPayload,
+    CurrentEndpoint,
+} from '../subscriptionUrl.js';
+
+const reset = () => {
+    CurrentEndpoint.apiBase = 'https://example.test/calendar';
+    CurrentEndpoint.calendarType = null;
+    CurrentEndpoint.calendarId = null;
+    CurrentEndpoint.calendarYear = null;
+    RequestPayload.epiphany = null;
+    RequestPayload.ascension = null;
+    RequestPayload.corpus_christi = null;
+    RequestPayload.eternal_high_priest = null;
+    RequestPayload.locale = null;
+    RequestPayload.return_type = 'ICS';
+    RequestPayload.year_type = 'CIVIL';
+};
+
+describe('CurrentEndpoint.serialize', () => {
+    beforeEach(reset);
+
+    it('emits the bare base with its query parameters when nothing is selected', () => {
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits a national calendar path', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = 'IT';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/nation/IT?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits a diocesan calendar path', () => {
+        CurrentEndpoint.calendarType = CalendarType.DIOCESAN;
+        CurrentEndpoint.calendarId = 'romamo_it';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/diocese/romamo_it?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('omits the calendar segment when the id is null', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = null;
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('skips null and empty payload fields', () => {
+        RequestPayload.locale = '';
+        RequestPayload.epiphany = 'JAN6';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar?epiphany=JAN6&return_type=ICS&year_type=CIVIL',
+        );
+    });
+});

--- a/assets/js/subscriptionUrl.js
+++ b/assets/js/subscriptionUrl.js
@@ -1,0 +1,67 @@
+/**
+ * The subscription URL model for usage.php's calendar-subscription card.
+ *
+ * Deliberately free of imports, DOM access and globals: `usage.js` injects
+ * `CurrentEndpoint.apiBase` at startup, and the rite arrives as a plain string.
+ * `@liturgical-calendar/components-js` resolves only through the browser
+ * importmap, so importing it here would break the Vitest suite.
+ */
+
+/**
+ * Enum CalendarType
+ * Used in building the endpoint URL for requests to the API /calendar endpoint
+ */
+const CalendarType = Object.freeze({
+    NATIONAL: 'nation',
+    DIOCESAN: 'diocese',
+});
+
+/**
+ * Represents the query parameters for the API /calendar endpoint request
+ */
+class RequestPayload {
+    static epiphany = null;
+    static ascension = null;
+    static corpus_christi = null;
+    static eternal_high_priest = null;
+    static locale = null;
+    static return_type = 'ICS';
+    static year_type = 'CIVIL';
+}
+
+/**
+ * Class CurrentEndpoint
+ * Builds the full endpoint URL used as the calendar subscription URL.
+ */
+class CurrentEndpoint {
+    /** @type {string} Set by usage.js from the CalendarUrl global; already ends in `/calendar`. */
+    static apiBase = '';
+    static calendarType = null;
+    static calendarId = null;
+    static calendarYear = null;
+
+    static serialize = () => {
+        let currentEndpoint = CurrentEndpoint.apiBase;
+        if (
+            CurrentEndpoint.calendarType !== null &&
+            CurrentEndpoint.calendarId !== null
+        ) {
+            currentEndpoint += `/${CurrentEndpoint.calendarType}/${CurrentEndpoint.calendarId}`;
+        }
+        if (CurrentEndpoint.calendarYear !== null) {
+            currentEndpoint += `/${CurrentEndpoint.calendarYear}`;
+        }
+        const parameters = [];
+        for (const key in RequestPayload) {
+            if (RequestPayload[key] !== null && RequestPayload[key] !== '') {
+                parameters.push(
+                    key + '=' + encodeURIComponent(RequestPayload[key]),
+                );
+            }
+        }
+        const urlParams = parameters.length ? `?${parameters.join('&')}` : '';
+        return `${currentEndpoint}${urlParams}`;
+    };
+}
+
+export { CalendarType, RequestPayload, CurrentEndpoint };

--- a/assets/js/subscriptionUrl.js
+++ b/assets/js/subscriptionUrl.js
@@ -36,12 +36,29 @@ class RequestPayload {
 class CurrentEndpoint {
     /** @type {string} Set by usage.js from the CalendarUrl global; already ends in `/calendar`. */
     static apiBase = '';
+
+    /**
+     * The liturgical rite, as a plain string (`'roman'` / `'ambrosian'`) rather
+     * than the components-js `Rite` enum, which this module cannot import.
+     *
+     * Emitted unconditionally, `roman` included. The API's
+     * `Router::extractRiteSegment()` accepts the explicit spelling and treats
+     * `/calendar/roman/nation/IT` and `/calendar/nation/IT` as the same request,
+     * so rite-explicit URLs are the default from here on and users transition
+     * onto them. URLs already pasted into calendar apps keep resolving.
+     *
+     * @type {string}
+     */
+    static rite = 'roman';
     static calendarType = null;
     static calendarId = null;
     static calendarYear = null;
 
     static serialize = () => {
         let currentEndpoint = CurrentEndpoint.apiBase;
+        // Before the calendar segment, never after: apiBase already ends in
+        // `/calendar`, and `/calendar/nation/IT/roman` is not a route.
+        currentEndpoint += `/${CurrentEndpoint.rite}`;
         if (
             CurrentEndpoint.calendarType !== null &&
             CurrentEndpoint.calendarId !== null

--- a/assets/js/usage.js
+++ b/assets/js/usage.js
@@ -2,6 +2,12 @@ import {
     CalendarType,
     CurrentEndpoint,
 } from './subscriptionUrl.js';
+import {
+    ApiClient,
+    CalendarSelect,
+    RiteSelect,
+    Rite,
+} from '@liturgical-calendar/components-js';
 
 /**
  * Updates the text of the element with the id 'calSubscriptionUrl' to reflect the current value of CurrentEndpoint.
@@ -165,6 +171,52 @@ const handleCardHeaderClick = (ev) => {
     }
 };
 
+/**
+ * Builds the rite and calendar selects and wires them to the subscription URL.
+ *
+ * The two selects are linked so that changing the rite repartitions the calendar
+ * list: the Ambrosian rite has no national tier and a different set of diocesan
+ * calendars, so a selection under one rite is never carried into the other.
+ */
+const buildCalendarControls = async () => {
+    await ApiClient.init(BaseUrl);
+
+    CurrentEndpoint.rite = Rite.ROMAN;
+
+    const lang = currentLocale.language;
+
+    // Must be in the DOM before linkToRiteSelect() below, which reads its
+    // element to attach the rite-change listener.
+    const riteSelect = new RiteSelect(lang)
+        .class('form-select')
+        .id('riteSelect')
+        .label({ text: Messages['Select rite'], class: 'form-label' });
+    riteSelect.appendTo('#riteSelectContainer');
+
+    const calendarSelect = new CalendarSelect(lang)
+        .class('form-select')
+        .id('calendarSelect')
+        .label({ text: Messages['Select calendar'], class: 'form-label' })
+        .allowNull(true);
+    calendarSelect.appendTo('#calendarSelectContainer');
+
+    calendarSelect.linkToRiteSelect(riteSelect);
+
+    // Default to the rite-level calendar rather than the first nation, so the
+    // card opens on the General Roman Calendar.
+    calendarSelect._domElement.value = '';
+
+    document.getElementById('riteSelect').addEventListener('change', (ev) => {
+        CurrentEndpoint.rite = ev.target.value;
+        updateSubscriptionURL();
+    });
+    document
+        .getElementById('calendarSelect')
+        .addEventListener('change', updateSubscriptionURL);
+
+    updateSubscriptionURL();
+};
+
 // Initialize on DOMContentLoaded
 document.addEventListener('DOMContentLoaded', () => {
     CurrentEndpoint.apiBase = CalendarUrl;
@@ -196,11 +248,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    // Event: Calendar select change
-    const calendarSelect = document.getElementById('calendarSelect');
-    if (calendarSelect) {
-        calendarSelect.addEventListener('change', updateSubscriptionURL);
-    }
+    // The selects are built asynchronously, so their change listeners are
+    // attached inside buildCalendarControls() once the elements exist.
+    buildCalendarControls().catch((error) => {
+        console.error(
+            `Could not build the calendar subscription controls: ${error.message}`,
+        );
+    });
 });
 
 // Handle hash changes

--- a/assets/js/usage.js
+++ b/assets/js/usage.js
@@ -1,62 +1,7 @@
-/**
- * Enum CalendarType
- * Used in building the endpoint URL for requests to the API /calendar endpoint
- */
-const CalendarType = Object.freeze({
-    NATIONAL: 'nation',
-    DIOCESAN: 'diocese'
-});
-
-/**
- * Represents the parameters for the API /calendar endpoint request
- * Currently only used to serialize the calendar subscription URL?
- */
-class RequestPayload {
-    static epiphany             = null;
-    static ascension            = null;
-    static corpus_christi       = null;
-    static eternal_high_priest  = null;
-    static locale               = null;
-    static return_type          = 'ICS';
-    static year_type            = 'CIVIL';
-}
-
-/**
- * Class CurrentEndpoint
- * Used to build the full endpoint URL for the API /calendar endpoint (currently only used to serialize the calendar subscription URL?)
- * @param {string} calendarType The type of calendar (national, diocesan)
- * @param {string} calendarId The ID of the calendar
- * @param {string} calendarYear The year of the calendar
- */
-class CurrentEndpoint {
-    /**
-     * The base URL of the API /calendar endpoint
-     * @returns {string} The base URL of the API /calendar endpoint
-     */
-    static get apiBase() {
-        return `${CalendarUrl}`;
-    }
-    static calendarType   = null;
-    static calendarId     = null;
-    static calendarYear   = null;
-    static serialize = () => {
-        let currentEndpoint = CurrentEndpoint.apiBase;
-        if (CurrentEndpoint.calendarType !== null && CurrentEndpoint.calendarId !== null) {
-            currentEndpoint += `/${CurrentEndpoint.calendarType}/${CurrentEndpoint.calendarId}`;
-        }
-        if (CurrentEndpoint.calendarYear !== null) {
-            currentEndpoint += `/${CurrentEndpoint.calendarYear}`;
-        }
-        const parameters = [];
-        for (const key in RequestPayload) {
-            if (RequestPayload[key] !== null && RequestPayload[key] !== '') {
-                parameters.push(key + '=' + encodeURIComponent(RequestPayload[key]));
-            }
-        }
-        const urlParams = parameters.length ? `?${parameters.join('&')}` : '';
-        return `${currentEndpoint}${urlParams}`;
-    };
-}
+import {
+    CalendarType,
+    CurrentEndpoint,
+} from './subscriptionUrl.js';
 
 /**
  * Updates the text of the element with the id 'calSubscriptionUrl' to reflect the current value of CurrentEndpoint.
@@ -222,6 +167,7 @@ const handleCardHeaderClick = (ev) => {
 
 // Initialize on DOMContentLoaded
 document.addEventListener('DOMContentLoaded', () => {
+    CurrentEndpoint.apiBase = CalendarUrl;
     handleHashChange();
     updateSubscriptionURL();
 

--- a/assets/js/usage.js
+++ b/assets/js/usage.js
@@ -70,10 +70,10 @@ const updateSubscriptionURL = () => {
     CurrentEndpoint.calendarId = calendarSelect.value;
     const selectedOption = calendarSelect.options[calendarSelect.selectedIndex];
     switch (selectedOption?.dataset.calendartype) {
-        case 'nationalcalendar':
+        case 'national':
             CurrentEndpoint.calendarType = CalendarType.NATIONAL;
             break;
-        case 'diocesancalendar':
+        case 'diocesan':
             CurrentEndpoint.calendarType = CalendarType.DIOCESAN;
             break;
         default:

--- a/assets/js/usage.js
+++ b/assets/js/usage.js
@@ -254,6 +254,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error(
             `Could not build the calendar subscription controls: ${error.message}`,
         );
+        toastr.error(Messages['Failed to load calendars'], Messages['Error']);
     });
 });
 

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,8 @@
         ],
         "lint": "phpcs || ( echo 'Linting failed. Please run composer lint:fix to fix the linting issues.' && exit 1 )",
         "lint:fix": "bash scripts/lint-fix.sh",
-        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\"",
-        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" --fix",
+        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#test-results\"",
+        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#test-results\" --fix",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit tests"

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,8 @@
         ],
         "lint": "phpcs || ( echo 'Linting failed. Please run composer lint:fix to fix the linting issues.' && exit 1 )",
         "lint:fix": "bash scripts/lint-fix.sh",
-        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#test-results\"",
-        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#test-results\" --fix",
+        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\"",
+        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" --fix",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit tests"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=8.4",
-        "liturgical-calendar/components": "^3.3",
+        "liturgical-calendar/components": "^4.2",
         "vlucas/phpdotenv": "^5.6",
         "monolog/monolog": "^3.0",
         "symfony/cache": "^6.0|^7.0|^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9096c5c1d86ac1a64bb6dc2beda26d93",
+    "content-hash": "a16edaee7e6729f1afa368fec0d729f3",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -464,23 +464,23 @@
         },
         {
             "name": "liturgical-calendar/components",
-            "version": "v3.3.1",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Liturgical-Calendar/liturgy-components-php.git",
-                "reference": "60fe997dea2e89868b6cba8b7f2bcf0cbdd5c3e1"
+                "reference": "b4e5602efe5a9654fcb323c9047b891de29f25fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Liturgical-Calendar/liturgy-components-php/zipball/60fe997dea2e89868b6cba8b7f2bcf0cbdd5c3e1",
-                "reference": "60fe997dea2e89868b6cba8b7f2bcf0cbdd5c3e1",
+                "url": "https://api.github.com/repos/Liturgical-Calendar/liturgy-components-php/zipball/b4e5602efe5a9654fcb323c9047b891de29f25fd",
+                "reference": "b4e5602efe5a9654fcb323c9047b891de29f25fd",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
                 "ext-json": "*",
                 "nyholm/psr7": "^1.0",
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "psr/cache": "^3.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
@@ -525,9 +525,9 @@
             "description": "Reusable frontend components for the Liturgical Calendar API",
             "support": {
                 "issues": "https://github.com/Liturgical-Calendar/liturgy-components-php/issues",
-                "source": "https://github.com/Liturgical-Calendar/liturgy-components-php/tree/v3.3.1"
+                "source": "https://github.com/Liturgical-Calendar/liturgy-components-php/tree/v4.2.0"
             },
-            "time": "2025-12-10T08:23:56+00:00"
+            "time": "2026-08-10T23:28:41+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4300,5 +4300,5 @@
         "php": ">=8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/AUTHENTICATION_ROADMAP.md
+++ b/docs/AUTHENTICATION_ROADMAP.md
@@ -32,29 +32,29 @@ The frontend can now proceed with implementing JWT client support as outlined in
 The frontend currently performs the following write operations that will require authentication once the API implements JWT protection:
 
 1. **Calendar Deletion** (`assets/js/extending.js:1740`)
-   - `DELETE` requests to remove wider region, national, or diocesan calendar definitions
-   - Function: `deleteCalendarConfirmClicked()`
+    - `DELETE` requests to remove wider region, national, or diocesan calendar definitions
+    - Function: `deleteCalendarConfirmClicked()`
 
 2. **Calendar Creation** (`assets/js/extending.js:2090`)
-   - `POST` requests to create new calendar definitions
-   - Function: `formSubmit()` with `formAction === 'CREATE_CALENDAR'`
+    - `POST` requests to create new calendar definitions
+    - Function: `formSubmit()` with `formAction === 'CREATE_CALENDAR'`
 
 3. **Calendar Updates** (`assets/js/extending.js:2929`)
-   - `PATCH`/`PUT` requests to modify existing calendar definitions
-   - Function: `formSubmit()` with `formAction === 'UPDATE_CALENDAR'`
+    - `PATCH`/`PUT` requests to modify existing calendar definitions
+    - Function: `formSubmit()` with `formAction === 'UPDATE_CALENDAR'`
 
 ### Current Request Pattern
 
 ```javascript
 const headers = new Headers({
-    'Accept': 'application/json',
-    'Accept-Language': API.locale
+    Accept: 'application/json',
+    'Accept-Language': API.locale,
 });
 
 const request = new Request(API.path, {
     method: 'DELETE', // or 'POST', 'PATCH'
     headers: headers,
-    body: formData
+    body: formData,
 });
 ```
 
@@ -99,35 +99,70 @@ const request = new Request(API.path, {
 ```html
 <!-- templates/partials/login-modal.php -->
 <div class="modal fade" id="loginModal" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Administrator Login</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-        <form id="loginForm">
-          <div class="mb-3">
-            <label for="username" class="form-label">Username</label>
-            <input type="text" class="form-control" id="username" required>
-          </div>
-          <div class="mb-3">
-            <label for="password" class="form-label">Password</label>
-            <input type="password" class="form-control" id="password" required>
-          </div>
-          <div class="mb-3 form-check">
-            <input type="checkbox" class="form-check-input" id="rememberMe">
-            <label class="form-check-label" for="rememberMe">Remember me</label>
-          </div>
-          <div class="alert alert-danger d-none" id="loginError"></div>
-        </form>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" id="loginSubmit">Login</button>
-      </div>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Administrator Login</h5>
+                <button
+                    type="button"
+                    class="btn-close"
+                    data-bs-dismiss="modal"
+                ></button>
+            </div>
+            <div class="modal-body">
+                <form id="loginForm">
+                    <div class="mb-3">
+                        <label for="username" class="form-label"
+                            >Username</label
+                        >
+                        <input
+                            type="text"
+                            class="form-control"
+                            id="username"
+                            required
+                        />
+                    </div>
+                    <div class="mb-3">
+                        <label for="password" class="form-label"
+                            >Password</label
+                        >
+                        <input
+                            type="password"
+                            class="form-control"
+                            id="password"
+                            required
+                        />
+                    </div>
+                    <div class="mb-3 form-check">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="rememberMe"
+                        />
+                        <label class="form-check-label" for="rememberMe"
+                            >Remember me</label
+                        >
+                    </div>
+                    <div
+                        class="alert alert-danger d-none"
+                        id="loginError"
+                    ></div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button
+                    type="button"
+                    class="btn btn-secondary"
+                    data-bs-dismiss="modal"
+                >
+                    Cancel
+                </button>
+                <button type="button" class="btn btn-primary" id="loginSubmit">
+                    Login
+                </button>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 ```
 
@@ -154,14 +189,17 @@ const Auth = {
      */
     async login(username, password, rememberMe = false) {
         try {
-            const response = await fetch(`${API.protocol}://${API.host}:${API.port}/auth/login`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json'
+            const response = await fetch(
+                `${API.protocol}://${API.host}:${API.port}/auth/login`,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json',
+                    },
+                    body: JSON.stringify({ username, password }),
                 },
-                body: JSON.stringify({ username, password })
-            });
+            );
 
             if (!response.ok) {
                 const error = await response.json();
@@ -194,8 +232,10 @@ const Auth = {
      * Get stored JWT token
      */
     getToken() {
-        return localStorage.getItem(this.TOKEN_KEY) ||
-               sessionStorage.getItem(this.TOKEN_KEY);
+        return (
+            localStorage.getItem(this.TOKEN_KEY) ||
+            sessionStorage.getItem(this.TOKEN_KEY)
+        );
     },
 
     /**
@@ -210,8 +250,10 @@ const Auth = {
      * Get refresh token
      */
     getRefreshToken() {
-        return localStorage.getItem(this.REFRESH_KEY) ||
-               sessionStorage.getItem(this.REFRESH_KEY);
+        return (
+            localStorage.getItem(this.REFRESH_KEY) ||
+            sessionStorage.getItem(this.REFRESH_KEY)
+        );
     },
 
     /**
@@ -251,14 +293,17 @@ const Auth = {
         }
 
         try {
-            const response = await fetch(`${API.protocol}://${API.host}:${API.port}/auth/refresh`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json'
+            const response = await fetch(
+                `${API.protocol}://${API.host}:${API.port}/auth/refresh`,
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json',
+                    },
+                    body: JSON.stringify({ refresh_token: refreshToken }),
                 },
-                body: JSON.stringify({ refresh_token: refreshToken })
-            });
+            );
 
             if (!response.ok) {
                 throw new Error('Token refresh failed');
@@ -281,13 +326,16 @@ const Auth = {
 
         if (token) {
             try {
-                await fetch(`${API.protocol}://${API.host}:${API.port}/auth/logout`, {
-                    method: 'POST',
-                    headers: {
-                        'Authorization': `Bearer ${token}`,
-                        'Accept': 'application/json'
-                    }
-                });
+                await fetch(
+                    `${API.protocol}://${API.host}:${API.port}/auth/logout`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                            Accept: 'application/json',
+                        },
+                    },
+                );
             } catch (error) {
                 console.error('Logout error:', error);
             }
@@ -295,7 +343,7 @@ const Auth = {
 
         this.clearTokens();
         window.location.reload(); // Refresh to reset UI state
-    }
+    },
 };
 ```
 
@@ -352,8 +400,8 @@ function deleteCalendarConfirmClicked() {
     }
 
     const headers = new Headers({
-        'Accept': 'application/json',
-        'Accept-Language': API.locale
+        Accept: 'application/json',
+        'Accept-Language': API.locale,
     });
 
     // Add JWT token
@@ -366,20 +414,22 @@ function deleteCalendarConfirmClicked() {
     const request = new Request(API.path, {
         method: 'DELETE',
         headers: headers,
-        body: formData
+        body: formData,
     });
 
     fetch(request)
-        .then(response => handleAuthError(response, () => deleteCalendarConfirmClicked()))
-        .then(response => response.json())
-        .then(data => {
+        .then((response) =>
+            handleAuthError(response, () => deleteCalendarConfirmClicked()),
+        )
+        .then((response) => response.json())
+        .then((data) => {
             // Handle success
             if (data.status === 'success') {
                 showSuccessMessage('Calendar deleted successfully');
                 // Refresh calendar list
             }
         })
-        .catch(error => {
+        .catch((error) => {
             showErrorMessage(error.message);
         });
 }
@@ -402,8 +452,8 @@ function formSubmit(ev) {
 
     const formData = new FormData(ev.target);
     const headers = new Headers({
-        'Accept': 'application/json',
-        'Accept-Language': API.locale
+        Accept: 'application/json',
+        'Accept-Language': API.locale,
     });
 
     // Add JWT token for write operations
@@ -416,16 +466,16 @@ function formSubmit(ev) {
     const request = new Request(API.path, {
         method: method,
         headers: headers,
-        body: formData
+        body: formData,
     });
 
     fetch(request)
-        .then(response => handleAuthError(response, () => formSubmit(ev)))
-        .then(response => response.json())
-        .then(data => {
+        .then((response) => handleAuthError(response, () => formSubmit(ev)))
+        .then((response) => response.json())
+        .then((data) => {
             // Handle success
         })
-        .catch(error => {
+        .catch((error) => {
             showErrorMessage(error.message);
         });
 }
@@ -434,7 +484,9 @@ function formSubmit(ev) {
  * Show login modal
  */
 function showLoginModal(onSuccess = null) {
-    const loginModal = new bootstrap.Modal(document.getElementById('loginModal'));
+    const loginModal = new bootstrap.Modal(
+        document.getElementById('loginModal'),
+    );
 
     document.getElementById('loginSubmit').onclick = async () => {
         const username = document.getElementById('username').value;
@@ -466,55 +518,69 @@ function showLoginModal(onSuccess = null) {
 ```html
 <!-- templates/partials/navbar.php -->
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
-  <!-- ... existing nav items ... -->
+    <!-- ... existing nav items ... -->
 
-  <div class="navbar-nav ms-auto">
-    <div id="authStatus">
-      <!-- Logged out state -->
-      <button type="button" class="btn btn-sm btn-outline-primary d-none" id="loginBtn">
-        Login
-      </button>
+    <div class="navbar-nav ms-auto">
+        <div id="authStatus">
+            <!-- Logged out state -->
+            <button
+                type="button"
+                class="btn btn-sm btn-outline-primary d-none"
+                id="loginBtn"
+            >
+                Login
+            </button>
 
-      <!-- Logged in state -->
-      <div class="dropdown d-none" id="userMenu">
-        <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
-          <i class="bi bi-person-circle"></i> <span id="username"></span>
-        </button>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li><button class="dropdown-item" id="logoutBtn">Logout</button></li>
-        </ul>
-      </div>
+            <!-- Logged in state -->
+            <div class="dropdown d-none" id="userMenu">
+                <button
+                    class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                    type="button"
+                    data-bs-toggle="dropdown"
+                >
+                    <i class="bi bi-person-circle"></i>
+                    <span id="username"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end">
+                    <li>
+                        <button class="dropdown-item" id="logoutBtn">
+                            Logout
+                        </button>
+                    </li>
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
 </nav>
 
 <script>
-// Update auth UI on page load
-document.addEventListener('DOMContentLoaded', () => {
-    updateAuthUI();
+    // Update auth UI on page load
+    document.addEventListener('DOMContentLoaded', () => {
+        updateAuthUI();
 
-    document.getElementById('loginBtn').onclick = () => showLoginModal();
-    document.getElementById('logoutBtn').onclick = () => Auth.logout();
-});
+        document.getElementById('loginBtn').onclick = () => showLoginModal();
+        document.getElementById('logoutBtn').onclick = () => Auth.logout();
+    });
 
-function updateAuthUI() {
-    const isAuth = Auth.isAuthenticated();
-    const loginBtn = document.getElementById('loginBtn');
-    const userMenu = document.getElementById('userMenu');
+    function updateAuthUI() {
+        const isAuth = Auth.isAuthenticated();
+        const loginBtn = document.getElementById('loginBtn');
+        const userMenu = document.getElementById('userMenu');
 
-    if (isAuth) {
-        loginBtn.classList.add('d-none');
-        userMenu.classList.remove('d-none');
+        if (isAuth) {
+            loginBtn.classList.add('d-none');
+            userMenu.classList.remove('d-none');
 
-        // Decode token to get username (if stored in JWT)
-        const token = Auth.getToken();
-        const payload = JSON.parse(atob(token.split('.')[1]));
-        document.getElementById('username').textContent = payload.sub || 'Admin';
-    } else {
-        loginBtn.classList.remove('d-none');
-        userMenu.classList.add('d-none');
+            // Decode token to get username (if stored in JWT)
+            const token = Auth.getToken();
+            const payload = JSON.parse(atob(token.split('.')[1]));
+            document.getElementById('username').textContent =
+                payload.sub || 'Admin';
+        } else {
+            loginBtn.classList.remove('d-none');
+            userMenu.classList.add('d-none');
+        }
     }
-}
 </script>
 ```
 
@@ -548,7 +614,7 @@ Silent token refresh before expiry implemented:
 /**
  * Auto-refresh tokens before expiry
  */
-Auth.startAutoRefresh = function() {
+Auth.startAutoRefresh = function () {
     const checkInterval = 60000; // Check every minute
 
     setInterval(async () => {
@@ -775,12 +841,12 @@ Access-Control-Allow-Credentials: true
 // All auth-related fetch calls now include credentials
 const response = await fetch(`${BaseUrl}/auth/login`, {
     method: 'POST',
-    credentials: 'include',  // Include cookies in cross-origin requests
+    credentials: 'include', // Include cookies in cross-origin requests
     headers: {
         'Content-Type': 'application/json',
-        'Accept': 'application/json'
+        Accept: 'application/json',
     },
-    body: JSON.stringify({ username, password })
+    body: JSON.stringify({ username, password }),
 });
 ```
 
@@ -805,46 +871,46 @@ localStorage/sessionStorage. This provides maximum security against XSS attacks.
 **Files Modified:**
 
 1. **`assets/js/auth.js`**
-   - Added auth state caching (`_cachedAuthState`, `_cacheExpiry`, `_cacheDuration`)
-   - Added `isAuthenticatedCached()` method for synchronous cache checks
-   - Added `updateAuthCache()` method to fetch and cache auth state
-   - Updated `isAuthenticated()` to use cached auth state instead of localStorage
-   - Updated `login()` to not store tokens locally (relies on HttpOnly cookies)
-   - Updated `_doRefreshToken()` to not require body (API reads from cookie)
-   - Updated `startAutoRefresh()` and `startExpiryWarning()` to use cached auth state
-   - Updated `hasPermission()`, `hasRole()`, `getUsername()` to use cached auth state
-   - Deprecated `setToken()`, `getToken()`, `setRefreshToken()`, `getRefreshToken()`, `getPayload()`
-   - Updated DOMContentLoaded to initialize auth cache on page load
+    - Added auth state caching (`_cachedAuthState`, `_cacheExpiry`, `_cacheDuration`)
+    - Added `isAuthenticatedCached()` method for synchronous cache checks
+    - Added `updateAuthCache()` method to fetch and cache auth state
+    - Updated `isAuthenticated()` to use cached auth state instead of localStorage
+    - Updated `login()` to not store tokens locally (relies on HttpOnly cookies)
+    - Updated `_doRefreshToken()` to not require body (API reads from cookie)
+    - Updated `startAutoRefresh()` and `startExpiryWarning()` to use cached auth state
+    - Updated `hasPermission()`, `hasRole()`, `getUsername()` to use cached auth state
+    - Deprecated `setToken()`, `getToken()`, `setRefreshToken()`, `getRefreshToken()`, `getPayload()`
+    - Updated DOMContentLoaded to initialize auth cache on page load
 
 2. **`assets/js/extending.js`**
-   - Deprecated `addAuthHeader()` function (no longer needed)
-   - Updated `makeAuthenticatedRequest()` to use `credentials: 'include'` instead of Authorization header
+    - Deprecated `addAuthHeader()` function (no longer needed)
+    - Updated `makeAuthenticatedRequest()` to use `credentials: 'include'` instead of Authorization header
 
 3. **`includes/login-modal.php`**
-   - Updated DOMContentLoaded to be async and wait for auth cache population
-   - Uses `Auth.isAuthenticatedCached()` to check if cache needs population
+    - Updated DOMContentLoaded to be async and wait for auth cache population
+    - Uses `Auth.isAuthenticatedCached()` to check if cache needs population
 
 **How It Works:**
 
 1. **Page Load:**
-   - `auth.js` DOMContentLoaded calls `Auth.updateAuthCache()` to fetch `/auth/me`
-   - Cache is populated with auth state (authenticated, username, roles, exp)
-   - Auto-refresh timer is started if authenticated
+    - `auth.js` DOMContentLoaded calls `Auth.updateAuthCache()` to fetch `/auth/me`
+    - Cache is populated with auth state (authenticated, username, roles, exp)
+    - Auto-refresh timer is started if authenticated
 
 2. **Auth State Checks:**
-   - `Auth.isAuthenticated()` returns cached state synchronously
-   - `Auth.isAuthenticatedCached()` returns `null` if cache expired (caller can decide to fetch)
-   - `Auth.updateAuthCache()` fetches fresh state from server
+    - `Auth.isAuthenticated()` returns cached state synchronously
+    - `Auth.isAuthenticatedCached()` returns `null` if cache expired (caller can decide to fetch)
+    - `Auth.updateAuthCache()` fetches fresh state from server
 
 3. **Authenticated Requests:**
-   - All requests use `credentials: 'include'` to send HttpOnly cookies
-   - No Authorization headers needed - API reads token from cookie
-   - `makeAuthenticatedRequest()` helper handles this automatically
+    - All requests use `credentials: 'include'` to send HttpOnly cookies
+    - No Authorization headers needed - API reads token from cookie
+    - `makeAuthenticatedRequest()` helper handles this automatically
 
 4. **Token Refresh:**
-   - API reads refresh token from HttpOnly cookie
-   - New tokens are set as HttpOnly cookies in response
-   - Frontend just calls the endpoint and updates the cache
+    - API reads refresh token from HttpOnly cookie
+    - New tokens are set as HttpOnly cookies in response
+    - Frontend just calls the endpoint and updates the cache
 
 **Security Benefits:**
 
@@ -875,7 +941,7 @@ function initPermissionUI() {
     const protectedElements = document.querySelectorAll('[data-requires-auth]');
     const isAuth = Auth.isAuthenticated();
 
-    protectedElements.forEach(el => {
+    protectedElements.forEach((el) => {
         if (isAuth) {
             el.classList.remove('d-none');
             el.disabled = false;
@@ -929,7 +995,9 @@ function initPermissionUI() {
             <strong>Session Expiring</strong>
         </div>
         <div class="toast-body">
-            <p id="sessionExpiryMessage">Your session will expire in less than 2 minutes.</p>
+            <p id="sessionExpiryMessage">
+                Your session will expire in less than 2 minutes.
+            </p>
             <div class="d-flex justify-content-end gap-2">
                 <button id="sessionExpiryLogout">Logout</button>
                 <button id="sessionExpiryExtend">Extend Session</button>
@@ -953,10 +1021,10 @@ The "Remember Me" checkbox now controls whether the refresh token cookie persist
 
 **Behavior:**
 
-| Remember Me         | Access Token Cookie                  | Refresh Token Cookie                       |
-|---------------------|--------------------------------------|--------------------------------------------|
-| Unchecked (default) | Persistent (short TTL, e.g., 1 hour) | Session cookie (deleted on browser close)  |
-| Checked             | Persistent (short TTL, e.g., 1 hour) | Persistent (long TTL, e.g., 7 days)        |
+| Remember Me         | Access Token Cookie                  | Refresh Token Cookie                      |
+| ------------------- | ------------------------------------ | ----------------------------------------- |
+| Unchecked (default) | Persistent (short TTL, e.g., 1 hour) | Session cookie (deleted on browser close) |
+| Checked             | Persistent (short TTL, e.g., 1 hour) | Persistent (long TTL, e.g., 7 days)       |
 
 **How It Works:**
 
@@ -995,7 +1063,7 @@ When the API implements RBAC (permissions/roles returned in `/auth/me` response)
 /**
  * Check user permissions (uses cached auth state)
  */
-Auth.hasPermission = function(permission) {
+Auth.hasPermission = function (permission) {
     if (!this.isAuthenticated()) return false;
 
     const permissions = this._cachedAuthState?.permissions;
@@ -1005,7 +1073,7 @@ Auth.hasPermission = function(permission) {
 /**
  * Check user role (uses cached auth state)
  */
-Auth.hasRole = function(role) {
+Auth.hasRole = function (role) {
     if (!this.isAuthenticated()) return false;
 
     const { role: userRole, roles } = this._cachedAuthState || {};
@@ -1035,12 +1103,12 @@ async function handleMfaChallenge(challengeToken) {
         credentials: 'include', // Cookie-based auth
         headers: {
             'Content-Type': 'application/json',
-            'Accept': 'application/json'
+            Accept: 'application/json',
         },
         body: JSON.stringify({
             challenge_token: challengeToken,
-            code: code
-        })
+            code: code,
+        }),
     });
 
     if (!response.ok) {
@@ -1061,7 +1129,7 @@ When integrating external identity providers (API sets HttpOnly cookies):
 /**
  * OAuth login flow
  */
-Auth.loginWithOAuth = function(provider) {
+Auth.loginWithOAuth = function (provider) {
     const authUrl = `${BaseUrl}/auth/oauth/${provider}`;
     const redirectUri = window.location.origin + '/auth/callback';
 
@@ -1074,7 +1142,7 @@ Auth.loginWithOAuth = function(provider) {
  * Handle OAuth callback
  * API sets HttpOnly cookies on successful authentication
  */
-Auth.handleOAuthCallback = async function() {
+Auth.handleOAuthCallback = async function () {
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
     const state = params.get('state');
@@ -1088,9 +1156,9 @@ Auth.handleOAuthCallback = async function() {
         credentials: 'include', // Cookie-based auth
         headers: {
             'Content-Type': 'application/json',
-            'Accept': 'application/json'
+            Accept: 'application/json',
         },
-        body: JSON.stringify({ code, state })
+        body: JSON.stringify({ code, state }),
     });
 
     if (!response.ok) {
@@ -1115,11 +1183,11 @@ Auth.handleOAuthCallback = async function() {
 
 **As of 2025-12-02**, the frontend uses HttpOnly cookies exclusively for token storage:
 
-| Storage Method  | XSS Safe | CSRF Safe | Cross-Tab | Status                        |
-| --------------- | -------- | --------- | --------- | ----------------------------- |
-| HttpOnly Cookie | Yes      | SameSite  | Yes       | Current - sole token storage  |
-| sessionStorage  | No       | Yes       | No        | Legacy - cleared on login     |
-| localStorage    | No       | Yes       | Yes       | Legacy - cleared on login     |
+| Storage Method  | XSS Safe | CSRF Safe | Cross-Tab | Status                       |
+| --------------- | -------- | --------- | --------- | ---------------------------- |
+| HttpOnly Cookie | Yes      | SameSite  | Yes       | Current - sole token storage |
+| sessionStorage  | No       | Yes       | No        | Legacy - cleared on login    |
+| localStorage    | No       | Yes       | Yes       | Legacy - cleared on login    |
 
 **How it works:**
 
@@ -1156,8 +1224,13 @@ XSS protection.
 
 ```javascript
 // Add check in auth.js
-if (window.location.protocol !== 'https:' && window.location.hostname !== 'localhost') {
-    console.warn('Authentication over HTTP is insecure. Use HTTPS in production.');
+if (
+    window.location.protocol !== 'https:' &&
+    window.location.hostname !== 'localhost'
+) {
+    console.warn(
+        'Authentication over HTTP is insecure. Use HTTPS in production.',
+    );
 }
 ```
 
@@ -1233,8 +1306,10 @@ test('login sets HttpOnly cookies', async ({ page, context }) => {
 
     // Verify cookies are set (HttpOnly cookies visible in context)
     const cookies = await context.cookies();
-    const accessCookie = cookies.find(c => c.name === 'litcal_access_token');
-    const refreshCookie = cookies.find(c => c.name === 'litcal_refresh_token');
+    const accessCookie = cookies.find((c) => c.name === 'litcal_access_token');
+    const refreshCookie = cookies.find(
+        (c) => c.name === 'litcal_refresh_token',
+    );
 
     expect(accessCookie).toBeDefined();
     expect(accessCookie.httpOnly).toBe(true);
@@ -1243,7 +1318,7 @@ test('login sets HttpOnly cookies', async ({ page, context }) => {
 
     // Verify no tokens in localStorage/sessionStorage
     const localStorageToken = await page.evaluate(() =>
-        localStorage.getItem('litcal_jwt_token')
+        localStorage.getItem('litcal_jwt_token'),
     );
     expect(localStorageToken).toBeNull();
 });
@@ -1309,22 +1384,22 @@ test('authenticated request uses cookies automatically', async ({ page }) => {
 ## Open Questions
 
 1. **User Management**
-   - Who creates the first admin user? (API seed script?)
-   - How do we handle password resets without email infrastructure?
-   - Should we implement account lockout after failed login attempts?
+    - Who creates the first admin user? (API seed script?)
+    - How do we handle password resets without email infrastructure?
+    - Should we implement account lockout after failed login attempts?
 
 2. **Token Lifetime**
-   - What should be the default access token TTL? (15 minutes? 1 hour?)
-   - What should be the refresh token TTL? (7 days? 30 days?)
-   - ✅ "Remember me" controls refresh token cookie persistence (see Phase 3.3)
+    - What should be the default access token TTL? (15 minutes? 1 hour?)
+    - What should be the refresh token TTL? (7 days? 30 days?)
+    - ✅ "Remember me" controls refresh token cookie persistence (see Phase 3.3)
 
 3. **Permissions**
-   - Is simple authentication enough, or do we need role-based permissions from the start?
-   - Who should have access to which calendars (all vs. specific nations/dioceses)?
+    - Is simple authentication enough, or do we need role-based permissions from the start?
+    - Who should have access to which calendars (all vs. specific nations/dioceses)?
 
 4. **Backward Compatibility**
-   - Should we version the API (/v1/ vs /v2/) when adding auth?
-   - How long to support unauthenticated writes (if at all)?
+    - Should we version the API (/v1/ vs /v2/) when adding auth?
+    - How long to support unauthenticated writes (if at all)?
 
 ## Related Documentation
 
@@ -1334,15 +1409,15 @@ test('authenticated request uses cookies automatically', async ({ page }) => {
 
 ## Timeline
 
-| Phase     | Description                                | Estimated Effort | Status      |
-| --------- | ------------------------------------------ | ---------------- | ----------- |
-| Phase 1   | Basic JWT authentication                   | 2-3 weeks        | COMPLETE    |
-| Phase 2   | Enhanced security (CSRF, auto-refresh)     | 1 week           | COMPLETE    |
-| Phase 2.4 | HttpOnly Cookie Authentication             | 1-2 days         | COMPLETE    |
-| Phase 2.5 | Full Cookie-Only Authentication            | 1 week           | COMPLETE    |
-| Phase 3.1 | Permission-Based UI                        | -                | COMPLETE    |
-| Phase 3.2 | Session Expiry Warning                     | 1 day            | COMPLETE    |
-| Phase 3.3 | Remember Me Functionality                  | 1 day            | COMPLETE    |
-| Phase 4   | Future enhancements (RBAC, MFA, OAuth)     | As needed        | Future      |
+| Phase     | Description                            | Estimated Effort | Status   |
+| --------- | -------------------------------------- | ---------------- | -------- |
+| Phase 1   | Basic JWT authentication               | 2-3 weeks        | COMPLETE |
+| Phase 2   | Enhanced security (CSRF, auto-refresh) | 1 week           | COMPLETE |
+| Phase 2.4 | HttpOnly Cookie Authentication         | 1-2 days         | COMPLETE |
+| Phase 2.5 | Full Cookie-Only Authentication        | 1 week           | COMPLETE |
+| Phase 3.1 | Permission-Based UI                    | -                | COMPLETE |
+| Phase 3.2 | Session Expiry Warning                 | 1 day            | COMPLETE |
+| Phase 3.3 | Remember Me Functionality              | 1 day            | COMPLETE |
+| Phase 4   | Future enhancements (RBAC, MFA, OAuth) | As needed        | Future   |
 
 **Note:** Timeline assumes sequential implementation coordinated with API development.

--- a/docs/FRONTEND_MODERNIZATION_ROADMAP.md
+++ b/docs/FRONTEND_MODERNIZATION_ROADMAP.md
@@ -233,11 +233,13 @@ import { LitElement, html, css } from 'https://cdn.jsdelivr.net/npm/lit@3/+esm';
 export class CalendarSelector extends LitElement {
     static properties = {
         calendars: { type: Array },
-        selected: { type: String }
+        selected: { type: String },
     };
 
     static styles = css`
-        select { @apply form-control; }
+        select {
+            @apply form-control;
+        }
     `;
 
     constructor() {
@@ -251,19 +253,26 @@ export class CalendarSelector extends LitElement {
     render() {
         return html`
             <select @change=${this.#handleChange}>
-                ${this.calendars.map(cal => html`
-                    <option value=${cal.id} ?selected=${cal.id === this.selected}>
-                        ${cal.name}
-                    </option>
-                `)}
+                ${this.calendars.map(
+                    (cal) => html`
+                        <option
+                            value=${cal.id}
+                            ?selected=${cal.id === this.selected}
+                        >
+                            ${cal.name}
+                        </option>
+                    `,
+                )}
             </select>
         `;
     }
 
     #handleChange(e) {
-        this.dispatchEvent(new CustomEvent('calendar-selected', {
-            detail: { calendarId: e.target.value }
-        }));
+        this.dispatchEvent(
+            new CustomEvent('calendar-selected', {
+                detail: { calendarId: e.target.value },
+            }),
+        );
     }
 }
 
@@ -819,14 +828,14 @@ in the top candidate frameworks to evaluate them against real requirements.
 
 **Evaluation Criteria**:
 
-| Criterion            | Weight | Description                              |
-|----------------------|--------|------------------------------------------|
-| i18n Support         | 25%    | Weblate integration, ICU language support|
-| Developer Familiarity| 20%    | Likelihood of attracting contributors    |
-| Form Handling        | 20%    | Complex form support, validation         |
-| Schema Integration   | 15%    | Coupling with API JSON schemas           |
-| Maintainability      | 10%    | Code organization, testing               |
-| Build Complexity     | 10%    | Development and deployment simplicity    |
+| Criterion             | Weight | Description                               |
+| --------------------- | ------ | ----------------------------------------- |
+| i18n Support          | 25%    | Weblate integration, ICU language support |
+| Developer Familiarity | 20%    | Likelihood of attracting contributors     |
+| Form Handling         | 20%    | Complex form support, validation          |
+| Schema Integration    | 15%    | Coupling with API JSON schemas            |
+| Maintainability       | 10%    | Code organization, testing                |
+| Build Complexity      | 10%    | Development and deployment simplicity     |
 
 **PoC Scope**: Each proof-of-concept should implement:
 
@@ -848,7 +857,7 @@ i18n is a critical requirement. The application must support:
 ### Weblate-Compatible Formats
 
 | Format                | Weblate Support | Frameworks                   |
-|-----------------------|-----------------|------------------------------|
+| --------------------- | --------------- | ---------------------------- |
 | gettext (`.po`/`.mo`) | Excellent       | Laravel, PHP, Python         |
 | i18next JSON          | Excellent       | Next.js, Nuxt.js, React, Vue |
 | JSON (nested)         | Good            | Most JS frameworks           |
@@ -991,7 +1000,7 @@ export default defineNuxtConfig({
         defaultLocale: 'en',
         lazy: true,
         langDir: 'locales/',
-    }
+    },
 });
 ```
 
@@ -1050,7 +1059,7 @@ module.exports = withNextIntl({
     i18n: {
         locales: ['en', 'it', 'la'],
         defaultLocale: 'en',
-    }
+    },
 });
 ```
 
@@ -1067,7 +1076,7 @@ module.exports = withNextIntl({
 ### i18n Comparison Matrix
 
 | Feature           | Laravel + gettext | Next.js + next-intl | Nuxt.js + @nuxtjs/i18n |
-|-------------------|-------------------|---------------------|------------------------|
+| ----------------- | ----------------- | ------------------- | ---------------------- |
 | Weblate Format    | `.po`/`.mo`       | JSON                | JSON                   |
 | ICU MessageFormat | Via php-intl      | Full support        | Full support           |
 | Pluralization     | gettext native    | ICU plural rules    | ICU plural rules       |
@@ -1192,12 +1201,12 @@ class StoreDiocesanCalendarRequest extends FormRequest
 
 To attract contributors, framework popularity matters:
 
-| Framework        | GitHub Stars    | NPM Downloads/week | Stack Overflow Questions |
-|------------------|-----------------|--------------------| -------------------------|
-| React/Next.js    | 120k+ / 120k+   | 25M+               | 450k+                    |
-| Vue/Nuxt.js      | 46k+ / 52k+     | 5M+                | 100k+                    |
-| Laravel          | 77k+            | N/A (PHP)          | 180k+                    |
-| Svelte/SvelteKit | 77k+ / 17k+     | 800k+              | 15k+                     |
+| Framework        | GitHub Stars  | NPM Downloads/week | Stack Overflow Questions |
+| ---------------- | ------------- | ------------------ | ------------------------ |
+| React/Next.js    | 120k+ / 120k+ | 25M+               | 450k+                    |
+| Vue/Nuxt.js      | 46k+ / 52k+   | 5M+                | 100k+                    |
+| Laravel          | 77k+          | N/A (PHP)          | 180k+                    |
+| Svelte/SvelteKit | 77k+ / 17k+   | 800k+              | 15k+                     |
 
 **Analysis**:
 
@@ -1229,11 +1238,11 @@ Use the Tailwind Play CDN for development - no build step required:
                         violet: '#800080',
                         rose: '#ff007f',
                         black: '#000000',
-                    }
-                }
-            }
-        }
-    }
+                    },
+                },
+            },
+        },
+    };
 </script>
 ```
 
@@ -1250,7 +1259,7 @@ This is a one-time build, not a continuous compilation requirement.
 ### Component Libraries for Web Components
 
 | Library                     | Description                          | Build Required     |
-|-----------------------------|--------------------------------------|--------------------|
+| --------------------------- | ------------------------------------ | ------------------ |
 | **Shoelace**                | Full UI library, Shadcn-like quality | No (CDN available) |
 | **Spectrum Web Components** | Adobe's design system                | No (CDN available) |
 | **Lion Web Components**     | ING Bank's accessible components     | No                 |
@@ -1268,8 +1277,14 @@ developer experience for Web Components:
 
 ```html
 <!-- Shoelace via CDN - no build required -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2/cdn/themes/light.css" />
-<script type="module" src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2/cdn/shoelace-autoloader.js"></script>
+<link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2/cdn/themes/light.css"
+/>
+<script
+    type="module"
+    src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2/cdn/shoelace-autoloader.js"
+></script>
 
 <!-- Use components -->
 <sl-button variant="primary">Save Calendar</sl-button>
@@ -1433,7 +1448,7 @@ for better integration and type safety.
 ### Final Comparison (Top 3 Candidates for PoC)
 
 | Criterion              | Weight | Laravel + Livewire | Next.js (React)     | Nuxt.js (Vue)   |
-|------------------------|--------|--------------------| --------------------|-----------------|
+| ---------------------- | ------ | ------------------ | ------------------- | --------------- |
 | i18n / Weblate Support | 25%    | 9 (gettext)        | 10 (JSON)           | 10 (JSON)       |
 | Developer Familiarity  | 20%    | 8 (PHP devs)       | 10 (largest)        | 7               |
 | Form Handling          | 20%    | 10                 | 9 (React Hook Form) | 9 (VeeValidate) |
@@ -1497,7 +1512,7 @@ But the PoC process will reveal practical considerations that scores can't captu
 Based on your input:
 
 | Question              | Answer                                             |
-|-----------------------|----------------------------------------------------|
+| --------------------- | -------------------------------------------------- |
 | Team Experience       | Some React experience                              |
 | External Contributors | None currently                                     |
 | Timeline              | No pressure, take time needed                      |
@@ -1519,19 +1534,19 @@ The frontend currently has **multiple separate administrative interfaces** sprea
 
 **LiturgicalCalendarFrontend:**
 
-| Page            | Purpose                                      | Auth Method        | Status      |
-|-----------------|----------------------------------------------|--------------------|-------------|
-| `extending.php` | Create/edit national, diocesan, wider region | JWT (modern)       | Active      |
-| `admin.php`     | Edit missals, decrees JSON files             | HTTP Basic (legacy)| Limited use |
-| `decrees.php`   | View decrees from API                        | None (read-only)   | Read-only   |
+| Page            | Purpose                                      | Auth Method         | Status      |
+| --------------- | -------------------------------------------- | ------------------- | ----------- |
+| `extending.php` | Create/edit national, diocesan, wider region | JWT (modern)        | Active      |
+| `admin.php`     | Edit missals, decrees JSON files             | HTTP Basic (legacy) | Limited use |
+| `decrees.php`   | View decrees from API                        | None (read-only)    | Read-only   |
 
 **UnitTestInterface (separate repository):**
 
-| Page            | Purpose                                      | Auth Method        | Status      |
-|-----------------|----------------------------------------------|--------------------|-------------|
-| `index.php`     | Run unit tests via WebSocket, view results   | HTTP Basic (legacy)| Active      |
-| `admin.php`     | Create/edit unit test definitions            | HTTP Basic (legacy)| Active      |
-| `resources.php` | Validate source data against JSON schemas    | HTTP Basic (legacy)| Active      |
+| Page            | Purpose                                    | Auth Method         | Status |
+| --------------- | ------------------------------------------ | ------------------- | ------ |
+| `index.php`     | Run unit tests via WebSocket, view results | HTTP Basic (legacy) | Active |
+| `admin.php`     | Create/edit unit test definitions          | HTTP Basic (legacy) | Active |
+| `resources.php` | Validate source data against JSON schemas  | HTTP Basic (legacy) | Active |
 
 **Current Problems:**
 
@@ -1829,28 +1844,28 @@ UnitTestInterface (current)        →    Admin Dashboard (future)
 **Tasks:**
 
 1. **Migrate Test Runner UI**
-   - Port WebSocket connection logic to admin dashboard
-   - Create test results display component with real-time updates
-   - Implement test filtering (by calendar, category, status)
-   - Add progress indicators and summary statistics
+    - Port WebSocket connection logic to admin dashboard
+    - Create test results display component with real-time updates
+    - Implement test filtering (by calendar, category, status)
+    - Add progress indicators and summary statistics
 
 2. **Migrate Test Editor**
-   - Port `AssertionsBuilder.js` for test assertion creation
-   - Create test definition form (event selection, assertion types)
-   - Implement CRUD operations via API `/tests` endpoint
-   - Add test preview/dry-run capability
+    - Port `AssertionsBuilder.js` for test assertion creation
+    - Create test definition form (event selection, assertion types)
+    - Implement CRUD operations via API `/tests` endpoint
+    - Add test preview/dry-run capability
 
 3. **Migrate Source Validation**
-   - Port schema validation UI
-   - Add validation for all source data types:
-     - Calendar definitions (national, diocesan, wider region)
-     - Roman Missal data (Proprium de Sanctis)
-     - Decree data
-   - Display validation results with error details
+    - Port schema validation UI
+    - Add validation for all source data types:
+        - Calendar definitions (national, diocesan, wider region)
+        - Roman Missal data (Proprium de Sanctis)
+        - Decree data
+    - Display validation results with error details
 
 4. **Authentication Migration**
-   - Replace HTTP Basic auth with JWT
-   - Use shared auth module from admin dashboard
+    - Replace HTTP Basic auth with JWT
+    - Use shared auth module from admin dashboard
 
 **Test Editor UI Components:**
 
@@ -1877,7 +1892,9 @@ UnitTestInterface (current)        →    Admin Dashboard (future)
             <div class="col-md-4">
                 <label>Test Type</label>
                 <select id="testType" class="form-select">
-                    <option value="exactCorrespondence">Exact Date Match</option>
+                    <option value="exactCorrespondence">
+                        Exact Date Match
+                    </option>
                     <option value="eventExists">Event Exists</option>
                     <option value="eventNotExists">Event Not Exists</option>
                 </select>
@@ -1931,10 +1948,12 @@ class TestRunner {
     }
 
     runTest(testDefinition) {
-        this.ws.send(JSON.stringify({
-            action: 'executeUnitTest',
-            ...testDefinition
-        }));
+        this.ws.send(
+            JSON.stringify({
+                action: 'executeUnitTest',
+                ...testDefinition,
+            }),
+        );
     }
 
     handleResult(event) {
@@ -2029,13 +2048,13 @@ class TestRunner {
 
 ### Success Metrics
 
-| Metric                           | Target                         |
-|----------------------------------|--------------------------------|
-| Single entry point for all admin | ✓ Unified `/admin` route       |
-| Consistent authentication        | ✓ JWT only, no HTTP Basic      |
-| Mobile-responsive admin UI       | ✓ All features work on mobile  |
-| Time to complete common tasks    | < current time                 |
-| User satisfaction                | Positive feedback              |
+| Metric                           | Target                        |
+| -------------------------------- | ----------------------------- |
+| Single entry point for all admin | ✓ Unified `/admin` route      |
+| Consistent authentication        | ✓ JWT only, no HTTP Basic     |
+| Mobile-responsive admin UI       | ✓ All features work on mobile |
+| Time to complete common tasks    | < current time                |
+| User satisfaction                | Positive feedback             |
 
 ### Dependencies
 

--- a/docs/TOAST_MIGRATION_PROPOSAL.md
+++ b/docs/TOAST_MIGRATION_PROPOSAL.md
@@ -8,10 +8,10 @@ This document proposes migrating from jQuery toastr to native Bootstrap toasts u
 The frontend currently uses the jQuery toastr plugin for toast notifications:
 
 ```javascript
-toastr["success"](message, title);
-toastr["error"](message, title);
-toastr["warning"](message, title);
-toastr["info"](message, title);
+toastr['success'](message, title);
+toastr['error'](message, title);
+toastr['warning'](message, title);
+toastr['info'](message, title);
 ```
 
 **Toastr advantages:**
@@ -66,23 +66,23 @@ toast({
     header: 'Success',
     body: 'Operation completed successfully',
     classes: 'bg-success text-white',
-    delay: 5000
+    delay: 5000,
 });
 ```
 
 ### Available Options
 
-| Option    | Type             | Default     | Description                                                    |
-|-----------|------------------|-------------|----------------------------------------------------------------|
-| animation | boolean          | true        | Apply CSS fade transition                                      |
-| autohide  | boolean          | true        | Automatically dismiss after delay                              |
-| delay     | number           | 4000        | Delay in milliseconds before hiding                            |
-| gap       | number           | 16          | Space between multiple toasts (px)                             |
-| margin    | string           | '1rem'      | Margin from corner                                             |
-| placement | string           | 'top-right' | Position: top-right, top-left, bottom-right, etc.              |
-| classes   | string           | ''          | Additional CSS classes                                         |
-| header    | string \| object | ''          | Header as string, or object with `icon`, `title`, `closeBtn`   |
-| body      | string           | ''          | Main toast message                                             |
+| Option    | Type             | Default     | Description                                                  |
+| --------- | ---------------- | ----------- | ------------------------------------------------------------ |
+| animation | boolean          | true        | Apply CSS fade transition                                    |
+| autohide  | boolean          | true        | Automatically dismiss after delay                            |
+| delay     | number           | 4000        | Delay in milliseconds before hiding                          |
+| gap       | number           | 16          | Space between multiple toasts (px)                           |
+| margin    | string           | '1rem'      | Margin from corner                                           |
+| placement | string           | 'top-right' | Position: top-right, top-left, bottom-right, etc.            |
+| classes   | string           | ''          | Additional CSS classes                                       |
+| header    | string \| object | ''          | Header as string, or object with `icon`, `title`, `closeBtn` |
+| body      | string           | ''          | Main toast message                                           |
 
 ### Methods
 
@@ -112,7 +112,7 @@ This allows incremental migration without changing existing code immediately.
  * Usage: <script src="/assets/js/toast-wrapper.js"></script>
  * Then use: toastr.success('Message', 'Title') or toastr["success"]('Message')
  */
-(function(global) {
+(function (global) {
     'use strict';
 
     // Icon mappings for each toast type (using Bootstrap Icons)
@@ -120,23 +120,23 @@ This allows incremental migration without changing existing code immediately.
         success: {
             icon: '<i class="bi bi-check-circle-fill text-success me-2"></i>',
             classes: 'border-success',
-            headerClass: 'bg-success-subtle'
+            headerClass: 'bg-success-subtle',
         },
         error: {
             icon: '<i class="bi bi-x-circle-fill text-danger me-2"></i>',
             classes: 'border-danger',
-            headerClass: 'bg-danger-subtle'
+            headerClass: 'bg-danger-subtle',
         },
         warning: {
             icon: '<i class="bi bi-exclamation-triangle-fill text-warning me-2"></i>',
             classes: 'border-warning',
-            headerClass: 'bg-warning-subtle'
+            headerClass: 'bg-warning-subtle',
         },
         info: {
             icon: '<i class="bi bi-info-circle-fill text-info me-2"></i>',
             classes: 'border-info',
-            headerClass: 'bg-info-subtle'
-        }
+            headerClass: 'bg-info-subtle',
+        },
     };
 
     /**
@@ -155,17 +155,17 @@ This allows incremental migration without changing existing code immediately.
             header: {
                 icon: config.icon,
                 title: title || type.charAt(0).toUpperCase() + type.slice(1),
-                closeBtn: true
+                closeBtn: true,
             },
             body: message,
             classes: config.classes,
             placement: 'top-right',
             delay: type === 'error' ? 0 : 5000, // Errors don't auto-hide
-            autohide: type !== 'error'
+            autohide: type !== 'error',
         };
 
         // Merge user options
-        Object.keys(options).forEach(function(key) {
+        Object.keys(options).forEach(function (key) {
             toastOptions[key] = options[key];
         });
 
@@ -174,15 +174,15 @@ This allows incremental migration without changing existing code immediately.
         // Return object for compatibility; .attr() is a no-op since
         // use-bootstrap-toaster doesn't expose DOM element directly
         const result = {
-            hide: function() {
+            hide: function () {
                 if (instance && typeof instance.hide === 'function') {
                     instance.hide();
                 }
             },
             // Stub for legacy .attr() calls - returns self for chaining
-            attr: function() {
+            attr: function () {
                 return result;
-            }
+            },
         };
 
         return result;
@@ -190,25 +190,27 @@ This allows incremental migration without changing existing code immediately.
 
     // toastr-compatible API attached to window
     global.toastr = {
-        success: function(message, title, options) {
+        success: function (message, title, options) {
             return showToast('success', message, title, options);
         },
-        error: function(message, title, options) {
+        error: function (message, title, options) {
             return showToast('error', message, title, options);
         },
-        warning: function(message, title, options) {
+        warning: function (message, title, options) {
             return showToast('warning', message, title, options);
         },
-        info: function(message, title, options) {
+        info: function (message, title, options) {
             return showToast('info', message, title, options);
         },
-        hide: function() {
-            if (typeof toast !== 'undefined' && typeof toast.hide === 'function') {
+        hide: function () {
+            if (
+                typeof toast !== 'undefined' &&
+                typeof toast.hide === 'function'
+            ) {
                 toast.hide();
             }
-        }
+        },
     };
-
 })(typeof window !== 'undefined' ? window : this);
 ```
 
@@ -217,8 +219,10 @@ This allows incremental migration without changing existing code immediately.
 Ensure Bootstrap Icons are available. Add to `layout/header.php`:
 
 ```html
-<link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+<link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+/>
 ```
 
 ### Phase 3: Update Script Includes
@@ -228,7 +232,10 @@ Replace toastr with the new wrapper in `layout/footer.php`:
 ```html
 <!-- Remove: -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet">
+<link
+    href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css"
+    rel="stylesheet"
+/>
 
 <!-- Add: -->
 <script src="https://cdn.jsdelivr.net/npm/use-bootstrap-toaster@1.0.3/dist/use-bootstrap-toaster.min.js"></script>
@@ -243,17 +250,20 @@ call sites to use the cleaner API directly:
 **Before (toastr):**
 
 ```javascript
-toastr["success"]('Calendar saved successfully', 'Success');
-toastr["error"](error.message, 'Error');
+toastr['success']('Calendar saved successfully', 'Success');
+toastr['error'](error.message, 'Error');
 ```
 
 **After (direct use-bootstrap-toaster):**
 
 ```javascript
 toast({
-    header: { icon: '<i class="bi bi-check-circle-fill"></i>', title: 'Success' },
+    header: {
+        icon: '<i class="bi bi-check-circle-fill"></i>',
+        title: 'Success',
+    },
     body: 'Calendar saved successfully',
-    classes: 'border-success'
+    classes: 'border-success',
 });
 ```
 
@@ -316,7 +326,7 @@ use-bootstrap-toaster supports the same browsers as Bootstrap 5:
 ## Timeline
 
 | Phase | Description                  | Effort    |
-|-------|------------------------------|-----------|
+| ----- | ---------------------------- | --------- |
 | 1     | Create compatibility wrapper | 2-3 hours |
 | 2     | Add Bootstrap Icons          | 15 min    |
 | 3     | Update script includes       | 30 min    |

--- a/docs/calendars/diocesan-create.md
+++ b/docs/calendars/diocesan-create.md
@@ -119,42 +119,42 @@ Leave these empty to use the national calendar settings.
 
 ### Settings
 
-| Field                       | Required | Description                                    |
-|-----------------------------|----------|------------------------------------------------|
-| Depends on national calendar| Yes      | Parent national calendar                       |
-| Diocese                     | Yes      | Diocese name                                   |
-| Diocesan group              | No       | Group for pooling calendar data                |
-| Locales                     | Yes      | Supported languages                            |
-| Current Localization        | Yes      | Language being edited                          |
-| Timezone                    | Yes      | Diocese timezone                               |
+| Field                        | Required | Description                     |
+| ---------------------------- | -------- | ------------------------------- |
+| Depends on national calendar | Yes      | Parent national calendar        |
+| Diocese                      | Yes      | Diocese name                    |
+| Diocesan group               | No       | Group for pooling calendar data |
+| Locales                      | Yes      | Supported languages             |
+| Current Localization         | Yes      | Language being edited           |
+| Timezone                     | Yes      | Diocese timezone                |
 
 ### Event Fields
 
-| Field      | Required | Description                               |
-|------------|----------|-------------------------------------------|
-| Event Key  | Yes      | Unique identifier for the event           |
-| Name       | Yes      | Display name in current locale            |
-| Day        | Yes      | Day of the month (1-31)                   |
-| Month      | Yes      | Month (January-December)                  |
-| Since      | Yes      | Year from which event takes effect        |
-| Until      | No       | Year until which event applies            |
+| Field     | Required | Description                        |
+| --------- | -------- | ---------------------------------- |
+| Event Key | Yes      | Unique identifier for the event    |
+| Name      | Yes      | Display name in current locale     |
+| Day       | Yes      | Day of the month (1-31)            |
+| Month     | Yes      | Month (January-December)           |
+| Since     | Yes      | Year from which event takes effect |
+| Until     | No       | Year until which event applies     |
 
 ### Override Settings
 
-| Field         | Required | Description                              |
-|---------------|----------|------------------------------------------|
-| Epiphany      | No       | Override national Epiphany setting       |
-| Ascension     | No       | Override national Ascension setting      |
-| Corpus Christi| No       | Override national Corpus Christi setting |
+| Field          | Required | Description                              |
+| -------------- | -------- | ---------------------------------------- |
+| Epiphany       | No       | Override national Epiphany setting       |
+| Ascension      | No       | Override national Ascension setting      |
+| Corpus Christi | No       | Override national Corpus Christi setting |
 
 ## Available Actions
 
 Diocesan calendars support these actions:
 
-| Action        | Description                                   |
-|---------------|-----------------------------------------------|
-| `makePatron`  | Designate a saint as diocesan patron          |
-| `createNew`   | Create a new liturgical event                 |
+| Action       | Description                          |
+| ------------ | ------------------------------------ |
+| `makePatron` | Designate a saint as diocesan patron |
+| `createNew`  | Create a new liturgical event        |
 
 > **Note:** The `setProperty` and `moveFeast` actions are **not available** for diocesan calendars.
 > These are only supported by national calendars.
@@ -169,8 +169,8 @@ Diocesan calendars support these actions:
 6. Set Current Localization to `en_US`
 7. Select timezone: **America/New_York**
 8. In Solemnities tab:
-   - Add principal patron
-   - Add cathedral dedication date
+    - Add principal patron
+    - Add cathedral dedication date
 9. Navigate through Feasts, Memorials, Optional Memorials tabs to add events
 10. Configure any diocesan overrides if needed
 11. Click **SAVE DIOCESAN CALENDAR**

--- a/docs/calendars/diocesan-delete.md
+++ b/docs/calendars/diocesan-delete.md
@@ -70,14 +70,14 @@ DELETE /data?category=diocesan&nation={nation_iso}&diocese={diocese_id}
 
 ## What Gets Deleted
 
-| Data Type              | Deleted |
-|------------------------|---------|
-| Liturgical events      | Yes     |
-| Event translations     | Yes     |
-| Diocesan group link    | Yes     |
-| Diocesan overrides     | Yes     |
-| Locale associations    | Yes     |
-| Timezone setting       | Yes     |
+| Data Type           | Deleted |
+| ------------------- | ------- |
+| Liturgical events   | Yes     |
+| Event translations  | Yes     |
+| Diocesan group link | Yes     |
+| Diocesan overrides  | Yes     |
+| Locale associations | Yes     |
+| Timezone setting    | Yes     |
 
 ## What Is NOT Deleted
 

--- a/docs/calendars/diocesan-edit.md
+++ b/docs/calendars/diocesan-edit.md
@@ -62,11 +62,11 @@ Navigate to the appropriate tab (Solemnities, Feasts, Memorials, Optional Memori
 
 1. Locate the event row to modify
 2. Update fields as needed:
-   - **Event Key** - Change the identifier
-   - **Name** - Edit the display name (for current locale)
-   - **Day/Month** - Change the celebration date
-   - **Since** - Modify the start year
-   - **Until** - Set or change the end year
+    - **Event Key** - Change the identifier
+    - **Name** - Edit the display name (for current locale)
+    - **Day/Month** - Change the celebration date
+    - **Since** - Modify the start year
+    - **Until** - Set or change the end year
 
 3. Save the calendar
 
@@ -106,7 +106,7 @@ To provide translations in different languages:
 ## Form Behavior on Edit
 
 | Field                        | Behavior                                         |
-|------------------------------|--------------------------------------------------|
+| ---------------------------- | ------------------------------------------------ |
 | Depends on national calendar | Can be changed (affects inheritance)             |
 | Diocese                      | Read-only (identifies the calendar being edited) |
 | Diocesan group               | Can be modified                                  |
@@ -142,11 +142,11 @@ PATCH /data?category=diocesan&nation={nation_iso}&diocese={diocese_id}
 4. Click on **Memorials** tab in the carousel
 5. Click the **+** button to add a new row
 6. Enter the memorial details:
-   - Event Key: `StPatrickOfBoston`
-   - Name: St. Patrick
-   - Day: 17
-   - Month: March
-   - Since: 2024
+    - Event Key: `StPatrickOfBoston`
+    - Name: St. Patrick
+    - Day: 17
+    - Month: March
+    - Since: 2024
 7. Click **SAVE DIOCESAN CALENDAR**
 
 ## Example: Adding Spanish Translations

--- a/docs/calendars/index.md
+++ b/docs/calendars/index.md
@@ -79,12 +79,12 @@ A Diocesan calendar defines diocese-specific liturgical events. It must be assoc
 
 All calendar types support these operations for liturgical events:
 
-| Operation           | Description                                           |
-|---------------------|-------------------------------------------------------|
-| **Designate Patron**| Add a patron saint for the region/nation/diocese      |
-| **Create New Event**| Define a new liturgical event                         |
-| **Change Property** | Modify the name or grade of an existing event         |
-| **Move Event**      | Change the date of an existing liturgical event       |
+| Operation            | Description                                      |
+| -------------------- | ------------------------------------------------ |
+| **Designate Patron** | Add a patron saint for the region/nation/diocese |
+| **Create New Event** | Define a new liturgical event                    |
+| **Change Property**  | Modify the name or grade of an existing event    |
+| **Move Event**       | Change the date of an existing liturgical event  |
 
 > **Note:** Not all operations are available for all calendar types. See the specific documentation for each
 > calendar type for details.

--- a/docs/calendars/national-create.md
+++ b/docs/calendars/national-create.md
@@ -64,17 +64,17 @@ Toggle whether the Feast of Jesus Christ Eternal High Priest is celebrated:
 
 1. **Locales** - Select all language/region combinations supported by this national calendar.
    For example, for Canada, you might select:
-   - `en_CA` (English - Canada)
-   - `fr_CA` (French - Canada)
+    - `en_CA` (English - Canada)
+    - `fr_CA` (French - Canada)
 
 2. **Current Localization** - Choose the locale you're currently editing. The event name entered in the main
    Name field will be saved for this locale. If you have selected multiple locales, you must also fill in the
    event name for each additional locale in the corresponding translation fields that appear below the main
    Name field.
 
-   > **Note:** If you change the Current Localization after entering localized names, the fields will be
-   > reordered so that the newly selected locale becomes the main Name field, and the previous locale moves
-   > to the translation fields below.
+    > **Note:** If you change the Current Localization after entering localized names, the fields will be
+    > reordered so that the newly selected locale becomes the main Name field, and the previous locale moves
+    > to the translation fields below.
 
 ### Step 4: Add Published Roman Missals (Optional)
 
@@ -155,7 +155,7 @@ Click **Create a new liturgical event** to define a new event:
 ### Settings
 
 | Field                   | Required | Description                            |
-|-------------------------|----------|----------------------------------------|
+| ----------------------- | -------- | -------------------------------------- |
 | National Calendar       | Yes      | Country ISO code (e.g., US, IT, DE)    |
 | Epiphany                | No       | When Epiphany is celebrated            |
 | Ascension               | No       | When Ascension is celebrated           |
@@ -168,40 +168,40 @@ Click **Create a new liturgical event** to define a new event:
 
 ### Event Fields
 
-| Field                    | Required | Description                                          |
-|--------------------------|----------|------------------------------------------------------|
-| Event Key                | Yes      | Unique identifier (PascalCase)                       |
-| Name                     | Yes      | Display name in current locale                       |
-| Day                      | Yes      | Day of the month (1-31)                              |
-| Month                    | Yes      | Month (January-December)                             |
-| Grade                    | Yes      | Celebration grade                                    |
-| Liturgical Color         | Yes      | Color(s) for the celebration                         |
-| Common                   | No       | Common of saints category                            |
-| Since                    | Yes      | Year from which this takes effect                    |
-| Until                    | No       | Year until which this applies                        |
-| Decree URL               | Yes      | URL to official decree                               |
-| Decree Language Mappings | Yes      | Languages the decree is available in                 |
+| Field                    | Required | Description                          |
+| ------------------------ | -------- | ------------------------------------ |
+| Event Key                | Yes      | Unique identifier (PascalCase)       |
+| Name                     | Yes      | Display name in current locale       |
+| Day                      | Yes      | Day of the month (1-31)              |
+| Month                    | Yes      | Month (January-December)             |
+| Grade                    | Yes      | Celebration grade                    |
+| Liturgical Color         | Yes      | Color(s) for the celebration         |
+| Common                   | No       | Common of saints category            |
+| Since                    | Yes      | Year from which this takes effect    |
+| Until                    | No       | Year until which this applies        |
+| Decree URL               | Yes      | URL to official decree               |
+| Decree Language Mappings | Yes      | Languages the decree is available in |
 
 ## Available Actions
 
 National calendars support all action types:
 
-| Action           | Description                                           |
-|------------------|-------------------------------------------------------|
-| `makePatron`     | Designate an existing saint as national patron        |
-| `setProperty`    | Change the name or grade of an existing event         |
-| `moveFeast`      | Move an event to a different date                     |
-| `createNew`      | Create a new liturgical event                         |
-| `makeDoctor`     | Designate a saint as Doctor of the Church             |
+| Action        | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `makePatron`  | Designate an existing saint as national patron |
+| `setProperty` | Change the name or grade of an existing event  |
+| `moveFeast`   | Move an event to a different date              |
+| `createNew`   | Create a new liturgical event                  |
+| `makeDoctor`  | Designate a saint as Doctor of the Church      |
 
 ## Example: Creating the USA National Calendar
 
 1. Select **US** from the National Calendar dropdown
 2. Configure settings:
-   - Epiphany: Sunday between January 2-8
-   - Ascension: Sunday
-   - Corpus Christi: Sunday
-   - Eternal High Priest: Disabled
+    - Epiphany: Sunday between January 2-8
+    - Ascension: Sunday
+    - Corpus Christi: Sunday
+    - Eternal High Priest: Disabled
 3. In Locales, select: `en_US`, `es_US`
 4. Set Current Localization to `en_US`
 5. Associate with **Americas** wider region

--- a/docs/calendars/national-delete.md
+++ b/docs/calendars/national-delete.md
@@ -78,14 +78,14 @@ DELETE /data?category=nation&key={country_iso}
 
 ## What Gets Deleted
 
-| Data Type             | Deleted |
-|-----------------------|---------|
-| Liturgical events     | Yes     |
-| Event translations    | Yes     |
-| Calendar settings     | Yes     |
-| Locale associations   | Yes     |
-| Missal associations   | Yes     |
-| Wider region link     | Yes     |
+| Data Type           | Deleted |
+| ------------------- | ------- |
+| Liturgical events   | Yes     |
+| Event translations  | Yes     |
+| Calendar settings   | Yes     |
+| Locale associations | Yes     |
+| Missal associations | Yes     |
+| Wider region link   | Yes     |
 
 ## What Is NOT Deleted
 

--- a/docs/calendars/national-edit.md
+++ b/docs/calendars/national-edit.md
@@ -76,12 +76,12 @@ The national calendar will now inherit events from the new wider region (or no w
 
 1. Locate the event row in the form
 2. Update fields as needed:
-   - **Name** - Edit the display name
-   - **Day/Month** - Change the date
-   - **Grade** - Modify celebration grade
-   - **Liturgical Color** - Update colors
-   - **Common** - Change the common
-   - **Since/Until** - Adjust year range
+    - **Name** - Edit the display name
+    - **Day/Month** - Change the date
+    - **Grade** - Modify celebration grade
+    - **Liturgical Color** - Update colors
+    - **Common** - Change the common
+    - **Since/Until** - Adjust year range
 
 3. Save the calendar
 
@@ -115,7 +115,7 @@ To provide translations for different languages:
 ## Form Behavior on Edit
 
 | Field                | Behavior                                         |
-|----------------------|--------------------------------------------------|
+| -------------------- | ------------------------------------------------ |
 | National Calendar    | Read-only (identifies the calendar being edited) |
 | Settings             | Can be modified                                  |
 | Locales              | Can add or remove                                |

--- a/docs/calendars/wider-region-create.md
+++ b/docs/calendars/wider-region-create.md
@@ -35,19 +35,19 @@ for that region.
 
 1. **Locales** - Select all language/region combinations that should be supported for this wider region calendar.
    For example, for the Americas region, you might select:
-   - `en_US` (English - United States)
-   - `es_MX` (Spanish - Mexico)
-   - `pt_BR` (Portuguese - Brazil)
-   - `fr_CA` (French - Canada)
+    - `en_US` (English - United States)
+    - `es_MX` (Spanish - Mexico)
+    - `pt_BR` (Portuguese - Brazil)
+    - `fr_CA` (French - Canada)
 
 2. **Current Localization** - Choose the locale you're currently editing. The event name entered in the main
    Name field will be saved for this locale. If you have selected multiple locales, you must also fill in the
    event name for each additional locale in the corresponding translation fields that appear below the main
    Name field.
 
-   > **Note:** If you change the Current Localization after entering localized names, the fields will be
-   > reordered so that the newly selected locale becomes the main Name field, and the previous locale moves
-   > to the translation fields below.
+    > **Note:** If you change the Current Localization after entering localized names, the fields will be
+    > reordered so that the newly selected locale becomes the main Name field, and the previous locale moves
+    > to the translation fields below.
 
 ### Step 3: Add Liturgical Events
 
@@ -89,7 +89,7 @@ Click **Create a new liturgical event** to define a new event:
 ## Form Fields Reference
 
 | Field                    | Required | Description                                                  |
-|--------------------------|----------|--------------------------------------------------------------|
+| ------------------------ | -------- | ------------------------------------------------------------ |
 | Wider Region             | Yes      | The region name (Americas, Europe, Asia, Africa, Oceania)    |
 | Locales                  | Yes      | Supported language/region combinations                       |
 | Current Localization     | Yes      | The locale being edited                                      |
@@ -109,10 +109,10 @@ Click **Create a new liturgical event** to define a new event:
 
 For wider region calendars, the following actions are supported:
 
-| Action            | Description                                    |
-|-------------------|------------------------------------------------|
-| `makePatron`      | Designate an existing saint as patron          |
-| `createNew`       | Create a new liturgical event                  |
+| Action       | Description                           |
+| ------------ | ------------------------------------- |
+| `makePatron` | Designate an existing saint as patron |
+| `createNew`  | Create a new liturgical event         |
 
 > **Note:** The `setProperty` and `moveFeast` actions are **not available** for wider region calendars. These
 > actions are only supported by national calendars.

--- a/docs/calendars/wider-region-delete.md
+++ b/docs/calendars/wider-region-delete.md
@@ -62,7 +62,7 @@ DELETE /data?category=widerregion&key={region_name}
 ## What Gets Deleted
 
 | Data Type           | Deleted |
-|---------------------|---------|
+| ------------------- | ------- |
 | Liturgical events   | Yes     |
 | Event translations  | Yes     |
 | Metadata            | Yes     |

--- a/docs/calendars/wider-region-edit.md
+++ b/docs/calendars/wider-region-edit.md
@@ -28,12 +28,12 @@ When you select an existing wider region:
 
 1. Locate the event row in the form
 2. Update the fields as needed:
-   - **Name** - Change the display name (for current locale)
-   - **Day/Month** - Modify the celebration date
-   - **Grade** - Change the celebration grade
-   - **Liturgical Color** - Update the color(s)
-   - **Common** - Modify the common of saints
-   - **Since/Until** - Adjust the year range
+    - **Name** - Change the display name (for current locale)
+    - **Day/Month** - Modify the celebration date
+    - **Grade** - Change the celebration grade
+    - **Liturgical Color** - Update the color(s)
+    - **Common** - Modify the common of saints
+    - **Since/Until** - Adjust the year range
 
 3. Click **Save Wider Region Calendar Data** to save changes
 
@@ -83,7 +83,7 @@ To edit event names in different languages:
 ## Form Behavior on Edit
 
 | Field                | Behavior                                         |
-|----------------------|--------------------------------------------------|
+| -------------------- | ------------------------------------------------ |
 | Wider Region         | Read-only (identifies the calendar being edited) |
 | Locales              | Can add or remove locales                        |
 | Current Localization | Can switch to edit different language versions   |

--- a/docs/superpowers/HANDOFF-admin-tests-phases-2-3.md
+++ b/docs/superpowers/HANDOFF-admin-tests-phases-2-3.md
@@ -70,7 +70,7 @@ concurrent agents", "API runs in Docker", and the WebSocket gotchas.
 - **Editor to port:** in the UnitTestInterface repo — `admin.php`, `assets/js/admin.js`,
   `assets/js/AssertionsBuilder.js`, `assets/css/multi-range-slider.css`, `components/NewTestModal.php`.
   Assertion shape: `{year:int, expected_value:RFC3339|null, assert:'eventNotExists'|'eventExists
-  AND hasExpectedDate', assertion:string, comment?:string}`. `LitCalTest` fields: `name`,
+AND hasExpectedDate', assertion:string, comment?:string}`. `LitCalTest` fields: `name`,
   `event_key`, `description`, `test_type` (`exactCorrespondence`|`variableCorrespondence`),
   `assertions`, `applies_to`/`excludes`, `year_since`/`year_until`. Schema:
   API repo `jsondata/schemas/LitCalTest.json`.

--- a/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-21-frontend-rbac-e2e-harness.md
@@ -109,11 +109,11 @@ git commit -m "test(rbac): scaffold rbac Playwright project"
 **Interfaces:**
 
 - Produces:
-  - `type RbacUser = { id: string; email: string; password: string; role: 'admin' | 'calendar_editor';
-    fga: { relation: 'admin' | 'editor'; objectType: string; objectId: string } | null }`
-  - `const USERS: Record<string, RbacUser>` keyed by id (`super-admin`, `cei-admin`, …, `europe-editor`)
-  - `const SEEDED_USER_IDS: string[]` and `const REGISTRATION_USER_IDS: string[]` (`cei-admin`,
-    `usccb-editor`) — the two whose specs use real registration (their seeding is skipped in setup).
+    - `type RbacUser = { id: string; email: string; password: string; role: 'admin' | 'calendar_editor';
+fga: { relation: 'admin' | 'editor'; objectType: string; objectId: string } | null }`
+    - `const USERS: Record<string, RbacUser>` keyed by id (`super-admin`, `cei-admin`, …, `europe-editor`)
+    - `const SEEDED_USER_IDS: string[]` and `const REGISTRATION_USER_IDS: string[]` (`cei-admin`,
+      `usccb-editor`) — the two whose specs use real registration (their seeding is skipped in setup).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -139,7 +139,8 @@ test('only super-admin holds the global admin role; others are calendar_editor',
 
 test('registration users are a subset not included in seeded ids', () => {
     expect(REGISTRATION_USER_IDS).toEqual(['cei-admin', 'usccb-editor']);
-    for (const id of REGISTRATION_USER_IDS) expect(SEEDED_USER_IDS).not.toContain(id);
+    for (const id of REGISTRATION_USER_IDS)
+        expect(SEEDED_USER_IDS).not.toContain(id);
 });
 ```
 
@@ -158,31 +159,81 @@ export interface RbacUser {
     email: string;
     password: string;
     role: 'admin' | 'calendar_editor';
-    fga: { relation: RbacRelation; objectType: string; objectId: string } | null;
+    fga: {
+        relation: RbacRelation;
+        objectType: string;
+        objectId: string;
+    } | null;
 }
 
 const pw = 'E2e-Test-Passw0rd!'; // shared test password; users live only in the test org
 
-function mk(id: string, role: RbacUser['role'], fga: RbacUser['fga']): RbacUser {
+function mk(
+    id: string,
+    role: RbacUser['role'],
+    fga: RbacUser['fga'],
+): RbacUser {
     return { id, email: `${id}+e2e@litcal.test`, password: pw, role, fga };
 }
 
 export const USERS: Record<string, RbacUser> = {
     'super-admin': mk('super-admin', 'admin', null),
-    'cei-admin': mk('cei-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'IT' }),
-    'cei-editor': mk('cei-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'IT' }),
-    'usccb-admin': mk('usccb-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'US' }),
-    'usccb-editor': mk('usccb-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'US' }),
-    'rome-admin': mk('rome-admin', 'calendar_editor', { relation: 'admin', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
-    'rome-editor': mk('rome-editor', 'calendar_editor', { relation: 'editor', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
-    'grc-admin': mk('grc-admin', 'calendar_editor', { relation: 'admin', objectType: 'general_roman_calendar', objectId: 'temporale' }),
-    'grc-editor': mk('grc-editor', 'calendar_editor', { relation: 'editor', objectType: 'general_roman_calendar', objectId: 'temporale' }),
-    'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: 'Europe' }),
-    'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: 'Europe' }),
+    'cei-admin': mk('cei-admin', 'calendar_editor', {
+        relation: 'admin',
+        objectType: 'national_calendar',
+        objectId: 'IT',
+    }),
+    'cei-editor': mk('cei-editor', 'calendar_editor', {
+        relation: 'editor',
+        objectType: 'national_calendar',
+        objectId: 'IT',
+    }),
+    'usccb-admin': mk('usccb-admin', 'calendar_editor', {
+        relation: 'admin',
+        objectType: 'national_calendar',
+        objectId: 'US',
+    }),
+    'usccb-editor': mk('usccb-editor', 'calendar_editor', {
+        relation: 'editor',
+        objectType: 'national_calendar',
+        objectId: 'US',
+    }),
+    'rome-admin': mk('rome-admin', 'calendar_editor', {
+        relation: 'admin',
+        objectType: 'diocesan_calendar',
+        objectId: 'romamo_it',
+    }),
+    'rome-editor': mk('rome-editor', 'calendar_editor', {
+        relation: 'editor',
+        objectType: 'diocesan_calendar',
+        objectId: 'romamo_it',
+    }),
+    'grc-admin': mk('grc-admin', 'calendar_editor', {
+        relation: 'admin',
+        objectType: 'general_roman_calendar',
+        objectId: 'temporale',
+    }),
+    'grc-editor': mk('grc-editor', 'calendar_editor', {
+        relation: 'editor',
+        objectType: 'general_roman_calendar',
+        objectId: 'temporale',
+    }),
+    'europe-admin': mk('europe-admin', 'calendar_editor', {
+        relation: 'admin',
+        objectType: 'wider_region',
+        objectId: 'Europe',
+    }),
+    'europe-editor': mk('europe-editor', 'calendar_editor', {
+        relation: 'editor',
+        objectType: 'wider_region',
+        objectId: 'Europe',
+    }),
 };
 
 export const REGISTRATION_USER_IDS = ['cei-admin', 'usccb-editor'];
-export const SEEDED_USER_IDS = Object.keys(USERS).filter((id) => !REGISTRATION_USER_IDS.includes(id));
+export const SEEDED_USER_IDS = Object.keys(USERS).filter(
+    (id) => !REGISTRATION_USER_IDS.includes(id),
+);
 ```
 
 > RESOLVED (verified against API source data + live stack, 2026-06-21): nation codes are `IT`/`US` (NOT
@@ -217,19 +268,19 @@ git commit -m "test(rbac): user/permission seed matrix"
 - Consumes: env `ZITADEL_ISSUER`, `ZITADEL_MACHINE_TOKEN`, `ZITADEL_ORG_ID`, and `ZITADEL_PROJECT_ID`
   (for role grants).
 - Produces a `ZitadelAdmin` class:
-  - `findUserIdByEmail(email: string): Promise<string | null>`
-  - `findUserIdByUsername(userName: string): Promise<string | null>` — used to locate the `login-client`
-    machine user.
-  - `createVerifiedUser(u: { email: string; password: string; firstName: string; lastName: string }):
-    Promise<string>` — returns the new userId; email pre-verified, password set, not requiring change.
-  - `grantProjectRole(userId: string, role: string): Promise<void>`
-  - `deleteUser(userId: string): Promise<void>`
-  - `mintPat(userId: string): Promise<{ tokenId: string; token: string }>` — create a Personal Access
-    Token for a (machine) user via `POST /management/v1/users/{userId}/pats`.
-  - `deletePat(userId: string, tokenId: string): Promise<void>`
-  - all calls send `Authorization: Bearer <machine token>`, `Host: localhost` (Zitadel's ExternalDomain
-    is `localhost`; Node `fetch` CAN set the Host header), and the org header
-    `x-zitadel-orgid: <ZITADEL_ORG_ID>`.
+    - `findUserIdByEmail(email: string): Promise<string | null>`
+    - `findUserIdByUsername(userName: string): Promise<string | null>` — used to locate the `login-client`
+      machine user.
+    - `createVerifiedUser(u: { email: string; password: string; firstName: string; lastName: string }):
+Promise<string>` — returns the new userId; email pre-verified, password set, not requiring change.
+    - `grantProjectRole(userId: string, role: string): Promise<void>`
+    - `deleteUser(userId: string): Promise<void>`
+    - `mintPat(userId: string): Promise<{ tokenId: string; token: string }>` — create a Personal Access
+      Token for a (machine) user via `POST /management/v1/users/{userId}/pats`.
+    - `deletePat(userId: string, tokenId: string): Promise<void>`
+    - all calls send `Authorization: Bearer <machine token>`, `Host: localhost` (Zitadel's ExternalDomain
+      is `localhost`; Node `fetch` CAN set the Host header), and the org header
+      `x-zitadel-orgid: <ZITADEL_ORG_ID>`.
 
 > NOTE: The `ZITADEL_MACHINE_TOKEN` belongs to the `test-service-account` machine user. It can create
 > users / grant roles, but CANNOT create Zitadel sessions (lacks `IAM_LOGIN_CLIENT`). The login flow
@@ -249,7 +300,12 @@ test('create, find, grant role, delete a verified user', async () => {
     const existing = await z.findUserIdByEmail(email);
     if (existing) await z.deleteUser(existing);
 
-    const id = await z.createVerifiedUser({ email, password: 'E2e-Test-Passw0rd!', firstName: 'Zit', lastName: 'Probe' });
+    const id = await z.createVerifiedUser({
+        email,
+        password: 'E2e-Test-Passw0rd!',
+        firstName: 'Zit',
+        lastName: 'Probe',
+    });
     expect(id).toMatch(/^\d+$/);
     expect(await z.findUserIdByEmail(email)).toBe(id);
 
@@ -280,7 +336,11 @@ export class ZitadelAdmin {
     private orgId = process.env.ZITADEL_ORG_ID!;
     private projectId = process.env.ZITADEL_PROJECT_ID!;
 
-    private async req(method: string, path: string, body?: unknown): Promise<any> {
+    private async req(
+        method: string,
+        path: string,
+        body?: unknown,
+    ): Promise<any> {
         const res = await fetch(`${this.issuer}${path}`, {
             method,
             headers: {
@@ -292,7 +352,10 @@ export class ZitadelAdmin {
             body: body === undefined ? undefined : JSON.stringify(body),
         });
         const text = await res.text();
-        if (!res.ok) throw new Error(`Zitadel ${method} ${path} -> ${res.status}: ${text}`);
+        if (!res.ok)
+            throw new Error(
+                `Zitadel ${method} ${path} -> ${res.status}: ${text}`,
+            );
         return text ? JSON.parse(text) : {};
     }
 
@@ -304,7 +367,12 @@ export class ZitadelAdmin {
         return u?.userId ?? null;
     }
 
-    async createVerifiedUser(u: { email: string; password: string; firstName: string; lastName: string }): Promise<string> {
+    async createVerifiedUser(u: {
+        email: string;
+        password: string;
+        firstName: string;
+        lastName: string;
+    }): Promise<string> {
         const data = await this.req('POST', '/v2/users/human', {
             profile: { givenName: u.firstName, familyName: u.lastName },
             email: { email: u.email, isVerified: true },
@@ -333,14 +401,21 @@ export class ZitadelAdmin {
     }
 
     async mintPat(userId: string): Promise<{ tokenId: string; token: string }> {
-        const data = await this.req('POST', `/management/v1/users/${userId}/pats`, {
-            expirationDate: '2030-01-01T00:00:00Z',
-        });
+        const data = await this.req(
+            'POST',
+            `/management/v1/users/${userId}/pats`,
+            {
+                expirationDate: '2030-01-01T00:00:00Z',
+            },
+        );
         return { tokenId: data.tokenId as string, token: data.token as string };
     }
 
     async deletePat(userId: string, tokenId: string): Promise<void> {
-        await this.req('DELETE', `/management/v1/users/${userId}/pats/${tokenId}`);
+        await this.req(
+            'DELETE',
+            `/management/v1/users/${userId}/pats/${tokenId}`,
+        );
     }
 }
 ```
@@ -374,12 +449,12 @@ git commit -m "test(rbac): zitadel admin client (create/find/grant/delete user)"
 
 - Consumes: env `OPENFGA_API_URL`, `OPENFGA_STORE_ID`, `OPENFGA_MODEL_ID`.
 - Produces a `Fga` class:
-  - `write(user: string, relation: string, object: string): Promise<void>` (idempotent — ignores
-    `already exists`)
-  - `delete(user: string, relation: string, object: string): Promise<void>` (idempotent — ignores
-    `not found`)
-  - `check(user: string, relation: string, object: string): Promise<boolean>`
-  - where `user` is `user:<zitadelUserId>` and `object` is `<objectType>:<objectId>`.
+    - `write(user: string, relation: string, object: string): Promise<void>` (idempotent — ignores
+      `already exists`)
+    - `delete(user: string, relation: string, object: string): Promise<void>` (idempotent — ignores
+      `not found`)
+    - `check(user: string, relation: string, object: string): Promise<boolean>`
+    - where `user` is `user:<zitadelUserId>` and `object` is `<objectType>:<objectId>`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -414,7 +489,10 @@ export class Fga {
     private store = process.env.OPENFGA_STORE_ID!;
     private model = process.env.OPENFGA_MODEL_ID!;
 
-    private async post(path: string, body: unknown): Promise<{ status: number; text: string }> {
+    private async post(
+        path: string,
+        body: unknown,
+    ): Promise<{ status: number; text: string }> {
         const res = await fetch(`${this.url}/stores/${this.store}${path}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -433,7 +511,11 @@ export class Fga {
         }
     }
 
-    async delete(user: string, relation: string, object: string): Promise<void> {
+    async delete(
+        user: string,
+        relation: string,
+        object: string,
+    ): Promise<void> {
         const r = await this.post('/write', {
             deletes: { tuple_keys: [{ user, relation, object }] },
             authorization_model_id: this.model,
@@ -443,12 +525,17 @@ export class Fga {
         }
     }
 
-    async check(user: string, relation: string, object: string): Promise<boolean> {
+    async check(
+        user: string,
+        relation: string,
+        object: string,
+    ): Promise<boolean> {
         const r = await this.post('/check', {
             tuple_key: { user, relation, object },
             authorization_model_id: this.model,
         });
-        if (r.status >= 400) throw new Error(`FGA check ${r.status}: ${r.text}`);
+        if (r.status >= 400)
+            throw new Error(`FGA check ${r.status}: ${r.text}`);
         return JSON.parse(r.text).allowed === true;
     }
 }
@@ -479,14 +566,14 @@ git commit -m "test(rbac): openfga tuple client (write/delete/check)"
 
 - Consumes: `USERS`, `ZitadelAdmin`, `Fga`.
 - Produces:
-  - `seedUser(id: string): Promise<string>` — upsert (delete-then-create) the Zitadel user, grant the
-    role, write the FGA tuple (if any); returns the Zitadel userId.
-  - `oidcLogin(email: string, password: string, loginClientToken: string): Promise<string>` — run the
-    headless Zitadel session→PKCE flow and return a Zitadel OIDC access token (JWT).
-  - `loginAndSaveState(id: string, loginClientToken: string): Promise<void>` — call `oidcLogin` and write
-    a Playwright `storageState` to `e2e/.auth/<id>.json` containing the `litcal_access_token` cookie
-    (domain `localhost`, HttpOnly). The `loginClientToken` is a session-capable PAT minted for the
-    `login-client` user in setup (Task 7).
+    - `seedUser(id: string): Promise<string>` — upsert (delete-then-create) the Zitadel user, grant the
+      role, write the FGA tuple (if any); returns the Zitadel userId.
+    - `oidcLogin(email: string, password: string, loginClientToken: string): Promise<string>` — run the
+      headless Zitadel session→PKCE flow and return a Zitadel OIDC access token (JWT).
+    - `loginAndSaveState(id: string, loginClientToken: string): Promise<void>` — call `oidcLogin` and write
+      a Playwright `storageState` to `e2e/.auth/<id>.json` containing the `litcal_access_token` cookie
+      (domain `localhost`, HttpOnly). The `loginClientToken` is a session-capable PAT minted for the
+      `login-client` user in setup (Task 7).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -502,7 +589,13 @@ test('seedUser creates user, grants role, writes scoped tuple', async () => {
     expect(id).toMatch(/^\d+$/);
     const f = new Fga();
     const u = USERS['cei-editor'].fga!;
-    expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+    expect(
+        await f.check(
+            `user:${id}`,
+            u.relation,
+            `${u.objectType}:${u.objectId}`,
+        ),
+    ).toBe(true);
     // cleanup
     await new ZitadelAdmin().deleteUser(id);
     await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`);
@@ -524,7 +617,10 @@ import { USERS } from './users';
 import { ZitadelAdmin } from './zitadel';
 import { Fga } from './fga';
 
-const ISSUER = (process.env.ZITADEL_ISSUER || 'http://localhost:8080').replace(/\/$/, '');
+const ISSUER = (process.env.ZITADEL_ISSUER || 'http://localhost:8080').replace(
+    /\/$/,
+    '',
+);
 // Reuse the existing Zitadel OIDC client (authorization_code + PKCE, public/no-secret) for the
 // headless login flow. We drive it server-side via the session API rather than a browser redirect.
 const CLIENT_ID = process.env.ZITADEL_CLIENT_ID!;
@@ -532,7 +628,12 @@ const REDIRECT_URI = `${process.env.FRONTEND_URL || 'http://localhost:3000'}/aut
 // Zitadel matches requests by its configured external domain; send Host = the issuer hostname
 // (port-stripped) rather than hardcoding 'localhost', so a non-localhost ZITADEL_ISSUER still works.
 const HOST = new URL(ISSUER).hostname;
-const b64url = (b: Buffer) => b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+const b64url = (b: Buffer) =>
+    b
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
 
 export async function seedUser(id: string): Promise<string> {
     const u = USERS[id];
@@ -541,12 +642,27 @@ export async function seedUser(id: string): Promise<string> {
 
     const existing = await z.findUserIdByEmail(u.email);
     if (existing) {
-        if (u.fga) await f.delete(`user:${existing}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+        if (u.fga)
+            await f.delete(
+                `user:${existing}`,
+                u.fga.relation,
+                `${u.fga.objectType}:${u.fga.objectId}`,
+            );
         await z.deleteUser(existing);
     }
-    const userId = await z.createVerifiedUser({ email: u.email, password: u.password, firstName: u.id, lastName: 'E2E' });
+    const userId = await z.createVerifiedUser({
+        email: u.email,
+        password: u.password,
+        firstName: u.id,
+        lastName: 'E2E',
+    });
     await z.grantProjectRole(userId, u.role);
-    if (u.fga) await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+    if (u.fga)
+        await f.write(
+            `user:${userId}`,
+            u.fga.relation,
+            `${u.fga.objectType}:${u.fga.objectId}`,
+        );
     return userId;
 }
 
@@ -555,63 +671,131 @@ export async function seedUser(id: string): Promise<string> {
  * `loginClientToken` is a session-capable PAT (minted for the `login-client` user in setup).
  * Returns the access_token to be set as the `litcal_access_token` cookie.
  */
-export async function oidcLogin(email: string, password: string, loginClientToken: string): Promise<string> {
-    const Hl = { Authorization: `Bearer ${loginClientToken}`, 'Content-Type': 'application/json', Host: HOST };
-    const json = async (r: Response) => { const t = await r.text(); if (!r.ok) throw new Error(`${r.url} -> ${r.status}: ${t}`); return JSON.parse(t); };
+export async function oidcLogin(
+    email: string,
+    password: string,
+    loginClientToken: string,
+): Promise<string> {
+    const Hl = {
+        Authorization: `Bearer ${loginClientToken}`,
+        'Content-Type': 'application/json',
+        Host: HOST,
+    };
+    const json = async (r: Response) => {
+        const t = await r.text();
+        if (!r.ok) throw new Error(`${r.url} -> ${r.status}: ${t}`);
+        return JSON.parse(t);
+    };
 
     // 1. Create a password-checked session (login-client token).
-    const s = await json(await fetch(`${ISSUER}/v2/sessions`, {
-        method: 'POST', headers: Hl,
-        body: JSON.stringify({ checks: { user: { loginName: email }, password: { password } } }),
-    }));
+    const s = await json(
+        await fetch(`${ISSUER}/v2/sessions`, {
+            method: 'POST',
+            headers: Hl,
+            body: JSON.stringify({
+                checks: { user: { loginName: email }, password: { password } },
+            }),
+        }),
+    );
 
     // 2. Start an OIDC auth request (Frontend client, PKCE S256) → 302 to login-v2 with ?authRequest=...
     const verifier = b64url(crypto.randomBytes(32));
-    const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+    const challenge = b64url(
+        crypto.createHash('sha256').update(verifier).digest(),
+    );
     const qs = new URLSearchParams({
-        response_type: 'code', client_id: CLIENT_ID, redirect_uri: REDIRECT_URI,
-        scope: 'openid profile email', code_challenge: challenge, code_challenge_method: 'S256', state: id_state(),
+        response_type: 'code',
+        client_id: CLIENT_ID,
+        redirect_uri: REDIRECT_URI,
+        scope: 'openid profile email',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        state: id_state(),
     });
-    const authResp = await fetch(`${ISSUER}/oauth/v2/authorize?${qs}`, { headers: { Host: HOST }, redirect: 'manual' });
+    const authResp = await fetch(`${ISSUER}/oauth/v2/authorize?${qs}`, {
+        headers: { Host: HOST },
+        redirect: 'manual',
+    });
     const loc = authResp.headers.get('location') || '';
     const arMatch = loc.match(/authRequest(?:Id)?=([^&]+)/);
-    if (!arMatch) throw new Error(`authorize did not return an authRequest id: ${authResp.status} ${loc}`);
+    if (!arMatch)
+        throw new Error(
+            `authorize did not return an authRequest id: ${authResp.status} ${loc}`,
+        );
     const authRequestId = decodeURIComponent(arMatch[1]);
 
     // 3. Finalize the auth request with the session (login-client token) → callbackUrl with ?code=
-    const fin = await json(await fetch(`${ISSUER}/v2/oidc/auth_requests/${authRequestId}`, {
-        method: 'POST', headers: Hl,
-        body: JSON.stringify({ session: { sessionId: s.sessionId, sessionToken: s.sessionToken } }),
-    }));
+    const fin = await json(
+        await fetch(`${ISSUER}/v2/oidc/auth_requests/${authRequestId}`, {
+            method: 'POST',
+            headers: Hl,
+            body: JSON.stringify({
+                session: {
+                    sessionId: s.sessionId,
+                    sessionToken: s.sessionToken,
+                },
+            }),
+        }),
+    );
     const codeMatch = String(fin.callbackUrl || '').match(/[?&]code=([^&]+)/);
-    if (!codeMatch) throw new Error(`finalize returned no code: ${JSON.stringify(fin)}`);
+    if (!codeMatch)
+        throw new Error(`finalize returned no code: ${JSON.stringify(fin)}`);
     const code = decodeURIComponent(codeMatch[1]);
 
     // 4. Exchange the code for tokens (public client, PKCE — no client secret).
-    const form = new URLSearchParams({ grant_type: 'authorization_code', code, redirect_uri: REDIRECT_URI, client_id: CLIENT_ID, code_verifier: verifier });
-    const tok = await json(await fetch(`${ISSUER}/oauth/v2/token`, {
-        method: 'POST', headers: { Host: HOST, 'Content-Type': 'application/x-www-form-urlencoded' }, body: form,
-    }));
-    if (!tok.access_token) throw new Error(`token exchange returned no access_token: ${JSON.stringify(tok)}`);
+    const form = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: CLIENT_ID,
+        code_verifier: verifier,
+    });
+    const tok = await json(
+        await fetch(`${ISSUER}/oauth/v2/token`, {
+            method: 'POST',
+            headers: {
+                Host: HOST,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: form,
+        }),
+    );
+    if (!tok.access_token)
+        throw new Error(
+            `token exchange returned no access_token: ${JSON.stringify(tok)}`,
+        );
     return tok.access_token as string;
 }
 
 // state param need only be opaque/unique-ish; avoid Math.random for determinism-friendliness.
-function id_state(): string { return b64url(crypto.randomBytes(8)); }
+function id_state(): string {
+    return b64url(crypto.randomBytes(8));
+}
 
 /**
  * Log a user in headlessly and write a Playwright storageState file containing the
  * `litcal_access_token` cookie. Cookie domain is `localhost` (port-agnostic) so it is sent to
  * both the frontend (:3000) and the API (:8000). The real cookie is HttpOnly.
  */
-export async function loginAndSaveState(id: string, loginClientToken: string): Promise<void> {
+export async function loginAndSaveState(
+    id: string,
+    loginClientToken: string,
+): Promise<void> {
     const u = USERS[id];
     const accessToken = await oidcLogin(u.email, u.password, loginClientToken);
     const storageState = {
-        cookies: [{
-            name: 'litcal_access_token', value: accessToken, domain: 'localhost', path: '/',
-            expires: -1, httpOnly: true, secure: false, sameSite: 'Lax' as const,
-        }],
+        cookies: [
+            {
+                name: 'litcal_access_token',
+                value: accessToken,
+                domain: 'localhost',
+                path: '/',
+                expires: -1,
+                httpOnly: true,
+                secure: false,
+                sameSite: 'Lax' as const,
+            },
+        ],
         origins: [],
     };
     const authPath = path.join(__dirname, '..', '..', '.auth', `${id}.json`);
@@ -649,10 +833,10 @@ git commit -m "test(rbac): seed one user (zitadel + role + fga tuple)"
 **Interfaces:**
 
 - Produces:
-  - `truncateAppTables(): Promise<void>` — `docker compose exec -T db psql` TRUNCATE of
-    `access_requests`, `audit_log`, and the user-notification-state table.
-  - `deleteAllSeededUsers(): Promise<void>` — for each id in `USERS`, find by email, delete the Zitadel
-    user and its FGA tuple if present.
+    - `truncateAppTables(): Promise<void>` — `docker compose exec -T db psql` TRUNCATE of
+      `access_requests`, `audit_log`, and the user-notification-state table.
+    - `deleteAllSeededUsers(): Promise<void>` — for each id in `USERS`, find by email, delete the Zitadel
+      user and its FGA tuple if present.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -666,7 +850,9 @@ import { USERS } from './users';
 test('deleteAllSeededUsers removes a seeded user', async () => {
     await seedUser('rome-editor');
     await deleteAllSeededUsers();
-    expect(await new ZitadelAdmin().findUserIdByEmail(USERS['rome-editor'].email)).toBeNull();
+    expect(
+        await new ZitadelAdmin().findUserIdByEmail(USERS['rome-editor'].email),
+    ).toBeNull();
 });
 
 test('truncateAppTables runs without error', async () => {
@@ -693,8 +879,21 @@ const exec = promisify(execFile);
 export async function truncateAppTables(): Promise<void> {
     // The active docker stack is the FRONTEND compose project (this repo root), not the API repo's.
     // Run `docker compose exec` from the frontend repo root so it targets the running `db` service.
-    const sql = 'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
-    await exec('docker', ['compose', 'exec', '-T', 'db', 'psql', '-U', 'litcal', '-d', 'litcal', '-c', sql]);
+    const sql =
+        'TRUNCATE access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE;';
+    await exec('docker', [
+        'compose',
+        'exec',
+        '-T',
+        'db',
+        'psql',
+        '-U',
+        'litcal',
+        '-d',
+        'litcal',
+        '-c',
+        sql,
+    ]);
 }
 
 export async function deleteAllSeededUsers(): Promise<void> {
@@ -704,7 +903,12 @@ export async function deleteAllSeededUsers(): Promise<void> {
         const u = USERS[id];
         const zid = await z.findUserIdByEmail(u.email);
         if (!zid) continue;
-        if (u.fga) await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+        if (u.fga)
+            await f.delete(
+                `user:${zid}`,
+                u.fga.relation,
+                `${u.fga.objectType}:${u.fga.objectId}`,
+            );
         await z.deleteUser(zid);
     }
 }
@@ -757,7 +961,8 @@ setup('seed rbac users', async () => {
     // The session API needs IAM_LOGIN_CLIENT, which the machine token lacks. Mint a fresh,
     // session-capable PAT for the `login-client` user and delete it when done.
     const loginClientUserId = await z.findUserIdByUsername('login-client');
-    if (!loginClientUserId) throw new Error('login-client machine user not found in Zitadel');
+    if (!loginClientUserId)
+        throw new Error('login-client machine user not found in Zitadel');
     const pat = await z.mintPat(loginClientUserId);
 
     try {
@@ -807,13 +1012,18 @@ git commit -m "test(rbac): global setup seeds 9 users + saves sessions"
 import { test, expect } from '@playwright/test';
 import { actingAs } from './actingAs';
 
-test('actingAs super-admin is authenticated with the admin role', async ({ browser }) => {
+test('actingAs super-admin is authenticated with the admin role', async ({
+    browser,
+}) => {
     const { context, page } = await actingAs(browser, 'super-admin');
     // In OIDC mode the frontend validates the litcal_access_token cookie via its own /auth/me.php
     // (the API's /auth/me is HS256/admin-only and rejects Zitadel OIDC tokens).
     await page.goto('/');
     const me = await page.evaluate(async () => {
-        const r = await fetch('/auth/me.php', { credentials: 'include', headers: { Accept: 'application/json' } });
+        const r = await fetch('/auth/me.php', {
+            credentials: 'include',
+            headers: { Accept: 'application/json' },
+        });
         return { status: r.status, body: await r.json() };
     });
     expect(me.status).toBe(200);
@@ -834,8 +1044,13 @@ Expected: FAIL — cannot find module `./actingAs`.
 import { Browser, BrowserContext, Page } from '@playwright/test';
 import * as path from 'path';
 
-export async function actingAs(browser: Browser, id: string): Promise<{ context: BrowserContext; page: Page }> {
-    const context = await browser.newContext({ storageState: path.join(__dirname, '..', '..', '.auth', `${id}.json`) });
+export async function actingAs(
+    browser: Browser,
+    id: string,
+): Promise<{ context: BrowserContext; page: Page }> {
+    const context = await browser.newContext({
+        storageState: path.join(__dirname, '..', '..', '.auth', `${id}.json`),
+    });
     const page = await context.newPage();
     return { context, page };
 }
@@ -863,7 +1078,7 @@ git commit -m "test(rbac): actingAs fixture (per-user browser context)"
 
 **Interfaces:**
 
-- Consumes: `actingAs`. Asserts the harness produces *differently-scoped* sessions by checking the admin
+- Consumes: `actingAs`. Asserts the harness produces _differently-scoped_ sessions by checking the admin
   dashboard for two users.
 
 - [ ] **Step 1: Write the spec (the deliverable)**
@@ -872,7 +1087,9 @@ git commit -m "test(rbac): actingAs fixture (per-user browser context)"
 import { test, expect } from '@playwright/test';
 import { actingAs } from './support/actingAs';
 
-test('super-admin sees the admin section; cei-editor does not', async ({ browser }) => {
+test('super-admin sees the admin section; cei-editor does not', async ({
+    browser,
+}) => {
     const sa = await actingAs(browser, 'super-admin');
     await sa.page.goto('/admin-dashboard.php');
     // super-admin sees the admin-only section (Users/Permissions); use a stable selector present only for admins
@@ -884,7 +1101,9 @@ test('super-admin sees the admin section; cei-editor does not', async ({ browser
     // a calendar_editor (non-admin) must NOT see the admin-only Users link
     await expect(ed.page.locator('a[href="admin-users.php"]')).toHaveCount(0);
     // but DOES see editor cards (e.g. National)
-    await expect(ed.page.locator('.admin-block[data-block-id="national"]')).toBeVisible();
+    await expect(
+        ed.page.locator('.admin-block[data-block-id="national"]'),
+    ).toBeVisible();
     await ed.context.close();
 });
 ```

--- a/docs/superpowers/plans/2026-06-21-scoped-admin-review.md
+++ b/docs/superpowers/plans/2026-06-21-scoped-admin-review.md
@@ -65,12 +65,12 @@ Frontend (`/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarF
   `listObjects(string $user, string $relation, string $type): array` (returns object IDs without type prefix, throws `\RuntimeException` on transport failure)
   and `check(string $user, string $relation, string $object): bool` (throws `\RuntimeException` on transport failure).
 - Produces (relied on by Tasks 2, 3, 4):
-  - `public const ADMIN_OBJECT_TYPES = ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'];`
-  - `__construct(OpenFgaClient $fgaClient)`
-  - `resolveScopes(string $sub): array` → returns `list<array{object_type: string, object_id: string}>`; fail-closed `[]` on any `\RuntimeException`.
-  - `filterByAdminAccess(array $requests, string $adminUserId): array` → returns the subset of `$requests` whose every permission targets a
-    resource the admin holds `admin` on; excludes empty-permission requests. Does NOT catch `\RuntimeException` (behavior-preserving).
-  - `administersAllResources(array $permissions, string $fgaUser, array &$cache): bool` → predicate; `$cache` is a by-reference `array<string, bool>` of `"{type}:{id}" => bool`.
+    - `public const ADMIN_OBJECT_TYPES = ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'];`
+    - `__construct(OpenFgaClient $fgaClient)`
+    - `resolveScopes(string $sub): array` → returns `list<array{object_type: string, object_id: string}>`; fail-closed `[]` on any `\RuntimeException`.
+    - `filterByAdminAccess(array $requests, string $adminUserId): array` → returns the subset of `$requests` whose every permission targets a
+      resource the admin holds `admin` on; excludes empty-permission requests. Does NOT catch `\RuntimeException` (behavior-preserving).
+    - `administersAllResources(array $permissions, string $fgaUser, array &$cache): bool` → predicate; `$cache` is a by-reference `array<string, bool>` of `"{type}:{id}" => bool`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1169,11 +1169,11 @@ git commit -m "feat(api): scope GET /admin/notifications for resource-admins"
 - Consumes: `GuzzleHttp\Client` (already a dependency), `$_COOKIE['litcal_access_token']`, `$_COOKIE['litcal_id_token']`,
   `LiturgicalCalendar\Frontend\ApiConfig::getInstance()->apiBaseUrl` (initialized in `includes/common.php`).
 - Produces (relied on by Tasks 7, 8):
-  - `public function isResourceAdmin(): bool`
-  - `public function adminScopes(): array` → `list<array{object_type: string, object_id: string}>`
-  - `public static function fetchAdminScopes(string $apiBaseUrl, ?string $cookieHeader, ?\GuzzleHttp\Client $client = null): array` →
-    `array{is_resource_admin: bool, admin_scopes: list<array{object_type: string, object_id: string}>}`;
-    fail-closed `['is_resource_admin' => false, 'admin_scopes' => []]` on any error.
+    - `public function isResourceAdmin(): bool`
+    - `public function adminScopes(): array` → `list<array{object_type: string, object_id: string}>`
+    - `public static function fetchAdminScopes(string $apiBaseUrl, ?string $cookieHeader, ?\GuzzleHttp\Client $client = null): array` →
+      `array{is_resource_admin: bool, admin_scopes: list<array{object_type: string, object_id: string}>}`;
+      fail-closed `['is_resource_admin' => false, 'admin_scopes' => []]` on any error.
 
 - [ ] **Step 1: Add the frontend test autoloading + PHPUnit config**
 
@@ -1639,27 +1639,27 @@ In `admin-permissions.php`, in the `window.AdminPermissionsConfig` object litera
 In `assets/js/admin-permissions.js`, replace line 30:
 
 ```javascript
-    const grantModal = new bootstrap.Modal(document.getElementById('grantModal'));
+const grantModal = new bootstrap.Modal(document.getElementById('grantModal'));
 ```
 
 with:
 
 ```javascript
-    const grantModalEl = document.getElementById('grantModal');
-    const grantModal = grantModalEl ? new bootstrap.Modal(grantModalEl) : null;
+const grantModalEl = document.getElementById('grantModal');
+const grantModal = grantModalEl ? new bootstrap.Modal(grantModalEl) : null;
 ```
 
 and replace line 90:
 
 ```javascript
-    const revokeModal = new bootstrap.Modal(document.getElementById('revokeModal'));
+const revokeModal = new bootstrap.Modal(document.getElementById('revokeModal'));
 ```
 
 with:
 
 ```javascript
-    const revokeModalEl = document.getElementById('revokeModal');
-    const revokeModal = revokeModalEl ? new bootstrap.Modal(revokeModalEl) : null;
+const revokeModalEl = document.getElementById('revokeModal');
+const revokeModal = revokeModalEl ? new bootstrap.Modal(revokeModalEl) : null;
 ```
 
 - [ ] **Step 6: Skip the FGA event-listener + load init for resource-admins**
@@ -1668,24 +1668,63 @@ In `assets/js/admin-permissions.js`, wrap the FGA event-listener registration an
 through the `loadUserMap().then(loadPermissions);` line, lines ~493–519) in a global-admin guard. Replace:
 
 ```javascript
-    // Event listeners
-    refreshBtn.addEventListener('click', async function() {
+// Event listeners
+refreshBtn.addEventListener('click', async function () {
+    const icon = this.querySelector('i');
+    icon.classList.add('fa-spin');
+    // Refresh user map first so newly-granted-to users appear with friendly names.
+    await loadUserMap();
+    loadPermissions().finally(function () {
+        icon.classList.remove('fa-spin');
+    });
+});
+
+grantPermissionBtn.addEventListener('click', openGrantModal);
+grantObjectType.addEventListener('change', (e) =>
+    syncObjectIdField(e.target.value),
+);
+confirmGrantBtn.addEventListener('click', handleGrant);
+confirmRevokeBtn.addEventListener('click', handleRevoke);
+applyFiltersBtn.addEventListener('click', loadPermissions);
+
+clearFiltersBtn.addEventListener('click', function () {
+    filterUser.value = '';
+    filterObjectType.value = '';
+    filterObjectId.value = '';
+    filterRelation.value = '';
+    loadPermissions();
+});
+
+// Load user map and then permissions on page load
+loadUserMap().then(loadPermissions);
+```
+
+with:
+
+```javascript
+// Event listeners — the FGA permission-tuple management section is
+// global-admin-only; its DOM is absent for resource-admins, so skip its
+// wiring and initial load entirely.
+if (config.isGlobalAdmin) {
+    refreshBtn.addEventListener('click', async function () {
         const icon = this.querySelector('i');
         icon.classList.add('fa-spin');
         // Refresh user map first so newly-granted-to users appear with friendly names.
         await loadUserMap();
-        loadPermissions().finally(function() {
+        loadPermissions().finally(function () {
             icon.classList.remove('fa-spin');
         });
     });
 
     grantPermissionBtn.addEventListener('click', openGrantModal);
-    grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
+    grantObjectType.addEventListener('change', (e) =>
+        syncObjectIdField(e.target.value),
+    );
     confirmGrantBtn.addEventListener('click', handleGrant);
     confirmRevokeBtn.addEventListener('click', handleRevoke);
     applyFiltersBtn.addEventListener('click', loadPermissions);
 
-    clearFiltersBtn.addEventListener('click', function() {
+    clearFiltersBtn.addEventListener('click', function () {
         filterUser.value = '';
         filterObjectType.value = '';
         filterObjectId.value = '';
@@ -1695,42 +1734,7 @@ through the `loadUserMap().then(loadPermissions);` line, lines ~493–519) in a 
 
     // Load user map and then permissions on page load
     loadUserMap().then(loadPermissions);
-```
-
-with:
-
-```javascript
-    // Event listeners — the FGA permission-tuple management section is
-    // global-admin-only; its DOM is absent for resource-admins, so skip its
-    // wiring and initial load entirely.
-    if (config.isGlobalAdmin) {
-        refreshBtn.addEventListener('click', async function() {
-            const icon = this.querySelector('i');
-            icon.classList.add('fa-spin');
-            // Refresh user map first so newly-granted-to users appear with friendly names.
-            await loadUserMap();
-            loadPermissions().finally(function() {
-                icon.classList.remove('fa-spin');
-            });
-        });
-
-        grantPermissionBtn.addEventListener('click', openGrantModal);
-        grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
-        confirmGrantBtn.addEventListener('click', handleGrant);
-        confirmRevokeBtn.addEventListener('click', handleRevoke);
-        applyFiltersBtn.addEventListener('click', loadPermissions);
-
-        clearFiltersBtn.addEventListener('click', function() {
-            filterUser.value = '';
-            filterObjectType.value = '';
-            filterObjectId.value = '';
-            filterRelation.value = '';
-            loadPermissions();
-        });
-
-        // Load user map and then permissions on page load
-        loadUserMap().then(loadPermissions);
-    }
+}
 ```
 
 - [ ] **Step 7: PHP lint + JS syntax check + ESLint**

--- a/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-foundation.md
+++ b/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-foundation.md
@@ -36,19 +36,19 @@ frontend's `/auth/access-requests` + `/admin/access-requests` endpoints. Folds i
 ## Reference: existing harness interfaces (verified 2026-06-22)
 
 - `users.ts`: `RbacUser = { id, email, password, role: 'admin'|'calendar_editor', fga: { relation:
-  'admin'|'editor', objectType, objectId } | null }`; `USERS` (11 users); `REGISTRATION_USER_IDS =
-  ['cei-admin','usccb-editor']`; `SEEDED_USER_IDS = Object.keys(USERS).filter(id => !REGISTRATION_USER_IDS.includes(id))`.
+'admin'|'editor', objectType, objectId } | null }`; `USERS` (11 users); `REGISTRATION_USER_IDS =
+['cei-admin','usccb-editor']`; `SEEDED_USER_IDS = Object.keys(USERS).filter(id => !REGISTRATION_USER_IDS.includes(id))`.
 - `seed.ts`: `seedUser(id: string): Promise<string>` — deletes existing, `createVerifiedUser`,
   `grantProjectRole(userId, role)`, and **if `u.fga` writes the tuple** (this is what Task 1 changes);
   `oidcLogin(email, password, loginClientToken): Promise<string>`; `loginAndSaveState(id, loginClientToken):
-  Promise<void>` (writes `e2e/.auth/<id>.json`).
+Promise<void>` (writes `e2e/.auth/<id>.json`).
 - `fga.ts`: `class Fga { write(user, relation, object): Promise<void>; delete(user, relation, object):
-  Promise<void> (tolerates not-found); check(user, relation, object): Promise<boolean> }`. `object` form is
+Promise<void> (tolerates not-found); check(user, relation, object): Promise<boolean> }`. `object` form is
   `"{type}:{id}"`, `user` form is `"user:{zitadelId}"`.
 - `zitadel.ts`: `class ZitadelAdmin { createVerifiedUser({email,password,firstName,lastName}): Promise<string>;
-  findUserIdByEmail(email): Promise<string|null>; findUserIdByUsername(userName): Promise<string|null>;
-  grantProjectRole(userId, role): Promise<void>; deleteUser(userId): Promise<void>; mintPat(userId):
-  Promise<{tokenId, token}>; deletePat(userId, tokenId): Promise<void> }`. Private `req(method, path, body?)`.
+findUserIdByEmail(email): Promise<string|null>; findUserIdByUsername(userName): Promise<string|null>;
+grantProjectRole(userId, role): Promise<void>; deleteUser(userId): Promise<void>; mintPat(userId):
+Promise<{tokenId, token}>; deletePat(userId, tokenId): Promise<void> }`. Private `req(method, path, body?)`.
 - `actingAs.ts`: `actingAs(browser, userId): Promise<{ context: BrowserContext, page: Page }>` — builds a
   context from `e2e/.auth/<userId>.json`.
 - `cleanup.ts`: `truncateAppTables(): Promise<void>` (TRUNCATE access_requests, audit_log,
@@ -112,7 +112,13 @@ test('seedUser grants role for all; writes FGA tuple only for admins', async () 
     const e = USERS['cei-editor'].fga!;
     try {
         expect(editorId).toMatch(/^\d+$/);
-        expect(await f.check(`user:${editorId}`, e.relation, `${e.objectType}:${e.objectId}`)).toBe(false);
+        expect(
+            await f.check(
+                `user:${editorId}`,
+                e.relation,
+                `${e.objectType}:${e.objectId}`,
+            ),
+        ).toBe(false);
     } finally {
         await z.deleteUser(editorId).catch(() => {});
     }
@@ -121,10 +127,22 @@ test('seedUser grants role for all; writes FGA tuple only for admins', async () 
     const adminId = await seedUser('usccb-admin');
     const a = USERS['usccb-admin'].fga!;
     try {
-        expect(await f.check(`user:${adminId}`, a.relation, `${a.objectType}:${a.objectId}`)).toBe(true);
+        expect(
+            await f.check(
+                `user:${adminId}`,
+                a.relation,
+                `${a.objectType}:${a.objectId}`,
+            ),
+        ).toBe(true);
     } finally {
         await z.deleteUser(adminId).catch(() => {});
-        await f.delete(`user:${adminId}`, a.relation, `${a.objectType}:${a.objectId}`).catch(() => {});
+        await f
+            .delete(
+                `user:${adminId}`,
+                a.relation,
+                `${a.objectType}:${a.objectId}`,
+            )
+            .catch(() => {});
     }
 });
 ```
@@ -142,18 +160,27 @@ Operations" section first.)
 In `e2e/rbac/support/seed.ts`, change the tuple-write line in `seedUser` from:
 
 ```ts
-    if (u.fga) await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
+if (u.fga)
+    await f.write(
+        `user:${userId}`,
+        u.fga.relation,
+        `${u.fga.objectType}:${u.fga.objectId}`,
+    );
 ```
 
 to:
 
 ```ts
-    // Seed the FGA tuple only for resource-admins. Editor grants are earned via the
-    // request-access UI in scenarios (the approval outcome), seeded per-spec where a
-    // scenario needs the grant as a precondition (see support/grant.ts).
-    if (u.fga?.relation === 'admin') {
-        await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
-    }
+// Seed the FGA tuple only for resource-admins. Editor grants are earned via the
+// request-access UI in scenarios (the approval outcome), seeded per-spec where a
+// scenario needs the grant as a precondition (see support/grant.ts).
+if (u.fga?.relation === 'admin') {
+    await f.write(
+        `user:${userId}`,
+        u.fga.relation,
+        `${u.fga.objectType}:${u.fga.objectId}`,
+    );
+}
 ```
 
 - [ ] **Step 4: Run the test to verify it passes**
@@ -186,12 +213,12 @@ git commit -m "test(rbac): seed FGA tuples for admins only; editors earn grants 
 
 - Consumes: `Fga`, `ZitadelAdmin`, `USERS`, `findUserIdByEmail`.
 - Produces (relied on by every scenario spec):
-  - `grantScope(userKey: string, opts?: { role?: boolean }): Promise<void>` — write the FGA tuple defined for
-    `USERS[userKey].fga` for the currently-seeded Zitadel user with that email, and (default) ensure the
-    project role is granted. Idempotent (tolerant of "already exists").
-  - `revokeScope(userKey: string): Promise<void>` — delete that tuple (tolerant of "not found").
-  - `grantTuple(zitadelUserId: string, relation: string, objectType: string, objectId: string):
-    Promise<void>` — low-level write for ad-hoc tuples.
+    - `grantScope(userKey: string, opts?: { role?: boolean }): Promise<void>` — write the FGA tuple defined for
+      `USERS[userKey].fga` for the currently-seeded Zitadel user with that email, and (default) ensure the
+      project role is granted. Idempotent (tolerant of "already exists").
+    - `revokeScope(userKey: string): Promise<void>` — delete that tuple (tolerant of "not found").
+    - `grantTuple(zitadelUserId: string, relation: string, objectType: string, objectId: string):
+Promise<void>` — low-level write for ad-hoc tuples.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -205,22 +232,42 @@ import { Fga } from './fga';
 import { ZitadelAdmin } from './zitadel';
 import { USERS } from './users';
 
-test('grantScope writes the user\'s defined tuple; revokeScope removes it', async () => {
+test("grantScope writes the user's defined tuple; revokeScope removes it", async () => {
     const f = new Fga();
     const z = new ZitadelAdmin();
     // cei-editor is seeded WITHOUT its tuple (Task 1). grantScope adds it as a precondition.
     const id = await seedUser('cei-editor');
     const u = USERS['cei-editor'].fga!;
     try {
-        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(false);
+        expect(
+            await f.check(
+                `user:${id}`,
+                u.relation,
+                `${u.objectType}:${u.objectId}`,
+            ),
+        ).toBe(false);
         await grantScope('cei-editor');
-        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(true);
+        expect(
+            await f.check(
+                `user:${id}`,
+                u.relation,
+                `${u.objectType}:${u.objectId}`,
+            ),
+        ).toBe(true);
         await grantScope('cei-editor'); // idempotent — must not throw
         await revokeScope('cei-editor');
-        expect(await f.check(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)).toBe(false);
+        expect(
+            await f.check(
+                `user:${id}`,
+                u.relation,
+                `${u.objectType}:${u.objectId}`,
+            ),
+        ).toBe(false);
     } finally {
         await z.deleteUser(id).catch(() => {});
-        await f.delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`).catch(() => {});
+        await f
+            .delete(`user:${id}`, u.relation, `${u.objectType}:${u.objectId}`)
+            .catch(() => {});
     }
 });
 ```
@@ -243,15 +290,26 @@ import { USERS } from './users';
  * Per-spec precondition seeding. Editors are not granted at setup (see seed.ts), so a
  * scenario that needs a user to already hold their scope seeds it here. Idempotent.
  */
-export async function grantScope(userKey: string, opts: { role?: boolean } = {}): Promise<void> {
+export async function grantScope(
+    userKey: string,
+    opts: { role?: boolean } = {},
+): Promise<void> {
     const u = USERS[userKey];
     if (!u?.fga) throw new Error(`grantScope: ${userKey} has no fga scope`);
     const z = new ZitadelAdmin();
     const f = new Fga();
     const zid = await z.findUserIdByEmail(u.email);
-    if (!zid) throw new Error(`grantScope: ${userKey} (${u.email}) is not seeded in Zitadel`);
-    if (opts.role !== false) await z.grantProjectRole(zid, u.role).catch(() => {}); // tolerate already-granted
-    await f.write(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`); // write tolerates dup
+    if (!zid)
+        throw new Error(
+            `grantScope: ${userKey} (${u.email}) is not seeded in Zitadel`,
+        );
+    if (opts.role !== false)
+        await z.grantProjectRole(zid, u.role).catch(() => {}); // tolerate already-granted
+    await f.write(
+        `user:${zid}`,
+        u.fga.relation,
+        `${u.fga.objectType}:${u.fga.objectId}`,
+    ); // write tolerates dup
 }
 
 export async function revokeScope(userKey: string): Promise<void> {
@@ -261,13 +319,26 @@ export async function revokeScope(userKey: string): Promise<void> {
     const f = new Fga();
     const zid = await z.findUserIdByEmail(u.email);
     if (!zid) return;
-    await f.delete(`user:${zid}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`).catch(() => {});
+    await f
+        .delete(
+            `user:${zid}`,
+            u.fga.relation,
+            `${u.fga.objectType}:${u.fga.objectId}`,
+        )
+        .catch(() => {});
 }
 
 export async function grantTuple(
-    zitadelUserId: string, relation: string, objectType: string, objectId: string,
+    zitadelUserId: string,
+    relation: string,
+    objectType: string,
+    objectId: string,
 ): Promise<void> {
-    await new Fga().write(`user:${zitadelUserId}`, relation, `${objectType}:${objectId}`);
+    await new Fga().write(
+        `user:${zitadelUserId}`,
+        relation,
+        `${objectType}:${objectId}`,
+    );
 }
 ```
 
@@ -281,7 +352,7 @@ Expected: PASS.
 
 - [ ] **Step 5: Typecheck + lint**
 
-Run: `yarn typecheck && yarn lint`  → exit 0.
+Run: `yarn typecheck && yarn lint` → exit 0.
 
 - [ ] **Step 6: Commit**
 
@@ -304,9 +375,9 @@ git commit -m "feat(rbac): grant.ts per-spec precondition seeding helper"
   (`input[name="requested_role"]`, `#permissionsSection`, the add-permission controls, the submit button),
   which POSTs to `/auth/access-requests`.
 - Produces (relied on by scenario specs):
-  - `submitAccessRequest(page: Page, opts: { requestedRole: string; permission: { objectType: string;
-    objectId: string; relation: 'admin'|'editor' }; justification?: string }): Promise<void>` — drives the
-    permission-requests UI to submit one scoped request and resolves once the success state is visible.
+    - `submitAccessRequest(page: Page, opts: { requestedRole: string; permission: { objectType: string;
+objectId: string; relation: 'admin'|'editor' }; justification?: string }): Promise<void>` — drives the
+      permission-requests UI to submit one scoped request and resolves once the success state is visible.
 
 This helper drives the real UI (the design's chosen mechanism). The dynamic permission-builder field
 selectors (the add-permission row, the object-type/object-id/relation inputs, the submit button) must be
@@ -364,10 +435,10 @@ git commit -m "feat(rbac): requestAccess.ts — submit a pending request via the
 
 - Consumes: the Mailpit REST API (`GET /api/v1/messages`, `GET /api/v1/message/{ID}`), `MAILPIT_API_URL`.
 - Produces (relied on by scenarios 01/04):
-  - `waitForVerificationLink(toEmail: string, opts?: { timeoutMs?: number }): Promise<string>` — poll Mailpit
-    for the newest message to `toEmail`, extract the Zitadel verification URL from its body, return it. Throws
-    on timeout. Injectable fetch for the unit test: `waitForVerificationLink(toEmail, { fetchImpl })`.
-  - `latestMessageTo(toEmail: string, fetchImpl?): Promise<{ id: string; html: string; text: string } | null>`.
+    - `waitForVerificationLink(toEmail: string, opts?: { timeoutMs?: number }): Promise<string>` — poll Mailpit
+      for the newest message to `toEmail`, extract the Zitadel verification URL from its body, return it. Throws
+      on timeout. Injectable fetch for the unit test: `waitForVerificationLink(toEmail, { fetchImpl })`.
+    - `latestMessageTo(toEmail: string, fetchImpl?): Promise<{ id: string; html: string; text: string } | null>`.
 
 - [ ] **Step 1: Confirm the Mailpit base URL**
 
@@ -386,18 +457,38 @@ import { test, expect } from '@playwright/test';
 import { waitForVerificationLink } from './mailpit';
 
 test('waitForVerificationLink extracts the verification URL from the newest message', async () => {
-    const verifyUrl = 'http://localhost:8080/ui/v2/login/verify?code=ABC&userID=42';
+    const verifyUrl =
+        'http://localhost:8080/ui/v2/login/verify?code=ABC&userID=42';
     const fetchImpl = (async (url: string) => {
         if (url.includes('/api/v1/messages')) {
-            return new Response(JSON.stringify({ messages: [{ ID: 'm1', To: [{ Address: 'cei-admin+e2e@litcal.test' }] }] }), { status: 200 });
+            return new Response(
+                JSON.stringify({
+                    messages: [
+                        {
+                            ID: 'm1',
+                            To: [{ Address: 'cei-admin+e2e@litcal.test' }],
+                        },
+                    ],
+                }),
+                { status: 200 },
+            );
         }
         if (url.includes('/api/v1/message/m1')) {
-            return new Response(JSON.stringify({ HTML: `<a href="${verifyUrl}">Verify</a>`, Text: '' }), { status: 200 });
+            return new Response(
+                JSON.stringify({
+                    HTML: `<a href="${verifyUrl}">Verify</a>`,
+                    Text: '',
+                }),
+                { status: 200 },
+            );
         }
         return new Response('not found', { status: 404 });
     }) as unknown as typeof fetch;
 
-    const link = await waitForVerificationLink('cei-admin+e2e@litcal.test', { fetchImpl, timeoutMs: 1000 });
+    const link = await waitForVerificationLink('cei-admin+e2e@litcal.test', {
+        fetchImpl,
+        timeoutMs: 1000,
+    });
     expect(link).toBe(verifyUrl);
 });
 ```
@@ -444,13 +535,13 @@ git commit -m "feat(rbac): mailpit.ts verification-email retrieval"
 
 - Consumes: `Fga`, `ZitadelAdmin`, `USERS`, `execFile` (already used in `cleanup.ts`).
 - Produces:
-  - `deleteAllSeededUsers()` — extended so it deletes **every** FGA tuple a user could hold (both `admin` and
-    `editor` relations from the matrix), not only the matrix-defined one, since scenarios create editor tuples
-    dynamically. Implementation: for each seeded user, attempt `f.delete` for their matrix tuple (tolerant),
-    then delete the Zitadel user.
-  - `gitRestoreApiData(): Promise<void>` (NEW) — restore the API repo's calendar source data after scenario 10
-    edits it, via `git -C <API_REPO> checkout -- jsondata/sourcedata` (path confirmed in Step 1). 30s timeout,
-    tolerant of "nothing to restore".
+    - `deleteAllSeededUsers()` — extended so it deletes **every** FGA tuple a user could hold (both `admin` and
+      `editor` relations from the matrix), not only the matrix-defined one, since scenarios create editor tuples
+      dynamically. Implementation: for each seeded user, attempt `f.delete` for their matrix tuple (tolerant),
+      then delete the Zitadel user.
+    - `gitRestoreApiData(): Promise<void>` (NEW) — restore the API repo's calendar source data after scenario 10
+      edits it, via `git -C <API_REPO> checkout -- jsondata/sourcedata` (path confirmed in Step 1). 30s timeout,
+      tolerant of "nothing to restore".
 
 - [ ] **Step 1: Confirm the API source-data path + restore command**
 

--- a/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-scenarios.md
+++ b/docs/superpowers/plans/2026-06-22-rbac-e2e-phase2-scenarios.md
@@ -66,10 +66,12 @@ test.afterEach(async () => {
 - "FGA tuple + role now exist for user U at scope" — resolve the Zitadel id by email, then assert the tuple
   (`.toBe(true)`; after revoke, `.toBe(false)`):
 
-  ```ts
-  const zid = await new ZitadelAdmin().findUserIdByEmail(USERS[U].email);
-  expect(await new Fga().check(`user:${zid}`, relation, `${type}:${id}`)).toBe(true);
-  ```
+    ```ts
+    const zid = await new ZitadelAdmin().findUserIdByEmail(USERS[U].email);
+    expect(
+        await new Fga().check(`user:${zid}`, relation, `${type}:${id}`),
+    ).toBe(true);
+    ```
 
 - "Request has status S in the list" → `requestVisible(page, { requesterEmail, status: S })` (the review list
   supports a status filter via `GET /admin/access-requests?status=...`).
@@ -88,15 +90,15 @@ test.afterEach(async () => {
   (`loadAccessRequests()` → `GET /admin/access-requests`; the review list container; per-request rows;
   `#permReqReviewModal` with `#permReqDetails`, `#permReqNotesSection` (the notes textarea),
   `#permReqModalAlerts`; the approve/reject/revoke buttons; `processAccessReq(action)` → `POST
-  /admin/access-requests/{id}/{action}` with `notes`).
+/admin/access-requests/{id}/{action}` with `notes`).
 - Produces (relied on by Tasks 2–13):
-  - `requestVisible(page: Page, q: { requesterEmail: string; status?: string }): Promise<boolean>` — navigate/
-    reload the review list (optionally with the status filter) and return whether a row for that requester is
-    present.
-  - `findRequestRow(page: Page, q: { requesterEmail: string }): Promise<Locator>` — the row locator.
-  - `actOnRequest(page: Page, q: { requesterEmail: string; action: 'approve'|'reject'|'revoke'; notes?:
-    string }): Promise<void>` — open the row's review modal, fill notes if given, click the action button,
-    and await the success state + list refresh.
+    - `requestVisible(page: Page, q: { requesterEmail: string; status?: string }): Promise<boolean>` — navigate/
+      reload the review list (optionally with the status filter) and return whether a row for that requester is
+      present.
+    - `findRequestRow(page: Page, q: { requesterEmail: string }): Promise<Locator>` — the row locator.
+    - `actOnRequest(page: Page, q: { requesterEmail: string; action: 'approve'|'reject'|'revoke'; notes?:
+string }): Promise<void>` — open the row's review modal, fill notes if given, click the action button,
+      and await the success state + list refresh.
 
 - [ ] **Step 1: Pin the review-UI selectors**
 
@@ -152,7 +154,7 @@ present as a Zitadel account in this independent spec, create+login it first via
 Then:
 
 1. `actingAs('cei-editor')` → `submitAccessRequest(page, { requestedRole: 'calendar_editor', permission: {
-   objectType: 'national_calendar', objectId: 'IT', relation: 'editor' } })`.
+objectType: 'national_calendar', objectId: 'IT', relation: 'editor' } })`.
 2. Assert visibility: act as `super-admin` → `requestVisible(cei-editor)` true; act as `cei-admin` →
    `requestVisible(cei-editor)` true; act as `usccb-admin` → `requestVisible(cei-editor)` **false**.
 3. `cei-admin` rejects: `actOnRequest({ requesterEmail: cei-editor, action: 'reject', notes: 'fix scope' })`.
@@ -190,9 +192,9 @@ git commit -m "test(rbac): 02 — cei-editor edit@IT scoped review lifecycle"
 - Consumes: the registration entry point (from `request-access.php`/login — pinned in Step 1), `mailpit.ts`
   `waitForVerificationLink`, the cross-org env (`ZITADEL_ORG_ID`, org-domain-suffix login-name setting).
 - Produces (relied on by scenarios 01/04):
-  - `registerAndVerify(page: Page, user: { email: string; password: string; firstName: string; lastName:
-    string }): Promise<void>` — drive the Zitadel self-registration UI, retrieve the verification link from
-    Mailpit, complete verification, and leave the user able to log in.
+    - `registerAndVerify(page: Page, user: { email: string; password: string; firstName: string; lastName:
+string }): Promise<void>` — drive the Zitadel self-registration UI, retrieve the verification link from
+      Mailpit, complete verification, and leave the user able to log in.
 
 - [ ] **Step 1: Pin the registration flow**
 
@@ -203,11 +205,11 @@ given/family name), the submit control, and how the Zitadel verification email's
 email pattern `<id>+e2e@litcal.test`. Record as a header comment.
 
 - [ ] **Step 2: Implement `register.ts`** using the pinned selectors + `waitForVerificationLink(email)` to
-  fetch + visit/complete the verification link.
+      fetch + visit/complete the verification link.
 
 - [ ] **Step 3: Smoke-validate** in a temp spec: `registerAndVerify(page, USERS['cei-admin'])` then assert the
-  user can log in (e.g. `oidcLogin` succeeds, or `findUserIdByEmail` returns an id and a login lands an
-  authenticated `/auth/me.php`). Run → PASS. Delete temp spec. Clean up the created user.
+      user can log in (e.g. `oidcLogin` succeeds, or `findUserIdByEmail` returns an id and a login lands an
+      authenticated `/auth/me.php`). Run → PASS. Delete temp spec. Clean up the created user.
 
 - [ ] **Step 4: Typecheck + lint + commit**
 
@@ -229,7 +231,7 @@ git commit -m "feat(rbac): register.ts — Zitadel self-registration + Mailpit v
 
 1. `registerAndVerify(page, USERS['cei-admin'])`; log in (save state or drive login UI).
 2. As cei-admin, `submitAccessRequest(page, { requestedRole: 'calendar_editor', permission: { objectType:
-   'national_calendar', objectId: 'IT', relation: 'admin' } })`.
+'national_calendar', objectId: 'IT', relation: 'admin' } })`.
 3. Assert **only `super-admin`** sees it (cei-admin is not yet an IT admin): act as `super-admin` →
    `requestVisible(cei-admin)` true; act as `usccb-admin` → false. (cei-admin cannot review their own request
    into existence — they have no admin tuple yet.)
@@ -239,7 +241,7 @@ git commit -m "feat(rbac): register.ts — Zitadel self-registration + Mailpit v
 `afterEach`: `truncateAppTables()`; delete the cei-admin Zitadel user + its tuple (it was created in-spec).
 
 - [ ] **Step 2: Run** `yarn test --project=rbac e2e/rbac/01-cei-admin-register-request.spec.ts` → PASS
-  (iterate; registration is the most timing-sensitive — allow Mailpit polling).
+      (iterate; registration is the most timing-sensitive — allow Mailpit polling).
 
 - [ ] **Step 3: Typecheck + lint + commit**
 
@@ -254,16 +256,16 @@ git commit -m "test(rbac): 01 — cei-admin registration + admin@IT request life
 
 **Files:** Create `e2e/rbac/03-usccb-admin-request.spec.ts`
 
-- [ ] **Step 1: Write the spec.** usccb-admin is a seeded resource-admin (already admin@US). For a *pending*
-  admin@US **request**, use a not-yet-US-admin requester (per the original design's intent, usccb-admin
-  requesting *additional* admin scope; if that's not meaningful, request as a fresh applicant for admin@US).
-  Concretely: act as a seeded editor without US scope (e.g. `grc-editor`) and
-  `submitAccessRequest(... admin@national_calendar:US)`. Assert **`cei-admin` does NOT see it** (IT admin),
-  only `super-admin` does → `super-admin` approves → assert the tuple now exists for the requester.
-  `afterEach`: truncate + revoke the requester's US tuple.
+- [ ] **Step 1: Write the spec.** usccb-admin is a seeded resource-admin (already admin@US). For a _pending_
+      admin@US **request**, use a not-yet-US-admin requester (per the original design's intent, usccb-admin
+      requesting _additional_ admin scope; if that's not meaningful, request as a fresh applicant for admin@US).
+      Concretely: act as a seeded editor without US scope (e.g. `grc-editor`) and
+      `submitAccessRequest(... admin@national_calendar:US)`. Assert **`cei-admin` does NOT see it** (IT admin),
+      only `super-admin` does → `super-admin` approves → assert the tuple now exists for the requester.
+      `afterEach`: truncate + revoke the requester's US tuple.
 
-  (Resolve the "who requests admin@US" requester during impl so the request is in-scope for usccb-admin/
-  super-admin but out-of-scope for cei-admin — the assertion target is the cei-admin-can't-see scoping.)
+    (Resolve the "who requests admin@US" requester during impl so the request is in-scope for usccb-admin/
+    super-admin but out-of-scope for cei-admin — the assertion target is the cei-admin-can't-see scoping.)
 
 - [ ] **Step 2: Run → PASS.**
 - [ ] **Step 3: commit** `test(rbac): 03 — admin@USA request not visible to cei-admin`.
@@ -275,9 +277,9 @@ git commit -m "test(rbac): 01 — cei-admin registration + admin@IT request life
 **Files:** Create `e2e/rbac/04-usccb-editor-register-request.spec.ts`
 
 - [ ] **Step 1: Write the spec.** Precondition: seed `usccb-admin = admin@US` (already seeded at setup).
-  `registerAndVerify(page, USERS['usccb-editor'])` (registration user) → request `edit@US` → assert
-  `usccb-admin` + `super-admin` see it, `cei-admin` does not → `usccb-admin` grants → assert tuple+role exist
-  → `super-admin` sees the grant. `afterEach`: truncate + delete usccb-editor user/tuple.
+      `registerAndVerify(page, USERS['usccb-editor'])` (registration user) → request `edit@US` → assert
+      `usccb-admin` + `super-admin` see it, `cei-admin` does not → `usccb-admin` grants → assert tuple+role exist
+      → `super-admin` sees the grant. `afterEach`: truncate + delete usccb-editor user/tuple.
 - [ ] **Step 2: Run → PASS.**
 - [ ] **Step 3: commit** `test(rbac): 04 — usccb-editor registration + edit@USA grant`.
 
@@ -288,7 +290,7 @@ git commit -m "test(rbac): 01 — cei-admin registration + admin@IT request life
 **Files:** Create `e2e/rbac/05-rome-admin-request.spec.ts`
 
 - [ ] **Step 1:** Pending admin@`diocesan_calendar:romamo_it` request (requester per the same pattern as Task
-  5). Assert only `super-admin` sees it → grants → tuple exists. `afterEach`: truncate + revoke.
+      5). Assert only `super-admin` sees it → grants → tuple exists. `afterEach`: truncate + revoke.
 - [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 05 — admin@romamo_it request, super-admin only`.
 
 ---
@@ -298,8 +300,8 @@ git commit -m "test(rbac): 01 — cei-admin registration + admin@IT request life
 **Files:** Create `e2e/rbac/06-rome-editor-request.spec.ts`
 
 - [ ] **Step 1:** Precondition `rome-admin = admin@romamo_it` (seeded at setup). `actingAs('rome-editor')` →
-  request `edit@romamo_it` → assert `super-admin` + `rome-admin` see it, `cei-admin`/`usccb-admin` do not →
-  `rome-admin` grants → `super-admin` sees the grant. `afterEach`: truncate + `revokeScope('rome-editor')`.
+      request `edit@romamo_it` → assert `super-admin` + `rome-admin` see it, `cei-admin`/`usccb-admin` do not →
+      `rome-admin` grants → `super-admin` sees the grant. `afterEach`: truncate + `revokeScope('rome-editor')`.
 - [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 06 — rome-editor edit@romamo_it scoped review`.
 
 ---
@@ -312,14 +314,14 @@ git commit -m "test(rbac): 01 — cei-admin registration + admin@IT request life
 to Review" card (from `admin-dashboard.php`/`admin-blocks.php`), `Auth`/page DOM.
 
 - [ ] **Step 1: Pin the card selectors + per-role expectations.** Read `admin-dashboard.php` +
-  `admin-blocks.php`: record each card's `data-block-id`/href and the gating conditional (`$isAdmin`,
-  `$isResourceAdmin`, `$hasCalendarRole`, scope checks). Build the expected per-user matrix: which cards each
-  of `super-admin`, `cei-admin`, `cei-editor`, `usccb-admin`, `grc-admin`, `europe-admin` sees, scope
-  narrowing (National → IT vs USA; Diocesan → romamo_it; GRC; Europe), and that resource-admins see the
-  "Access Requests to Review" card while editors do not and the global FGA-tuple section is hidden.
+      `admin-blocks.php`: record each card's `data-block-id`/href and the gating conditional (`$isAdmin`,
+      `$isResourceAdmin`, `$hasCalendarRole`, scope checks). Build the expected per-user matrix: which cards each
+      of `super-admin`, `cei-admin`, `cei-editor`, `usccb-admin`, `grc-admin`, `europe-admin` sees, scope
+      narrowing (National → IT vs USA; Diocesan → romamo_it; GRC; Europe), and that resource-admins see the
+      "Access Requests to Review" card while editors do not and the global FGA-tuple section is hidden.
 - [ ] **Step 2: Write the spec** asserting the matrix per user (extends the existing
-  `00-smoke-dashboard-scoping.spec.ts` patterns; this is the full matrix). Precondition: `grantScope` for any
-  editor whose card-visibility depends on holding a scope. `afterEach`: revoke those.
+      `00-smoke-dashboard-scoping.spec.ts` patterns; this is the full matrix). Precondition: `grantScope` for any
+      editor whose card-visibility depends on holding a scope. `afterEach`: revoke those.
 - [ ] **Step 3: Run → PASS.** **Step 4: commit** `test(rbac): 07 — dashboard card scoping matrix`.
 
 ---
@@ -329,10 +331,10 @@ to Review" card (from `admin-dashboard.php`/`admin-blocks.php`), `Auth`/page DOM
 **Files:** Create `e2e/rbac/08-negative-auth.spec.ts`
 
 - [ ] **Step 1: Write the spec.** Seed a pending `edit@US` request (requester as in Task 5). As `cei-admin`
-  (IT admin): (a) attempt to approve the US request via the API the UI uses
-  (`POST /admin/access-requests/{id}/approve` through `page.request` with cei-admin's session) → expect 403;
-  (b) assert the US request is **not visible** in cei-admin's review list; (c) attempt to open a USA-scoped
-  dashboard card / edit the USA calendar via `extending.php` → denied/hidden. `afterEach`: truncate + revoke.
+      (IT admin): (a) attempt to approve the US request via the API the UI uses
+      (`POST /admin/access-requests/{id}/approve` through `page.request` with cei-admin's session) → expect 403;
+      (b) assert the US request is **not visible** in cei-admin's review list; (c) attempt to open a USA-scoped
+      dashboard card / edit the USA calendar via `extending.php` → denied/hidden. `afterEach`: truncate + revoke.
 - [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 08 — negative authorization (cei-admin vs USA)`.
 
 ---
@@ -342,12 +344,12 @@ to Review" card (from `admin-dashboard.php`/`admin-blocks.php`), `Auth`/page DOM
 **Files:** Create `e2e/rbac/09-revoke-after-grant.spec.ts`
 
 - [ ] **Step 1: Write the spec.** Precondition: `grantScope('cei-editor')` (cei-editor already edit@IT) and a
-  corresponding approved request row (seed via submit+approve, or seed the approved request). As `cei-admin`
-  (or `super-admin`), `actOnRequest({ requesterEmail: cei-editor, action: 'revoke', notes: 'revoked' })`.
-  Assert: the FGA tuple + role are **removed** (`Fga.check(...) === false`); cei-editor's dashboard cards for
-  IT disappear (act as cei-editor, assert the National-IT card is gone); a `revoked` notification is delivered
-  (assert via cei-editor's notification surface — `/auth/access-requests/status` or the bell — pin during
-  impl). `afterEach`: truncate + ensure tuple removed.
+      corresponding approved request row (seed via submit+approve, or seed the approved request). As `cei-admin`
+      (or `super-admin`), `actOnRequest({ requesterEmail: cei-editor, action: 'revoke', notes: 'revoked' })`.
+      Assert: the FGA tuple + role are **removed** (`Fga.check(...) === false`); cei-editor's dashboard cards for
+      IT disappear (act as cei-editor, assert the National-IT card is gone); a `revoked` notification is delivered
+      (assert via cei-editor's notification surface — `/auth/access-requests/status` or the bell — pin during
+      impl). `afterEach`: truncate + ensure tuple removed.
 - [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 09 — revoke-after-grant lifecycle`.
 
 ---
@@ -359,10 +361,10 @@ to Review" card (from `admin-dashboard.php`/`admin-blocks.php`), `Auth`/page DOM
 **Interfaces:** consumes `grantScope`, `actingAs`, `extending.php` edit flow, `gitRestoreApiData`.
 
 - [ ] **Step 1: Pin the `extending.php` edit flow** (calendar selection, an edit, save, success indicator) for
-  the IT national calendar; confirm the same against USA is blocked for a user scoped only to IT.
+      the IT national calendar; confirm the same against USA is blocked for a user scoped only to IT.
 - [ ] **Step 2: Write the spec.** Precondition `grantScope('cei-editor')` (edit@IT). As cei-editor: edit the
-  IT national calendar via `extending.php` → assert success; attempt the same edit against USA → assert
-  failure (403/hidden). `afterEach`: `truncateAppTables()`; `revokeScope('cei-editor')`; **`gitRestoreApiData()`**.
+      IT national calendar via `extending.php` → assert success; attempt the same edit against USA → assert
+      failure (403/hidden). `afterEach`: `truncateAppTables()`; `revokeScope('cei-editor')`; **`gitRestoreApiData()`**.
 - [ ] **Step 3: Run → PASS** (verify `gitRestoreApiData` reverts the edit — re-run must start clean).
 - [ ] **Step 4: commit** `test(rbac): 10 — scoped data editing (IT ok, USA denied)`.
 
@@ -373,10 +375,10 @@ to Review" card (from `admin-dashboard.php`/`admin-blocks.php`), `Auth`/page DOM
 **Files:** Create `e2e/rbac/11-session-resilience.spec.ts`
 
 - [ ] **Step 1: Write the spec.** (a) Cookie/session expiry + refresh mid-flow: clear/expire the
-  `litcal_access_token` cookie and assert the app refreshes or redirects to re-auth correctly; (b) logout then
-  log in as a different user (act as A, log out, act as B) — assert no stale auth state; (c) a grant/revoke is
-  reflected on the next `/auth/me` without stale caching: `grantScope`/`revokeScope` a user mid-session and
-  assert the change surfaces after a reload. `afterEach`: truncate + revoke any dynamic grants.
+      `litcal_access_token` cookie and assert the app refreshes or redirects to re-auth correctly; (b) logout then
+      log in as a different user (act as A, log out, act as B) — assert no stale auth state; (c) a grant/revoke is
+      reflected on the next `/auth/me` without stale caching: `grantScope`/`revokeScope` a user mid-session and
+      assert the change surfaces after a reload. `afterEach`: truncate + revoke any dynamic grants.
 - [ ] **Step 2: Run → PASS.** **Step 3: commit** `test(rbac): 11 — session/token resilience`.
 
 ---

--- a/docs/superpowers/plans/2026-06-25-permission-request-ui-calendar-scoped.md
+++ b/docs/superpowers/plans/2026-06-25-permission-request-ui-calendar-scoped.md
@@ -43,26 +43,26 @@ gates.
   `LITCAL_LOCALE` / `currentLocale` are existing globals.
 - **Object-type sets must mirror the API verbatim**
   (`AccessRequestRepository::ROLE_OBJECT_TYPES`, post-merge of API PR #666):
-  - `calendar_editor`: `national_calendar`, `diocesan_calendar`, `wider_region`,
-    `general_roman_calendar`
-  - `test_editor`: `national_calendar_test`, `diocesan_calendar_test`,
-    `general_roman_calendar_test`
-  - `developer`: `national_calendar`, `diocesan_calendar`, `wider_region`,
-    `national_calendar_test`, `diocesan_calendar_test`,
-    `general_roman_calendar_test`, `general_roman_calendar`
+    - `calendar_editor`: `national_calendar`, `diocesan_calendar`, `wider_region`,
+      `general_roman_calendar`
+    - `test_editor`: `national_calendar_test`, `diocesan_calendar_test`,
+      `general_roman_calendar_test`
+    - `developer`: `national_calendar`, `diocesan_calendar`, `wider_region`,
+      `national_calendar_test`, `diocesan_calendar_test`,
+      `general_roman_calendar_test`, `general_roman_calendar`
 - **Scope → Calendar ID source:**
-  - `national_calendar`, `national_calendar_test` →
-    `CalendarSelect().filter(CalendarSelectFilter.NATIONAL_CALENDARS)` (option
-    value = nation code, e.g. `IT`)
-  - `diocesan_calendar`, `diocesan_calendar_test` →
-    `CalendarSelect().filter(CalendarSelectFilter.DIOCESAN_CALENDARS)` (option
-    value = diocese calendar_id, grouped by nation)
-  - `wider_region` → static `['Americas','Europe','Asia','Africa','Oceania']`
-    (value = label = name)
-  - `general_roman_calendar` → static `GRC_OBJECT_IDS` (`temporale`,
-    `EDITIO_TYPICA_1970`, `EDITIO_TYPICA_2002`, `EDITIO_TYPICA_2008`, `decrees`)
-  - `general_roman_calendar_test` → single fixed option value
-    `general_roman_calendar` (auto-selected)
+    - `national_calendar`, `national_calendar_test` →
+      `CalendarSelect().filter(CalendarSelectFilter.NATIONAL_CALENDARS)` (option
+      value = nation code, e.g. `IT`)
+    - `diocesan_calendar`, `diocesan_calendar_test` →
+      `CalendarSelect().filter(CalendarSelectFilter.DIOCESAN_CALENDARS)` (option
+      value = diocese calendar_id, grouped by nation)
+    - `wider_region` → static `['Americas','Europe','Asia','Africa','Oceania']`
+      (value = label = name)
+    - `general_roman_calendar` → static `GRC_OBJECT_IDS` (`temporale`,
+      `EDITIO_TYPICA_1970`, `EDITIO_TYPICA_2002`, `EDITIO_TYPICA_2008`, `decrees`)
+    - `general_roman_calendar_test` → single fixed option value
+      `general_roman_calendar` (auto-selected)
 - **`GRC_OBJECT_IDS` keys** must stay in sync with API
   `AccessRequestRepository::GRC_OBJECT_IDS`. They remain duplicated in
   `permission-requests.js` and `admin-permissions.js` (existing convention, with
@@ -147,18 +147,21 @@ At the very top of the file (module top-level, before the existing IIFE), add:
 
 ```js
 import {
-  ApiClient,
-  CalendarSelect,
-  CalendarSelectFilter,
-} from "@liturgical-calendar/components-js";
+    ApiClient,
+    CalendarSelect,
+    CalendarSelectFilter,
+} from '@liturgical-calendar/components-js';
 
 // Initialize the API client once; CalendarSelect requires this to have resolved.
 const apiClientReady = ApiClient.init(BaseUrl)
-  .then((client) => (client instanceof ApiClient ? client : false))
-  .catch((err) => {
-    console.error("Failed to initialize ApiClient for permission fields:", err);
-    return false;
-  });
+    .then((client) => (client instanceof ApiClient ? client : false))
+    .catch((err) => {
+        console.error(
+            'Failed to initialize ApiClient for permission fields:',
+            err,
+        );
+        return false;
+    });
 ```
 
 - [ ] **Step 2: Replace `objectTypeNames` and `roleObjectTypes` with the scoped
@@ -169,13 +172,13 @@ Replace the `objectTypeNames` block (lines 49-55) with:
 ```js
 // Object type ("Calendar scope") display names
 const objectTypeNames = {
-  national_calendar: config.i18n.nationalCalendar,
-  diocesan_calendar: config.i18n.diocesanCalendar,
-  wider_region: config.i18n.widerRegion,
-  general_roman_calendar: config.i18n.generalRomanCalendar,
-  national_calendar_test: config.i18n.testsNational,
-  diocesan_calendar_test: config.i18n.testsDiocesan,
-  general_roman_calendar_test: config.i18n.testsGeneralRoman,
+    national_calendar: config.i18n.nationalCalendar,
+    diocesan_calendar: config.i18n.diocesanCalendar,
+    wider_region: config.i18n.widerRegion,
+    general_roman_calendar: config.i18n.generalRomanCalendar,
+    national_calendar_test: config.i18n.testsNational,
+    diocesan_calendar_test: config.i18n.testsDiocesan,
+    general_roman_calendar_test: config.i18n.testsGeneralRoman,
 };
 ```
 
@@ -184,26 +187,26 @@ Replace `roleObjectTypes` (lines 94-98) with the API-mirrored sets:
 ```js
 // Object types allowed per role (mirror AccessRequestRepository::ROLE_OBJECT_TYPES)
 const roleObjectTypes = {
-  calendar_editor: [
-    "national_calendar",
-    "diocesan_calendar",
-    "wider_region",
-    "general_roman_calendar",
-  ],
-  test_editor: [
-    "national_calendar_test",
-    "diocesan_calendar_test",
-    "general_roman_calendar_test",
-  ],
-  developer: [
-    "national_calendar",
-    "diocesan_calendar",
-    "wider_region",
-    "national_calendar_test",
-    "diocesan_calendar_test",
-    "general_roman_calendar_test",
-    "general_roman_calendar",
-  ],
+    calendar_editor: [
+        'national_calendar',
+        'diocesan_calendar',
+        'wider_region',
+        'general_roman_calendar',
+    ],
+    test_editor: [
+        'national_calendar_test',
+        'diocesan_calendar_test',
+        'general_roman_calendar_test',
+    ],
+    developer: [
+        'national_calendar',
+        'diocesan_calendar',
+        'wider_region',
+        'national_calendar_test',
+        'diocesan_calendar_test',
+        'general_roman_calendar_test',
+        'general_roman_calendar',
+    ],
 };
 ```
 
@@ -213,7 +216,7 @@ add the wider-region constant:
 ```js
 // The five wider-region names (object_id for the wider_region scope).
 // Keep in sync with the API; these are not localized (proper nouns).
-const WIDER_REGIONS = ["Americas", "Europe", "Asia", "Africa", "Oceania"];
+const WIDER_REGIONS = ['Americas', 'Europe', 'Asia', 'Africa', 'Oceania'];
 ```
 
 - [ ] **Step 3: Replace `syncRowObjectIdField` with the hybrid builder**
@@ -224,47 +227,50 @@ three static scopes build a native `<select>`. Both end with an element carrying
 class `perm-object-id` inside the row's `.perm-objid-mount` cell.
 
 ```js
-const NATIONAL_FILTER_TYPES = ["national_calendar", "national_calendar_test"];
-const DIOCESAN_FILTER_TYPES = ["diocesan_calendar", "diocesan_calendar_test"];
+const NATIONAL_FILTER_TYPES = ['national_calendar', 'national_calendar_test'];
+const DIOCESAN_FILTER_TYPES = ['diocesan_calendar', 'diocesan_calendar_test'];
 
 /**
  * Build a native <select class="form-select form-select-sm perm-object-id">
  * for the three non-calendar scopes (wider_region / GRC / GRC test).
  */
 function buildStaticObjectIdSelect(objectType) {
-  const select = document.createElement("select");
-  select.className = "form-select form-select-sm perm-object-id";
-  select.required = true;
+    const select = document.createElement('select');
+    select.className = 'form-select form-select-sm perm-object-id';
+    select.required = true;
 
-  const placeholder = document.createElement("option");
-  placeholder.value = "";
-  placeholder.textContent =
-    config.i18n.selectCalendarId || "Select calendar ID...";
-  placeholder.disabled = true;
-  placeholder.selected = true;
-  select.appendChild(placeholder);
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent =
+        config.i18n.selectCalendarId || 'Select calendar ID...';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    select.appendChild(placeholder);
 
-  let entries = [];
-  if (objectType === "wider_region") {
-    entries = WIDER_REGIONS.map((name) => ({ value: name, label: name }));
-  } else if (objectType === "general_roman_calendar") {
-    entries = GRC_OBJECT_IDS.map((o) => ({ value: o.id, label: o.label }));
-  } else if (objectType === "general_roman_calendar_test") {
-    entries = [
-      { value: "general_roman_calendar", label: config.i18n.testsGeneralRoman },
-    ];
-  }
-  for (const e of entries) {
-    const o = document.createElement("option");
-    o.value = e.value;
-    o.textContent = e.label;
-    select.appendChild(o);
-  }
-  // Auto-select the single fixed GRC-test id.
-  if (objectType === "general_roman_calendar_test") {
-    select.value = "general_roman_calendar";
-  }
-  return select;
+    let entries = [];
+    if (objectType === 'wider_region') {
+        entries = WIDER_REGIONS.map((name) => ({ value: name, label: name }));
+    } else if (objectType === 'general_roman_calendar') {
+        entries = GRC_OBJECT_IDS.map((o) => ({ value: o.id, label: o.label }));
+    } else if (objectType === 'general_roman_calendar_test') {
+        entries = [
+            {
+                value: 'general_roman_calendar',
+                label: config.i18n.testsGeneralRoman,
+            },
+        ];
+    }
+    for (const e of entries) {
+        const o = document.createElement('option');
+        o.value = e.value;
+        o.textContent = e.label;
+        select.appendChild(o);
+    }
+    // Auto-select the single fixed GRC-test id.
+    if (objectType === 'general_roman_calendar_test') {
+        select.value = 'general_roman_calendar';
+    }
+    return select;
 }
 
 /**
@@ -272,33 +278,33 @@ function buildStaticObjectIdSelect(objectType) {
  * Calendar-backed scopes mount a CalendarSelect; the rest use a native select.
  */
 async function syncRowObjectIdField(row, objectType) {
-  const mount = row.querySelector(".perm-objid-mount");
-  if (!mount) return;
-  mount.innerHTML = "";
+    const mount = row.querySelector('.perm-objid-mount');
+    if (!mount) return;
+    mount.innerHTML = '';
 
-  if (
-    NATIONAL_FILTER_TYPES.includes(objectType) ||
-    DIOCESAN_FILTER_TYPES.includes(objectType)
-  ) {
-    const client = await apiClientReady;
-    if (!client) return; // init failed; leave empty (validation will block submit)
-    // Guard against a rapid scope change that already replaced the mount.
     if (
-      !row.isConnected ||
-      row.querySelector(".perm-object-type").value !== objectType
-    )
-      return;
-    const filter = NATIONAL_FILTER_TYPES.includes(objectType)
-      ? CalendarSelectFilter.NATIONAL_CALENDARS
-      : CalendarSelectFilter.DIOCESAN_CALENDARS;
-    const calSelect = new CalendarSelect(LITCAL_LOCALE)
-      .filter(filter)
-      .allowNull(true)
-      .class("form-select form-select-sm perm-object-id");
-    calSelect.appendTo(mount);
-  } else {
-    mount.appendChild(buildStaticObjectIdSelect(objectType));
-  }
+        NATIONAL_FILTER_TYPES.includes(objectType) ||
+        DIOCESAN_FILTER_TYPES.includes(objectType)
+    ) {
+        const client = await apiClientReady;
+        if (!client) return; // init failed; leave empty (validation will block submit)
+        // Guard against a rapid scope change that already replaced the mount.
+        if (
+            !row.isConnected ||
+            row.querySelector('.perm-object-type').value !== objectType
+        )
+            return;
+        const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+            ? CalendarSelectFilter.NATIONAL_CALENDARS
+            : CalendarSelectFilter.DIOCESAN_CALENDARS;
+        const calSelect = new CalendarSelect(LITCAL_LOCALE)
+            .filter(filter)
+            .allowNull(true)
+            .class('form-select form-select-sm perm-object-id');
+        calSelect.appendTo(mount);
+    } else {
+        mount.appendChild(buildStaticObjectIdSelect(objectType));
+    }
 }
 ```
 
@@ -357,9 +363,9 @@ the new key:
 
 ```js
 let html =
-  '<option value="">' +
-  escapeHtml(config.i18n.selectCalendarScope) +
-  "</option>";
+    '<option value="">' +
+    escapeHtml(config.i18n.selectCalendarScope) +
+    '</option>';
 ```
 
 - [ ] **Step 6: Guard `collectPermissions` against an unpopulated Calendar ID**
@@ -368,8 +374,8 @@ In `collectPermissions()` (lines ~316-340), replace the object-id read so a row
 with no chosen Calendar ID is treated as invalid rather than throwing:
 
 ```js
-const objectIdEl = row.querySelector(".perm-object-id");
-const objectId = objectIdEl ? objectIdEl.value.trim() : "";
+const objectIdEl = row.querySelector('.perm-object-id');
+const objectId = objectIdEl ? objectIdEl.value.trim() : '';
 ```
 
 (Leave the subsequent
@@ -501,67 +507,70 @@ with `.class('form-select').id('grantObjectId')`; static scopes build a native
 `<select id="grantObjectId" class="form-select">`:
 
 ```js
-const NATIONAL_FILTER_TYPES = ["national_calendar", "national_calendar_test"];
-const DIOCESAN_FILTER_TYPES = ["diocesan_calendar", "diocesan_calendar_test"];
+const NATIONAL_FILTER_TYPES = ['national_calendar', 'national_calendar_test'];
+const DIOCESAN_FILTER_TYPES = ['diocesan_calendar', 'diocesan_calendar_test'];
 
 function buildStaticGrantObjectId(objectType) {
-  const select = document.createElement("select");
-  select.className = "form-select";
-  select.id = "grantObjectId";
-  select.required = true;
-  const placeholder = document.createElement("option");
-  placeholder.value = "";
-  placeholder.textContent =
-    config.i18n.selectCalendarId || "Select calendar ID...";
-  placeholder.disabled = true;
-  placeholder.selected = true;
-  select.appendChild(placeholder);
+    const select = document.createElement('select');
+    select.className = 'form-select';
+    select.id = 'grantObjectId';
+    select.required = true;
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent =
+        config.i18n.selectCalendarId || 'Select calendar ID...';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    select.appendChild(placeholder);
 
-  let entries = [];
-  if (objectType === "wider_region") {
-    entries = WIDER_REGIONS.map((name) => ({ value: name, label: name }));
-  } else if (objectType === "general_roman_calendar") {
-    entries = GRC_OBJECT_IDS.map((o) => ({ value: o.id, label: o.label }));
-  } else if (objectType === "general_roman_calendar_test") {
-    entries = [
-      { value: "general_roman_calendar", label: config.i18n.testsGeneralRoman },
-    ];
-  }
-  for (const e of entries) {
-    const o = document.createElement("option");
-    o.value = e.value;
-    o.textContent = e.label;
-    select.appendChild(o);
-  }
-  if (objectType === "general_roman_calendar_test") {
-    select.value = "general_roman_calendar";
-  }
-  return select;
+    let entries = [];
+    if (objectType === 'wider_region') {
+        entries = WIDER_REGIONS.map((name) => ({ value: name, label: name }));
+    } else if (objectType === 'general_roman_calendar') {
+        entries = GRC_OBJECT_IDS.map((o) => ({ value: o.id, label: o.label }));
+    } else if (objectType === 'general_roman_calendar_test') {
+        entries = [
+            {
+                value: 'general_roman_calendar',
+                label: config.i18n.testsGeneralRoman,
+            },
+        ];
+    }
+    for (const e of entries) {
+        const o = document.createElement('option');
+        o.value = e.value;
+        o.textContent = e.label;
+        select.appendChild(o);
+    }
+    if (objectType === 'general_roman_calendar_test') {
+        select.value = 'general_roman_calendar';
+    }
+    return select;
 }
 
 async function syncObjectIdField(objectType) {
-  const mount = document.getElementById("grantObjectIdMount");
-  if (!mount) return;
-  mount.innerHTML = "";
-  if (
-    NATIONAL_FILTER_TYPES.includes(objectType) ||
-    DIOCESAN_FILTER_TYPES.includes(objectType)
-  ) {
-    const client = await apiClientReady;
-    if (!client) return;
-    if (grantObjectType.value !== objectType) return; // scope changed again meanwhile
-    const filter = NATIONAL_FILTER_TYPES.includes(objectType)
-      ? CalendarSelectFilter.NATIONAL_CALENDARS
-      : CalendarSelectFilter.DIOCESAN_CALENDARS;
-    new CalendarSelect(LITCAL_LOCALE)
-      .filter(filter)
-      .allowNull(true)
-      .class("form-select")
-      .id("grantObjectId")
-      .appendTo(mount);
-  } else {
-    mount.appendChild(buildStaticGrantObjectId(objectType));
-  }
+    const mount = document.getElementById('grantObjectIdMount');
+    if (!mount) return;
+    mount.innerHTML = '';
+    if (
+        NATIONAL_FILTER_TYPES.includes(objectType) ||
+        DIOCESAN_FILTER_TYPES.includes(objectType)
+    ) {
+        const client = await apiClientReady;
+        if (!client) return;
+        if (grantObjectType.value !== objectType) return; // scope changed again meanwhile
+        const filter = NATIONAL_FILTER_TYPES.includes(objectType)
+            ? CalendarSelectFilter.NATIONAL_CALENDARS
+            : CalendarSelectFilter.DIOCESAN_CALENDARS;
+        new CalendarSelect(LITCAL_LOCALE)
+            .filter(filter)
+            .allowNull(true)
+            .class('form-select')
+            .id('grantObjectId')
+            .appendTo(mount);
+    } else {
+        mount.appendChild(buildStaticGrantObjectId(objectType));
+    }
 }
 ```
 
@@ -604,13 +613,13 @@ git commit -m "feat(admin-permissions): hybrid CalendarSelect/static grant Calen
 In `e2e/rbac/support/requestAccess.ts`, extend the union:
 
 ```ts
-objectType: "national_calendar" |
-  "diocesan_calendar" |
-  "wider_region" |
-  "general_roman_calendar" |
-  "national_calendar_test" |
-  "diocesan_calendar_test" |
-  "general_roman_calendar_test";
+objectType: 'national_calendar' |
+    'diocesan_calendar' |
+    'wider_region' |
+    'general_roman_calendar' |
+    'national_calendar_test' |
+    'diocesan_calendar_test' |
+    'general_roman_calendar_test';
 ```
 
 - [ ] **Step 2: Ensure the object-id interaction uses `selectOption`**
@@ -620,8 +629,8 @@ In `submitAccessRequest` (lines ~39-77), the Calendar ID control is now always a
 `.fill()`s `.perm-object-id`, change it to wait for the option then select it:
 
 ```ts
-const objectIdControl = row.locator(".perm-object-id");
-await objectIdControl.waitFor({ state: "visible" });
+const objectIdControl = row.locator('.perm-object-id');
+await objectIdControl.waitFor({ state: 'visible' });
 await objectIdControl.selectOption(opts.permission.objectId);
 ```
 

--- a/docs/superpowers/plans/2026-06-29-admin-tests-page-phase2.md
+++ b/docs/superpowers/plans/2026-06-29-admin-tests-page-phase2.md
@@ -22,12 +22,12 @@ Per-row Edit/Delete buttons are gated against the caller's scopes from `GET /aut
   list `['admin-applications','admin-role-requests']`). `assets/css/admin-tests.css` is auto-loaded by `layout/head.php`. Do not edit footer/head
   loaders for these two files.
 - **Imports:** `import { ApiClient, CalendarSelect, CalendarSelectFilter } from '@liturgical-calendar/components-js';` and `import {
-  AssertionsBuilder, TestType, AssertType } from './AssertionsBuilder.js';`.
+AssertionsBuilder, TestType, AssertType } from './AssertionsBuilder.js';`.
 - **All API calls:** `credentials: 'include'`, `Accept: application/json`, and `Content-Type: application/json` on writes. Base URL from `window.AdminTestsConfig.apiUrl`.
 - **RFC 3339 dates:** `expected_value` is always `YYYY-MM-DDT00:00:00+00:00` (UTC midnight) or `null`. Compute via `new Date(Date.UTC(year, month-1,
-  day)).toISOString().split('T')[0] + 'T00:00:00+00:00'`.
+day)).toISOString().split('T')[0] + 'T00:00:00+00:00'`.
 - **Test name pattern (schema):** `^(?:[a-z_]+?_){0,1}[A-Z][a-zA-Z1-9]+[0-9]{0,2}(?:_vigil)?Test$`. `name` is the resource key for `PATCH/DELETE
-  /tests/{name}` → render it **read-only when editing**.
+/tests/{name}` → render it **read-only when editing**.
 - **Test types:** `exactCorrespondence`, `exactCorrespondenceSince` (requires `year_since`), `exactCorrespondenceUntil` (requires `year_until`),
   `variableCorrespondence`. Schema: `exactCorrespondence` and `variableCorrespondence` share the base shape (no pivot year); Since/Until each require
   their pivot year.
@@ -157,19 +157,30 @@ Create `assets/js/__tests__/AssertionsBuilder.test.js`:
 
 ```javascript
 import { describe, it, expect } from 'vitest';
-import { TestType, AssertType, LitGrade, Assertion } from '../AssertionsBuilder.js';
+import {
+    TestType,
+    AssertType,
+    LitGrade,
+    Assertion,
+} from '../AssertionsBuilder.js';
 
 describe('enums', () => {
     it('exposes the four test types', () => {
         expect(TestType.ExactCorrespondence).toBe('exactCorrespondence');
-        expect(TestType.ExactCorrespondenceSince).toBe('exactCorrespondenceSince');
-        expect(TestType.ExactCorrespondenceUntil).toBe('exactCorrespondenceUntil');
+        expect(TestType.ExactCorrespondenceSince).toBe(
+            'exactCorrespondenceSince',
+        );
+        expect(TestType.ExactCorrespondenceUntil).toBe(
+            'exactCorrespondenceUntil',
+        );
         expect(TestType.VariableCorrespondence).toBe('variableCorrespondence');
     });
 
     it('exposes the two assert types', () => {
         expect(AssertType.EventNotExists).toBe('eventNotExists');
-        expect(AssertType.EventTypeExact).toBe('eventExists AND hasExpectedDate');
+        expect(AssertType.EventTypeExact).toBe(
+            'eventExists AND hasExpectedDate',
+        );
     });
 
     it('maps liturgical grades to strings', () => {
@@ -185,7 +196,13 @@ describe('Assertion', () => {
     });
 
     it('keeps comment when provided', () => {
-        const a = new Assertion(2024, null, AssertType.EventNotExists, 'x', 'note');
+        const a = new Assertion(
+            2024,
+            null,
+            AssertType.EventNotExists,
+            'x',
+            'note',
+        );
         expect(a.comment).toBe('note');
     });
 });
@@ -210,10 +227,10 @@ Create `assets/js/AssertionsBuilder.js`:
  */
 
 export const TestType = Object.freeze({
-    ExactCorrespondence:      'exactCorrespondence',
+    ExactCorrespondence: 'exactCorrespondence',
     ExactCorrespondenceSince: 'exactCorrespondenceSince',
     ExactCorrespondenceUntil: 'exactCorrespondenceUntil',
-    VariableCorrespondence:   'variableCorrespondence',
+    VariableCorrespondence: 'variableCorrespondence',
 });
 
 export const AssertType = Object.freeze({
@@ -222,10 +239,24 @@ export const AssertType = Object.freeze({
 });
 
 export const LitGrade = Object.freeze({
-    WEEKDAY: 0, COMMEMORATION: 1, OPTIONAL_MEMORIAL: 2, MEMORIAL: 3,
-    FEAST: 4, FEAST_OF_THE_LORD: 5, SOLEMNITY: 6, HIGHER_SOLEMNITY: 7,
-    stringVals: ['weekday', 'commemoration', 'optional memorial', 'Memorial',
-        'FEAST', 'FEAST OF THE LORD', 'SOLEMNITY', 'HIGHER SOLEMNITY'],
+    WEEKDAY: 0,
+    COMMEMORATION: 1,
+    OPTIONAL_MEMORIAL: 2,
+    MEMORIAL: 3,
+    FEAST: 4,
+    FEAST_OF_THE_LORD: 5,
+    SOLEMNITY: 6,
+    HIGHER_SOLEMNITY: 7,
+    stringVals: [
+        'weekday',
+        'commemoration',
+        'optional memorial',
+        'Memorial',
+        'FEAST',
+        'FEAST OF THE LORD',
+        'SOLEMNITY',
+        'HIGHER SOLEMNITY',
+    ],
     toString: (n) => LitGrade.stringVals[parseInt(n, 10)],
 });
 
@@ -284,12 +315,26 @@ import { AssertionsBuilder } from '../AssertionsBuilder.js';
 const sampleExact = {
     name: 'StIgnatiusOfLoyolaTest',
     event_key: 'StIgnatiusOfLoyola',
-    description: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+    description:
+        "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
     test_type: 'exactCorrespondence',
     applies_to: { national_calendar: 'USA' },
     assertions: [
-        { year: 2024, expected_value: '2024-07-31T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31" },
-        { year: 2025, expected_value: '2025-07-31T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31", comment: 'note' },
+        {
+            year: 2024,
+            expected_value: '2024-07-31T00:00:00+00:00',
+            assert: 'eventExists AND hasExpectedDate',
+            assertion:
+                "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+        },
+        {
+            year: 2025,
+            expected_value: '2025-07-31T00:00:00+00:00',
+            assert: 'eventExists AND hasExpectedDate',
+            assertion:
+                "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+            comment: 'note',
+        },
     ],
 };
 
@@ -300,8 +345,18 @@ const sampleSince = {
     test_type: 'exactCorrespondenceSince',
     year_since: 2026,
     assertions: [
-        { year: 2025, expected_value: null, assert: 'eventNotExists', assertion: "The FEAST of 'Some Feast' should not exist on March 19" },
-        { year: 2026, expected_value: '2026-03-19T00:00:00+00:00', assert: 'eventExists AND hasExpectedDate', assertion: "The FEAST of 'Some Feast' should fall on March 19" },
+        {
+            year: 2025,
+            expected_value: null,
+            assert: 'eventNotExists',
+            assertion: "The FEAST of 'Some Feast' should not exist on March 19",
+        },
+        {
+            year: 2026,
+            expected_value: '2026-03-19T00:00:00+00:00',
+            assert: 'eventExists AND hasExpectedDate',
+            assertion: "The FEAST of 'Some Feast' should fall on March 19",
+        },
     ],
 };
 
@@ -317,11 +372,22 @@ describe('load + serialize round-trip', () => {
     });
 
     it('omits year_since/year_until/applies_to/excludes when not applicable', () => {
-        const out = new AssertionsBuilder().load({
-            name: 'BareTest', event_key: 'Bare', description: 'd',
-            test_type: 'exactCorrespondence',
-            assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }],
-        }).serialize();
+        const out = new AssertionsBuilder()
+            .load({
+                name: 'BareTest',
+                event_key: 'Bare',
+                description: 'd',
+                test_type: 'exactCorrespondence',
+                assertions: [
+                    {
+                        year: 2024,
+                        expected_value: null,
+                        assert: 'eventNotExists',
+                        assertion: 'd',
+                    },
+                ],
+            })
+            .serialize();
         expect('year_since' in out).toBe(false);
         expect('year_until' in out).toBe(false);
         expect('applies_to' in out).toBe(false);
@@ -330,7 +396,11 @@ describe('load + serialize round-trip', () => {
 
     it('setMeta updates name/description/event_key/test_type without touching assertions', () => {
         const b = new AssertionsBuilder().load(sampleExact);
-        b.setMeta({ name: 'RenamedTest', description: 'new desc', test_type: 'variableCorrespondence' });
+        b.setMeta({
+            name: 'RenamedTest',
+            description: 'new desc',
+            test_type: 'variableCorrespondence',
+        });
         const out = b.serialize();
         expect(out.name).toBe('RenamedTest');
         expect(out.description).toBe('new desc');
@@ -387,14 +457,30 @@ export class AssertionsBuilder {
         this.model.year_since = def.year_since ?? null;
         this.model.year_until = def.year_until ?? null;
         this.model.assertions = (def.assertions ?? []).map(
-            (a) => new Assertion(a.year, a.expected_value, a.assert, a.assertion, a.comment ?? null)
+            (a) =>
+                new Assertion(
+                    a.year,
+                    a.expected_value,
+                    a.assert,
+                    a.assertion,
+                    a.comment ?? null,
+                ),
         );
-        this.baseMonthDay = AssertionsBuilder.#deriveBaseMonthDay(this.model.assertions);
+        this.baseMonthDay = AssertionsBuilder.#deriveBaseMonthDay(
+            this.model.assertions,
+        );
         return this;
     }
 
     /** Update editor-form metadata (never touches the assertions array). */
-    setMeta({ name, event_key, description, test_type, applies_to, excludes } = {}) {
+    setMeta({
+        name,
+        event_key,
+        description,
+        test_type,
+        applies_to,
+        excludes,
+    } = {}) {
         if (name !== undefined) this.model.name = name;
         if (event_key !== undefined) this.model.event_key = event_key;
         if (description !== undefined) this.model.description = description;
@@ -415,10 +501,16 @@ export class AssertionsBuilder {
         };
         if (m.applies_to) out.applies_to = m.applies_to;
         if (m.excludes) out.excludes = m.excludes;
-        if (m.test_type === TestType.ExactCorrespondenceSince && m.year_since !== null) {
+        if (
+            m.test_type === TestType.ExactCorrespondenceSince &&
+            m.year_since !== null
+        ) {
             out.year_since = m.year_since;
         }
-        if (m.test_type === TestType.ExactCorrespondenceUntil && m.year_until !== null) {
+        if (
+            m.test_type === TestType.ExactCorrespondenceUntil &&
+            m.year_until !== null
+        ) {
             out.year_until = m.year_until;
         }
         out.assertions = m.assertions.map((a) => {
@@ -481,48 +573,93 @@ git commit -m "feat(admin-tests): AssertionsBuilder model load/setMeta/serialize
 Append to the test file:
 
 ```javascript
-const event = { event_key: 'StIgnatiusOfLoyola', name: 'Saint Ignatius of Loyola', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 };
+const event = {
+    event_key: 'StIgnatiusOfLoyola',
+    name: 'Saint Ignatius of Loyola',
+    grade: 3,
+    grade_lcl: 'Memorial',
+    month: 7,
+    day: 31,
+};
 
 describe('generate', () => {
     it('exactCorrespondence: every year asserts eventExists with a UTC midnight date', () => {
         const b = new AssertionsBuilder({ locale: 'en' });
-        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondence' });
+        b.setMeta({
+            event_key: event.event_key,
+            test_type: 'exactCorrespondence',
+        });
         b.generate({ event, minYear: 2023, maxYear: 2025 });
         const out = b.serialize();
         expect(out.assertions.map((a) => a.year)).toEqual([2023, 2024, 2025]);
-        expect(out.assertions.every((a) => a.assert === 'eventExists AND hasExpectedDate')).toBe(true);
-        expect(out.assertions[1].expected_value).toBe('2024-07-31T00:00:00+00:00');
-        expect(out.description).toBe("The Memorial of 'Saint Ignatius of Loyola' should fall on July 31");
+        expect(
+            out.assertions.every(
+                (a) => a.assert === 'eventExists AND hasExpectedDate',
+            ),
+        ).toBe(true);
+        expect(out.assertions[1].expected_value).toBe(
+            '2024-07-31T00:00:00+00:00',
+        );
+        expect(out.description).toBe(
+            "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31",
+        );
     });
 
     it('exactCorrespondenceSince: years before the pivot assert eventNotExists', () => {
         const b = new AssertionsBuilder();
-        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondenceSince' });
+        b.setMeta({
+            event_key: event.event_key,
+            test_type: 'exactCorrespondenceSince',
+        });
         b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2025 });
         const out = b.serialize();
         expect(out.year_since).toBe(2025);
-        expect(out.assertions.find((a) => a.year === 2024).assert).toBe('eventNotExists');
-        expect(out.assertions.find((a) => a.year === 2024).expected_value).toBe(null);
-        expect(out.assertions.find((a) => a.year === 2025).assert).toBe('eventExists AND hasExpectedDate');
-        expect(out.assertions.find((a) => a.year === 2024).assertion)
-            .toBe("The Memorial of 'Saint Ignatius of Loyola' should not exist on July 31");
+        expect(out.assertions.find((a) => a.year === 2024).assert).toBe(
+            'eventNotExists',
+        );
+        expect(out.assertions.find((a) => a.year === 2024).expected_value).toBe(
+            null,
+        );
+        expect(out.assertions.find((a) => a.year === 2025).assert).toBe(
+            'eventExists AND hasExpectedDate',
+        );
+        expect(out.assertions.find((a) => a.year === 2024).assertion).toBe(
+            "The Memorial of 'Saint Ignatius of Loyola' should not exist on July 31",
+        );
     });
 
     it('exactCorrespondenceUntil: years after the pivot assert eventNotExists', () => {
         const b = new AssertionsBuilder();
-        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondenceUntil' });
+        b.setMeta({
+            event_key: event.event_key,
+            test_type: 'exactCorrespondenceUntil',
+        });
         b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2025 });
         const out = b.serialize();
         expect(out.year_until).toBe(2025);
-        expect(out.assertions.find((a) => a.year === 2026).assert).toBe('eventNotExists');
-        expect(out.assertions.find((a) => a.year === 2025).assert).toBe('eventExists AND hasExpectedDate');
+        expect(out.assertions.find((a) => a.year === 2026).assert).toBe(
+            'eventNotExists',
+        );
+        expect(out.assertions.find((a) => a.year === 2025).assert).toBe(
+            'eventExists AND hasExpectedDate',
+        );
     });
 
     it('skips excluded years', () => {
         const b = new AssertionsBuilder();
-        b.setMeta({ event_key: event.event_key, test_type: 'exactCorrespondence' });
-        b.generate({ event, minYear: 2023, maxYear: 2025, excludedYears: [2024] });
-        expect(b.serialize().assertions.map((a) => a.year)).toEqual([2023, 2025]);
+        b.setMeta({
+            event_key: event.event_key,
+            test_type: 'exactCorrespondence',
+        });
+        b.generate({
+            event,
+            minYear: 2023,
+            maxYear: 2025,
+            excludedYears: [2024],
+        });
+        expect(b.serialize().assertions.map((a) => a.year)).toEqual([
+            2023, 2025,
+        ]);
     });
 });
 ```
@@ -655,17 +792,25 @@ describe('mutators', () => {
     it('setExpectedDate updates the RFC3339 value', () => {
         const b = build();
         b.setExpectedDate(2024, '2024-08-01T00:00:00+00:00');
-        expect(b.model.assertions.find((x) => x.year === 2024).expected_value).toBe('2024-08-01T00:00:00+00:00');
+        expect(
+            b.model.assertions.find((x) => x.year === 2024).expected_value,
+        ).toBe('2024-08-01T00:00:00+00:00');
     });
 
     it('setAssertionText and setComment work; empty comment removes it', () => {
         const b = build();
         b.setAssertionText(2024, 'custom sentence');
-        expect(b.model.assertions.find((x) => x.year === 2024).assertion).toBe('custom sentence');
+        expect(b.model.assertions.find((x) => x.year === 2024).assertion).toBe(
+            'custom sentence',
+        );
         b.setComment(2024, 'a note');
-        expect(b.model.assertions.find((x) => x.year === 2024).comment).toBe('a note');
+        expect(b.model.assertions.find((x) => x.year === 2024).comment).toBe(
+            'a note',
+        );
         b.setComment(2024, '');
-        expect('comment' in b.model.assertions.find((x) => x.year === 2024)).toBe(false);
+        expect(
+            'comment' in b.model.assertions.find((x) => x.year === 2024),
+        ).toBe(false);
     });
 
     it('excludeYear removes the assertion', () => {
@@ -680,8 +825,12 @@ describe('mutators', () => {
         b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2024 });
         b.setPivot(2026);
         expect(b.model.year_since).toBe(2026);
-        expect(b.model.assertions.find((x) => x.year === 2024).assert).toBe('eventNotExists');
-        expect(b.model.assertions.find((x) => x.year === 2026).assert).toBe('eventExists AND hasExpectedDate');
+        expect(b.model.assertions.find((x) => x.year === 2024).assert).toBe(
+            'eventNotExists',
+        );
+        expect(b.model.assertions.find((x) => x.year === 2026).assert).toBe(
+            'eventExists AND hasExpectedDate',
+        );
     });
 });
 ```
@@ -811,14 +960,22 @@ describe('render', () => {
         expect(cards).toHaveLength(2);
 
         const card2024 = container.querySelector('[data-year="2024"]');
-        expect(card2024.querySelector('.assert').textContent).toBe('eventExists AND hasExpectedDate');
+        expect(card2024.querySelector('.assert').textContent).toBe(
+            'eventExists AND hasExpectedDate',
+        );
         expect(card2024.querySelector('textarea.assertionText')).not.toBeNull();
         expect(card2024.querySelector('.toggleAssert')).not.toBeNull();
-        expect(card2024.querySelector('.expectedValue').getAttribute('data-value')).toBe('2024-07-31T00:00:00+00:00');
+        expect(
+            card2024.querySelector('.expectedValue').getAttribute('data-value'),
+        ).toBe('2024-07-31T00:00:00+00:00');
 
         const card2025 = container.querySelector('[data-year="2025"]');
-        expect(card2025.querySelector('.assert').textContent).toBe('eventNotExists');
-        expect(card2025.querySelector('.editDate').classList.contains('disabled')).toBe(true);
+        expect(card2025.querySelector('.assert').textContent).toBe(
+            'eventNotExists',
+        );
+        expect(
+            card2025.querySelector('.editDate').classList.contains('disabled'),
+        ).toBe(true);
     });
 });
 ```
@@ -1411,7 +1568,7 @@ git commit -m "feat(admin-tests): admin-tests.php page, nav link, dashboard card
 **Interfaces:**
 
 - Consumes: `window.AdminTestsConfig`; `GET /tests` → `{ litcal_tests: LitCalTest[] }`; `GET /auth/test-scopes` → `{ is_global_admin, editor:
-  [{object_type, object_id}], admin: [...] }`.
+[{object_type, object_id}], admin: [...] }`.
 - Produces: generic seam `fetchJson`, `gateByScope`, `deriveScope`, `renderTableRows`, `showModalAlert`; on load, fetches scopes + tests and renders
   rows with per-row Edit/Delete buttons gated by scope.
 
@@ -1422,36 +1579,82 @@ Append to `e2e/admin-tests.spec.ts`:
 ```typescript
 const sampleTests = {
     litcal_tests: [
-        { name: 'GrcOnlyTest', event_key: 'StX', description: 'd', test_type: 'exactCorrespondence', assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }] },
-        { name: 'UsaNationalTest', event_key: 'StY', description: 'd', test_type: 'exactCorrespondence', applies_to: { national_calendar: 'USA' }, assertions: [{ year: 2024, expected_value: null, assert: 'eventNotExists', assertion: 'd' }] },
+        {
+            name: 'GrcOnlyTest',
+            event_key: 'StX',
+            description: 'd',
+            test_type: 'exactCorrespondence',
+            assertions: [
+                {
+                    year: 2024,
+                    expected_value: null,
+                    assert: 'eventNotExists',
+                    assertion: 'd',
+                },
+            ],
+        },
+        {
+            name: 'UsaNationalTest',
+            event_key: 'StY',
+            description: 'd',
+            test_type: 'exactCorrespondence',
+            applies_to: { national_calendar: 'USA' },
+            assertions: [
+                {
+                    year: 2024,
+                    expected_value: null,
+                    assert: 'eventNotExists',
+                    assertion: 'd',
+                },
+            ],
+        },
     ],
 };
 
 async function stub(page, scopes) {
     await page.route('**/auth/test-scopes', (r) => r.fulfill({ json: scopes }));
-    await page.route('**/auth/me', (r) => r.fulfill({ json: { authenticated: true, roles: ['test_editor'] } }));
+    await page.route('**/auth/me', (r) =>
+        r.fulfill({ json: { authenticated: true, roles: ['test_editor'] } }),
+    );
     await page.route('**/tests', (r) => {
-        if (r.request().method() === 'GET') return r.fulfill({ json: sampleTests });
+        if (r.request().method() === 'GET')
+            return r.fulfill({ json: sampleTests });
         return r.continue();
     });
 }
 
 test.describe('admin-tests gating (stubbed)', () => {
-    test('scoped editor sees Edit only on the USA test, no Delete', async ({ page }) => {
-        await stub(page, { is_global_admin: false, editor: [{ object_type: 'national_calendar_test', object_id: 'USA' }], admin: [] });
+    test('scoped editor sees Edit only on the USA test, no Delete', async ({
+        page,
+    }) => {
+        await stub(page, {
+            is_global_admin: false,
+            editor: [
+                { object_type: 'national_calendar_test', object_id: 'USA' },
+            ],
+            admin: [],
+        });
         await page.goto('/admin-tests.php');
         const usaRow = page.locator('tr', { hasText: 'UsaNationalTest' });
         const grcRow = page.locator('tr', { hasText: 'GrcOnlyTest' });
-        await expect(usaRow.getByRole('button', { name: 'Edit' })).toBeVisible();
-        await expect(usaRow.getByRole('button', { name: 'Delete' })).toHaveCount(0);
-        await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+        await expect(
+            usaRow.getByRole('button', { name: 'Edit' }),
+        ).toBeVisible();
+        await expect(
+            usaRow.getByRole('button', { name: 'Delete' }),
+        ).toHaveCount(0);
+        await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(
+            0,
+        );
     });
 
     test('global admin sees Edit and Delete on every row', async ({ page }) => {
         await stub(page, { is_global_admin: true, editor: [], admin: [] });
         await page.goto('/admin-tests.php');
         await expect(page.getByRole('button', { name: 'Edit' })).toHaveCount(2);
-        await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(2);
+        await expect(page.getByRole('button', { name: 'Delete' })).toHaveCount(
+            2,
+        );
     });
 });
 ```
@@ -1508,23 +1711,37 @@ document.addEventListener('DOMContentLoaded', () => {
     /** Mirror TestScopeResolver: derive a test's scope object from applies_to. */
     function deriveScope(appliesTo) {
         if (appliesTo && appliesTo.diocesan_calendar) {
-            return { object_type: 'diocesan_calendar_test', object_id: appliesTo.diocesan_calendar };
+            return {
+                object_type: 'diocesan_calendar_test',
+                object_id: appliesTo.diocesan_calendar,
+            };
         }
         if (appliesTo && appliesTo.national_calendar) {
-            return { object_type: 'national_calendar_test', object_id: appliesTo.national_calendar };
+            return {
+                object_type: 'national_calendar_test',
+                object_id: appliesTo.national_calendar,
+            };
         }
-        return { object_type: 'general_roman_calendar_test', object_id: 'general_roman_calendar' };
+        return {
+            object_type: 'general_roman_calendar_test',
+            object_id: 'general_roman_calendar',
+        };
     }
 
     function gateByScope(scopeObj, scopes) {
-        return scopes.some((s) => s.object_type === scopeObj.object_type && s.object_id === scopeObj.object_id);
+        return scopes.some(
+            (s) =>
+                s.object_type === scopeObj.object_type &&
+                s.object_id === scopeObj.object_id,
+        );
     }
 
     function showModalAlert(modalEl, type, message) {
         const area = modalEl.querySelector('[id$="Alerts"]');
         if (!area) return;
-        area.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">`
-            + `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
+        area.innerHTML =
+            `<div class="alert alert-${type} alert-dismissible fade show" role="alert">` +
+            `${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
     }
 
     // ---- state ------------------------------------------------------------
@@ -1537,31 +1754,50 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function scopeLabel(appliesTo) {
         const s = deriveScope(appliesTo);
-        if (s.object_type === 'national_calendar_test') return `${i18n.nationalCalendar}: ${s.object_id}`;
-        if (s.object_type === 'diocesan_calendar_test') return `${i18n.diocesanCalendar}: ${s.object_id}`;
+        if (s.object_type === 'national_calendar_test')
+            return `${i18n.nationalCalendar}: ${s.object_id}`;
+        if (s.object_type === 'diocesan_calendar_test')
+            return `${i18n.diocesanCalendar}: ${s.object_id}`;
         return i18n.generalRomanCalendar;
     }
 
     function yearRange(test) {
         const years = test.assertions.map((a) => a.year);
-        return years.length ? `${Math.min(...years)}–${Math.max(...years)}` : '';
+        return years.length
+            ? `${Math.min(...years)}–${Math.max(...years)}`
+            : '';
     }
 
     function canEdit(test) {
-        return state.scopes.is_global_admin || gateByScope(deriveScope(test.applies_to), state.scopes.editor);
+        return (
+            state.scopes.is_global_admin ||
+            gateByScope(deriveScope(test.applies_to), state.scopes.editor)
+        );
     }
 
     function canDelete(test) {
-        return state.scopes.is_global_admin || gateByScope(deriveScope(test.applies_to), state.scopes.admin);
+        return (
+            state.scopes.is_global_admin ||
+            gateByScope(deriveScope(test.applies_to), state.scopes.admin)
+        );
     }
 
     function renderTableRows() {
         const tbody = document.getElementById('testsTableBody');
-        const nameFilter = document.getElementById('filterTestName').value.trim().toLowerCase();
-        const scopeFilter = document.getElementById('filterTestScope').value.trim().toLowerCase();
+        const nameFilter = document
+            .getElementById('filterTestName')
+            .value.trim()
+            .toLowerCase();
+        const scopeFilter = document
+            .getElementById('filterTestScope')
+            .value.trim()
+            .toLowerCase();
         const rows = state.tests.filter((t) => {
-            const matchesName = !nameFilter || t.name.toLowerCase().includes(nameFilter);
-            const matchesScope = !scopeFilter || scopeLabel(t.applies_to).toLowerCase().includes(scopeFilter);
+            const matchesName =
+                !nameFilter || t.name.toLowerCase().includes(nameFilter);
+            const matchesScope =
+                !scopeFilter ||
+                scopeLabel(t.applies_to).toLowerCase().includes(scopeFilter);
             return matchesName && matchesScope;
         });
         document.getElementById('testsCount').textContent = String(rows.length);
@@ -1594,7 +1830,11 @@ document.addEventListener('DOMContentLoaded', () => {
         tbody.innerHTML = `<tr><td colspan="6" class="text-center text-muted">${i18n.loading}</td></tr>`;
         try {
             const [scopes, testsResp] = await Promise.all([
-                fetchJson('GET', '/auth/test-scopes').catch(() => ({ is_global_admin: false, editor: [], admin: [] })),
+                fetchJson('GET', '/auth/test-scopes').catch(() => ({
+                    is_global_admin: false,
+                    editor: [],
+                    admin: [],
+                })),
                 fetchJson('GET', '/tests'),
             ]);
             state.scopes = scopes;
@@ -1606,12 +1846,31 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    document.getElementById('refreshTestsBtn').addEventListener('click', loadTests);
-    document.getElementById('filterTestName').addEventListener('input', renderTableRows);
-    document.getElementById('filterTestScope').addEventListener('input', renderTableRows);
+    document
+        .getElementById('refreshTestsBtn')
+        .addEventListener('click', loadTests);
+    document
+        .getElementById('filterTestName')
+        .addEventListener('input', renderTableRows);
+    document
+        .getElementById('filterTestScope')
+        .addEventListener('input', renderTableRows);
 
     // Expose internals for later tasks (editor/delete wiring appended below).
-    window.__adminTests = { state, fetchJson, deriveScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, ApiClient };
+    window.__adminTests = {
+        state,
+        fetchJson,
+        deriveScope,
+        gateByScope,
+        showModalAlert,
+        loadTests,
+        renderTableRows,
+        AssertionsBuilder,
+        TestType,
+        CalendarSelect,
+        CalendarSelectFilter,
+        ApiClient,
+    };
 
     loadTests();
 });
@@ -1646,7 +1905,7 @@ git commit -m "feat(admin-tests): admin-tests.js bootstrap, list, per-row scope 
 **Interfaces:**
 
 - Consumes: `AssertionsBuilder` (Tasks 1–5), `CalendarSelect`/`CalendarSelectFilter`/`ApiClient`, generic seam from Task 8; `GET /events[ /nation/{id}
-  | /diocese/{id} ]` → `{ litcal_events: [{event_key, name, grade, grade_lcl, month, day}] }`; `PUT /tests` (create), `PATCH /tests/{name}` (edit).
+| /diocese/{id} ]` → `{ litcal_events: [{event_key, name, grade, grade_lcl, month, day}] }`; `PUT /tests` (create), `PATCH /tests/{name}` (edit).
 - Produces: a working editor that opens for create/edit, builds the datalist + slider + per-year cards from the model, and submits. `name` is read-only when editing.
 
 - [ ] **Step 1: Write the failing create/edit specs**
@@ -1656,7 +1915,14 @@ Append to `e2e/admin-tests.spec.ts`:
 ```typescript
 const grcEvents = {
     litcal_events: [
-        { event_key: 'StIgnatiusOfLoyola', name: 'Saint Ignatius of Loyola', grade: 3, grade_lcl: 'Memorial', month: 7, day: 31 },
+        {
+            event_key: 'StIgnatiusOfLoyola',
+            name: 'Saint Ignatius of Loyola',
+            grade: 3,
+            grade_lcl: 'Memorial',
+            month: 7,
+            day: 31,
+        },
     ],
 };
 
@@ -1666,8 +1932,14 @@ async function stubEditor(page, scopes) {
 }
 
 test.describe('admin-tests editor (stubbed)', () => {
-    test('create flow submits a PUT with a schema-shaped body', async ({ page }) => {
-        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+    test('create flow submits a PUT with a schema-shaped body', async ({
+        page,
+    }) => {
+        await stubEditor(page, {
+            is_global_admin: true,
+            editor: [],
+            admin: [],
+        });
         let putBody = null;
         await page.route('**/tests', (r) => {
             if (r.request().method() === 'PUT') {
@@ -1683,21 +1955,37 @@ test.describe('admin-tests editor (stubbed)', () => {
         await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
         await page.locator('#testEventKey').dispatchEvent('change');
         await page.locator('#saveTestBtn').click();
-        await expect.poll(() => putBody && putBody.name).toBe('StIgnatiusOfLoyolaTest');
+        await expect
+            .poll(() => putBody && putBody.name)
+            .toBe('StIgnatiusOfLoyolaTest');
         expect(putBody.test_type).toBe('exactCorrespondence');
         expect(putBody.assertions.length).toBeGreaterThan(0);
-        expect(putBody.assertions[0].assert).toBe('eventExists AND hasExpectedDate');
+        expect(putBody.assertions[0].assert).toBe(
+            'eventExists AND hasExpectedDate',
+        );
     });
 
-    test('edit flow renders name read-only and submits PATCH', async ({ page }) => {
-        await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+    test('edit flow renders name read-only and submits PATCH', async ({
+        page,
+    }) => {
+        await stubEditor(page, {
+            is_global_admin: true,
+            editor: [],
+            admin: [],
+        });
         let patched = false;
         await page.route('**/tests/UsaNationalTest', (r) => {
-            if (r.request().method() === 'PATCH') { patched = true; return r.fulfill({ json: {} }); }
+            if (r.request().method() === 'PATCH') {
+                patched = true;
+                return r.fulfill({ json: {} });
+            }
             return r.continue();
         });
         await page.goto('/admin-tests.php');
-        await page.locator('tr', { hasText: 'UsaNationalTest' }).getByRole('button', { name: 'Edit' }).click();
+        await page
+            .locator('tr', { hasText: 'UsaNationalTest' })
+            .getByRole('button', { name: 'Edit' })
+            .click();
         await expect(page.locator('#testName')).toHaveAttribute('readonly', '');
         await page.locator('#saveTestBtn').click();
         await expect.poll(() => patched).toBe(true);
@@ -1716,228 +2004,285 @@ Insert the following inside the `DOMContentLoaded` callback, before the final `l
 `config`, and the imported classes):
 
 ```javascript
-    // ---- editor -----------------------------------------------------------
+// ---- editor -----------------------------------------------------------
 
-    const editorModalEl = document.getElementById('testEditorModal');
-    const editorModal = bootstrap.Modal.getOrCreateInstance(editorModalEl);
-    const builder = new AssertionsBuilder({ locale: config.locale });
-    let events = [];
+const editorModalEl = document.getElementById('testEditorModal');
+const editorModal = bootstrap.Modal.getOrCreateInstance(editorModalEl);
+const builder = new AssertionsBuilder({ locale: config.locale });
+let events = [];
 
-    function selectedTestType() {
-        return document.querySelector('input[name="testType"]:checked')?.value ?? TestType.ExactCorrespondence;
+function selectedTestType() {
+    return (
+        document.querySelector('input[name="testType"]:checked')?.value ??
+        TestType.ExactCorrespondence
+    );
+}
+
+function selectedScope() {
+    const type = document.getElementById('testScopeType').value;
+    if (type === 'general_roman_calendar') return null;
+    const idEl = document.getElementById('testScopeId');
+    const id = idEl ? idEl.value : '';
+    return id ? { [type]: id } : null;
+}
+
+function eventsPath(appliesTo) {
+    if (appliesTo && appliesTo.diocesan_calendar)
+        return `/events/diocese/${appliesTo.diocesan_calendar}`;
+    if (appliesTo && appliesTo.national_calendar)
+        return `/events/nation/${appliesTo.national_calendar}`;
+    return '/events';
+}
+
+async function loadEvents(appliesTo) {
+    const res = await fetch(apiUrl + eventsPath(appliesTo), {
+        headers: {
+            Accept: 'application/json',
+            'Accept-Language': config.locale,
+        },
+        credentials: 'include',
+    });
+    const json = await res.json();
+    events = json.litcal_events ?? [];
+    const datalist = document.getElementById('testEventKeyList');
+    datalist.innerHTML = '';
+    events.forEach((e) => {
+        const opt = document.createElement('option');
+        opt.value = e.event_key;
+        opt.textContent = `${e.name} (${e.grade_lcl})`;
+        if (e.month != null) opt.dataset.month = String(e.month);
+        if (e.day != null) opt.dataset.day = String(e.day);
+        if (e.grade != null) opt.dataset.grade = String(e.grade);
+        datalist.appendChild(opt);
+    });
+}
+
+function sliderYears() {
+    const a = Number(document.getElementById('lowerRange').value);
+    const b = Number(document.getElementById('upperRange').value);
+    return { minYear: Math.min(a, b), maxYear: Math.max(a, b) };
+}
+
+function renderYearGrid() {
+    const grid = document.getElementById('yearGrid');
+    const { minYear, maxYear } = sliderYears();
+    grid.innerHTML = '';
+    for (let y = minYear; y <= maxYear; y++) {
+        const span = document.createElement('span');
+        span.className = `testYearSpan year-${y}`;
+        span.dataset.year = String(y);
+        span.textContent = String(y);
+        grid.appendChild(span);
     }
+}
 
-    function selectedScope() {
-        const type = document.getElementById('testScopeType').value;
-        if (type === 'general_roman_calendar') return null;
-        const idEl = document.getElementById('testScopeId');
-        const id = idEl ? idEl.value : '';
-        return id ? { [type]: id } : null;
-    }
-
-    function eventsPath(appliesTo) {
-        if (appliesTo && appliesTo.diocesan_calendar) return `/events/diocese/${appliesTo.diocesan_calendar}`;
-        if (appliesTo && appliesTo.national_calendar) return `/events/nation/${appliesTo.national_calendar}`;
-        return '/events';
-    }
-
-    async function loadEvents(appliesTo) {
-        const res = await fetch(apiUrl + eventsPath(appliesTo), {
-            headers: { Accept: 'application/json', 'Accept-Language': config.locale },
-            credentials: 'include',
-        });
-        const json = await res.json();
-        events = json.litcal_events ?? [];
-        const datalist = document.getElementById('testEventKeyList');
-        datalist.innerHTML = '';
-        events.forEach((e) => {
-            const opt = document.createElement('option');
-            opt.value = e.event_key;
-            opt.textContent = `${e.name} (${e.grade_lcl})`;
-            if (e.month != null) opt.dataset.month = String(e.month);
-            if (e.day != null) opt.dataset.day = String(e.day);
-            if (e.grade != null) opt.dataset.grade = String(e.grade);
-            datalist.appendChild(opt);
-        });
-    }
-
-    function sliderYears() {
-        const a = Number(document.getElementById('lowerRange').value);
-        const b = Number(document.getElementById('upperRange').value);
-        return { minYear: Math.min(a, b), maxYear: Math.max(a, b) };
-    }
-
-    function renderYearGrid() {
-        const grid = document.getElementById('yearGrid');
-        const { minYear, maxYear } = sliderYears();
-        grid.innerHTML = '';
-        for (let y = minYear; y <= maxYear; y++) {
-            const span = document.createElement('span');
-            span.className = `testYearSpan year-${y}`;
-            span.dataset.year = String(y);
-            span.textContent = String(y);
-            grid.appendChild(span);
-        }
-    }
-
-    function regenerate() {
-        const event = events.find((e) => e.event_key === document.getElementById('testEventKey').value);
-        if (!event) return;
-        const { minYear, maxYear } = sliderYears();
-        const tt = selectedTestType();
-        builder.setMeta({ test_type: tt, applies_to: selectedScope() });
-        const pivot = (tt === TestType.ExactCorrespondenceSince || tt === TestType.ExactCorrespondenceUntil)
+function regenerate() {
+    const event = events.find(
+        (e) => e.event_key === document.getElementById('testEventKey').value,
+    );
+    if (!event) return;
+    const { minYear, maxYear } = sliderYears();
+    const tt = selectedTestType();
+    builder.setMeta({ test_type: tt, applies_to: selectedScope() });
+    const pivot =
+        tt === TestType.ExactCorrespondenceSince ||
+        tt === TestType.ExactCorrespondenceUntil
             ? minYear
             : null;
-        builder.generate({ event, minYear, maxYear, pivotYear: pivot });
-        document.getElementById('testDescription').value = builder.model.description;
-        document.getElementById('baseDate').value = event.month && event.day
+    builder.generate({ event, minYear, maxYear, pivotYear: pivot });
+    document.getElementById('testDescription').value =
+        builder.model.description;
+    document.getElementById('baseDate').value =
+        event.month && event.day
             ? `${minYear}-${String(event.month).padStart(2, '0')}-${String(event.day).padStart(2, '0')}`
             : '';
-        builder.render(document.getElementById('assertionsContainer'));
-        renderYearGrid();
-    }
+    builder.render(document.getElementById('assertionsContainer'));
+    renderYearGrid();
+}
 
-    document.getElementById('testEventKey').addEventListener('change', regenerate);
-    document.querySelectorAll('input[name="testType"]').forEach((el) => el.addEventListener('change', regenerate));
-    document.getElementById('lowerRange').addEventListener('change', regenerate);
-    document.getElementById('upperRange').addEventListener('change', regenerate);
+document.getElementById('testEventKey').addEventListener('change', regenerate);
+document
+    .querySelectorAll('input[name="testType"]')
+    .forEach((el) => el.addEventListener('change', regenerate));
+document.getElementById('lowerRange').addEventListener('change', regenerate);
+document.getElementById('upperRange').addEventListener('change', regenerate);
 
-    // sync slider CSS custom properties as the user drags
-    ['lowerRange', 'upperRange'].forEach((id, idx) => {
-        const el = document.getElementById(id);
-        el.addEventListener('input', () => {
-            const prop = idx === 0 ? '--value-a' : '--value-b';
-            const textProp = idx === 0 ? '--text-value-a' : '--text-value-b';
-            el.parentNode.style.setProperty(prop, el.value);
-            el.parentNode.style.setProperty(textProp, `"${el.value}"`);
-        });
+// sync slider CSS custom properties as the user drags
+['lowerRange', 'upperRange'].forEach((id, idx) => {
+    const el = document.getElementById(id);
+    el.addEventListener('input', () => {
+        const prop = idx === 0 ? '--value-a' : '--value-b';
+        const textProp = idx === 0 ? '--text-value-a' : '--text-value-b';
+        el.parentNode.style.setProperty(prop, el.value);
+        el.parentNode.style.setProperty(textProp, `"${el.value}"`);
     });
+});
 
-    // per-year card interactions (event-delegated on the assertions container)
-    const assertionsContainer = document.getElementById('assertionsContainer');
-    assertionsContainer.addEventListener('click', (ev) => {
-        const card = ev.target.closest('[data-year]');
-        if (!card) return;
-        const year = Number(card.dataset.year);
-        if (ev.target.closest('.toggleAssert')) {
-            builder.toggleAssert(year);
-            builder.render(assertionsContainer);
-        } else if (ev.target.closest('.comment')) {
-            document.getElementById('commentYear').value = String(year);
-            const a = builder.model.assertions.find((x) => x.year === year);
-            document.getElementById('commentText').value = a && 'comment' in a ? a.comment : '';
-            bootstrap.Modal.getOrCreateInstance(document.getElementById('testCommentModal')).show();
-        }
-    });
-    assertionsContainer.addEventListener('change', (ev) => {
-        const card = ev.target.closest('[data-year]');
-        if (!card) return;
-        const year = Number(card.dataset.year);
-        if (ev.target.matches('.assertionText')) {
-            builder.setAssertionText(year, ev.target.value);
-        }
-    });
-    document.getElementById('saveCommentBtn').addEventListener('click', () => {
-        const year = Number(document.getElementById('commentYear').value);
-        builder.setComment(year, document.getElementById('commentText').value);
+// per-year card interactions (event-delegated on the assertions container)
+const assertionsContainer = document.getElementById('assertionsContainer');
+assertionsContainer.addEventListener('click', (ev) => {
+    const card = ev.target.closest('[data-year]');
+    if (!card) return;
+    const year = Number(card.dataset.year);
+    if (ev.target.closest('.toggleAssert')) {
+        builder.toggleAssert(year);
         builder.render(assertionsContainer);
-        bootstrap.Modal.getInstance(document.getElementById('testCommentModal')).hide();
-    });
+    } else if (ev.target.closest('.comment')) {
+        document.getElementById('commentYear').value = String(year);
+        const a = builder.model.assertions.find((x) => x.year === year);
+        document.getElementById('commentText').value =
+            a && 'comment' in a ? a.comment : '';
+        bootstrap.Modal.getOrCreateInstance(
+            document.getElementById('testCommentModal'),
+        ).show();
+    }
+});
+assertionsContainer.addEventListener('change', (ev) => {
+    const card = ev.target.closest('[data-year]');
+    if (!card) return;
+    const year = Number(card.dataset.year);
+    if (ev.target.matches('.assertionText')) {
+        builder.setAssertionText(year, ev.target.value);
+    }
+});
+document.getElementById('saveCommentBtn').addEventListener('click', () => {
+    const year = Number(document.getElementById('commentYear').value);
+    builder.setComment(year, document.getElementById('commentText').value);
+    builder.render(assertionsContainer);
+    bootstrap.Modal.getInstance(
+        document.getElementById('testCommentModal'),
+    ).hide();
+});
 
-    async function syncScopeIdField() {
-        const type = document.getElementById('testScopeType').value;
-        const mount = document.getElementById('testScopeIdMount');
-        mount.innerHTML = '';
-        if (type === 'national_calendar' || type === 'diocesan_calendar') {
-            const client = await ApiClient.init(apiUrl).catch(() => null);
-            if (!client) return;
-            const filter = type === 'national_calendar'
+async function syncScopeIdField() {
+    const type = document.getElementById('testScopeType').value;
+    const mount = document.getElementById('testScopeIdMount');
+    mount.innerHTML = '';
+    if (type === 'national_calendar' || type === 'diocesan_calendar') {
+        const client = await ApiClient.init(apiUrl).catch(() => null);
+        if (!client) return;
+        const filter =
+            type === 'national_calendar'
                 ? CalendarSelectFilter.NATIONAL_CALENDARS
                 : CalendarSelectFilter.DIOCESAN_CALENDARS;
-            const sel = new CalendarSelect(config.locale).filter(filter).allowNull(true).class('form-select').id('testScopeId');
-            sel.appendTo(mount);
-        }
+        const sel = new CalendarSelect(config.locale)
+            .filter(filter)
+            .allowNull(true)
+            .class('form-select')
+            .id('testScopeId');
+        sel.appendTo(mount);
     }
-    document.getElementById('testScopeType').addEventListener('change', () => { syncScopeIdField(); regenerate(); });
+}
+document.getElementById('testScopeType').addEventListener('change', () => {
+    syncScopeIdField();
+    regenerate();
+});
 
-    function openEditor(test) {
-        state.editing = test ? test.name : null;
-        document.getElementById('testEditorAlerts').innerHTML = '';
-        const nameEl = document.getElementById('testName');
-        if (test) {
-            builder.load(test);
-            nameEl.value = test.name;
-            nameEl.setAttribute('readonly', '');
-            document.querySelector(`input[name="testType"][value="${test.test_type}"]`).checked = true;
-            document.getElementById('testEventKey').value = test.event_key;
-            document.getElementById('testDescription').value = test.description;
-            const scope = deriveScope(test.applies_to);
-            const typeSel = document.getElementById('testScopeType');
-            typeSel.value = scope.object_type === 'national_calendar_test' ? 'national_calendar'
-                : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
-                : 'general_roman_calendar';
-            loadEvents(test.applies_to).then(() => builder.render(assertionsContainer));
-        } else {
-            builder.load({ name: '', event_key: '', description: '', test_type: TestType.ExactCorrespondence, assertions: [] });
-            nameEl.value = '';
-            nameEl.removeAttribute('readonly');
-            document.getElementById('tt-exact').checked = true;
-            document.getElementById('testEventKey').value = '';
-            document.getElementById('testDescription').value = '';
-            document.getElementById('testScopeType').value = 'general_roman_calendar';
-            assertionsContainer.innerHTML = '';
-            loadEvents(null);
-        }
-        syncScopeIdField();
-        editorModal.show();
-    }
-
-    document.getElementById('createTestBtn').addEventListener('click', () => openEditor(null));
-    document.getElementById('testsTableBody').addEventListener('click', (ev) => {
-        const editBtn = ev.target.closest('.editTestBtn');
-        if (editBtn) {
-            const test = state.tests.find((t) => t.name === editBtn.dataset.name);
-            if (test) openEditor(test);
-        }
-    });
-
-    document.getElementById('saveTestBtn').addEventListener('click', async () => {
-        const btn = document.getElementById('saveTestBtn');
-        const nameEl = document.getElementById('testName');
-        if (!nameEl.checkValidity() || !document.getElementById('testEventKey').value) {
-            showModalAlert(editorModalEl, 'warning', i18n.requiredFields);
-            return;
-        }
-        builder.setMeta({
-            name: nameEl.value,
-            event_key: document.getElementById('testEventKey').value,
-            description: document.getElementById('testDescription').value,
-            test_type: selectedTestType(),
-            applies_to: selectedScope(),
+function openEditor(test) {
+    state.editing = test ? test.name : null;
+    document.getElementById('testEditorAlerts').innerHTML = '';
+    const nameEl = document.getElementById('testName');
+    if (test) {
+        builder.load(test);
+        nameEl.value = test.name;
+        nameEl.setAttribute('readonly', '');
+        document.querySelector(
+            `input[name="testType"][value="${test.test_type}"]`,
+        ).checked = true;
+        document.getElementById('testEventKey').value = test.event_key;
+        document.getElementById('testDescription').value = test.description;
+        const scope = deriveScope(test.applies_to);
+        const typeSel = document.getElementById('testScopeType');
+        typeSel.value =
+            scope.object_type === 'national_calendar_test'
+                ? 'national_calendar'
+                : scope.object_type === 'diocesan_calendar_test'
+                  ? 'diocesan_calendar'
+                  : 'general_roman_calendar';
+        loadEvents(test.applies_to).then(() =>
+            builder.render(assertionsContainer),
+        );
+    } else {
+        builder.load({
+            name: '',
+            event_key: '',
+            description: '',
+            test_type: TestType.ExactCorrespondence,
+            assertions: [],
         });
-        const payload = builder.serialize();
-        btn.disabled = true;
-        const original = btn.textContent;
-        btn.textContent = i18n.saving;
-        try {
-            if (state.editing) {
-                await fetchJson('PATCH', `/tests/${encodeURIComponent(state.editing)}`, payload);
-            } else {
-                await fetchJson('PUT', '/tests', payload);
-            }
-            editorModal.hide();
-            await loadTests();
-        } catch (err) {
-            const msg = err.status === 403 ? i18n.denied403
-                : err.status === 409 ? i18n.conflict409
-                : (err.body && err.body.message) ? err.body.message : i18n.failedToLoad;
-            showModalAlert(editorModalEl, 'danger', msg);
-        } finally {
-            btn.disabled = false;
-            btn.textContent = original;
-        }
+        nameEl.value = '';
+        nameEl.removeAttribute('readonly');
+        document.getElementById('tt-exact').checked = true;
+        document.getElementById('testEventKey').value = '';
+        document.getElementById('testDescription').value = '';
+        document.getElementById('testScopeType').value =
+            'general_roman_calendar';
+        assertionsContainer.innerHTML = '';
+        loadEvents(null);
+    }
+    syncScopeIdField();
+    editorModal.show();
+}
+
+document
+    .getElementById('createTestBtn')
+    .addEventListener('click', () => openEditor(null));
+document.getElementById('testsTableBody').addEventListener('click', (ev) => {
+    const editBtn = ev.target.closest('.editTestBtn');
+    if (editBtn) {
+        const test = state.tests.find((t) => t.name === editBtn.dataset.name);
+        if (test) openEditor(test);
+    }
+});
+
+document.getElementById('saveTestBtn').addEventListener('click', async () => {
+    const btn = document.getElementById('saveTestBtn');
+    const nameEl = document.getElementById('testName');
+    if (
+        !nameEl.checkValidity() ||
+        !document.getElementById('testEventKey').value
+    ) {
+        showModalAlert(editorModalEl, 'warning', i18n.requiredFields);
+        return;
+    }
+    builder.setMeta({
+        name: nameEl.value,
+        event_key: document.getElementById('testEventKey').value,
+        description: document.getElementById('testDescription').value,
+        test_type: selectedTestType(),
+        applies_to: selectedScope(),
     });
+    const payload = builder.serialize();
+    btn.disabled = true;
+    const original = btn.textContent;
+    btn.textContent = i18n.saving;
+    try {
+        if (state.editing) {
+            await fetchJson(
+                'PATCH',
+                `/tests/${encodeURIComponent(state.editing)}`,
+                payload,
+            );
+        } else {
+            await fetchJson('PUT', '/tests', payload);
+        }
+        editorModal.hide();
+        await loadTests();
+    } catch (err) {
+        const msg =
+            err.status === 403
+                ? i18n.denied403
+                : err.status === 409
+                  ? i18n.conflict409
+                  : err.body && err.body.message
+                    ? err.body.message
+                    : i18n.failedToLoad;
+        showModalAlert(editorModalEl, 'danger', msg);
+    } finally {
+        btn.disabled = false;
+        btn.textContent = original;
+    }
+});
 ```
 
 - [ ] **Step 4: Run the editor specs to verify they pass**
@@ -1978,11 +2323,17 @@ test.describe('admin-tests delete (stubbed)', () => {
         await stub(page, { is_global_admin: true, editor: [], admin: [] });
         let deleted = false;
         await page.route('**/tests/GrcOnlyTest', (r) => {
-            if (r.request().method() === 'DELETE') { deleted = true; return r.fulfill({ json: {} }); }
+            if (r.request().method() === 'DELETE') {
+                deleted = true;
+                return r.fulfill({ json: {} });
+            }
             return r.continue();
         });
         await page.goto('/admin-tests.php');
-        await page.locator('tr', { hasText: 'GrcOnlyTest' }).getByRole('button', { name: 'Delete' }).click();
+        await page
+            .locator('tr', { hasText: 'GrcOnlyTest' })
+            .getByRole('button', { name: 'Delete' })
+            .click();
         await expect(page.locator('#deleteTestModal')).toBeVisible();
         await page.locator('#confirmDeleteTestBtn').click();
         await expect.poll(() => deleted).toBe(true);
@@ -2000,33 +2351,44 @@ Expected: FAIL — Delete button does nothing.
 Insert before the final `loadTests();`:
 
 ```javascript
-    // ---- delete -----------------------------------------------------------
+// ---- delete -----------------------------------------------------------
 
-    const deleteModalEl = document.getElementById('deleteTestModal');
-    const deleteModal = bootstrap.Modal.getOrCreateInstance(deleteModalEl);
-    let deleteTarget = null;
+const deleteModalEl = document.getElementById('deleteTestModal');
+const deleteModal = bootstrap.Modal.getOrCreateInstance(deleteModalEl);
+let deleteTarget = null;
 
-    document.getElementById('testsTableBody').addEventListener('click', (ev) => {
-        const delBtn = ev.target.closest('.deleteTestBtn');
-        if (!delBtn) return;
-        deleteTarget = delBtn.dataset.name;
-        document.getElementById('deleteTestAlerts').innerHTML = '';
-        document.getElementById('deleteTestConfirmText').textContent = i18n.confirmDelete.replace('%s', deleteTarget);
-        deleteModal.show();
-    });
+document.getElementById('testsTableBody').addEventListener('click', (ev) => {
+    const delBtn = ev.target.closest('.deleteTestBtn');
+    if (!delBtn) return;
+    deleteTarget = delBtn.dataset.name;
+    document.getElementById('deleteTestAlerts').innerHTML = '';
+    document.getElementById('deleteTestConfirmText').textContent =
+        i18n.confirmDelete.replace('%s', deleteTarget);
+    deleteModal.show();
+});
 
-    document.getElementById('confirmDeleteTestBtn').addEventListener('click', async () => {
+document
+    .getElementById('confirmDeleteTestBtn')
+    .addEventListener('click', async () => {
         if (!deleteTarget) return;
         const btn = document.getElementById('confirmDeleteTestBtn');
         btn.disabled = true;
         const original = btn.textContent;
         btn.textContent = i18n.deleting;
         try {
-            await fetchJson('DELETE', `/tests/${encodeURIComponent(deleteTarget)}`);
+            await fetchJson(
+                'DELETE',
+                `/tests/${encodeURIComponent(deleteTarget)}`,
+            );
             deleteModal.hide();
             await loadTests();
         } catch (err) {
-            const msg = err.status === 403 ? i18n.denied403 : (err.body && err.body.message) ? err.body.message : i18n.failedToLoad;
+            const msg =
+                err.status === 403
+                    ? i18n.denied403
+                    : err.body && err.body.message
+                      ? err.body.message
+                      : i18n.failedToLoad;
             showModalAlert(deleteModalEl, 'danger', msg);
         } finally {
             btn.disabled = false;
@@ -2063,7 +2425,7 @@ git commit -m "feat(admin-tests): delete-confirm flow (DELETE /tests/{name})"
 **Interfaces:**
 
 - Consumes: the existing RBAC harness — `e2e/rbac/support/` (`actingAs`, `grant`, `seed`, `cleanup`) and the `rbac` Playwright project (`dependencies:
-  ['rbac-setup']`). Model on `e2e/rbac/12-test-editor-scoped-test-request.spec.ts`.
+['rbac-setup']`). Model on `e2e/rbac/12-test-editor-scoped-test-request.spec.ts`.
 - Produces: a real end-to-end spec where a seeded `test_editor` with a scoped FGA `editor` tuple creates/edits a test in their scope and is denied
   outside it; a global admin deletes.
 
@@ -2091,8 +2453,14 @@ import { grant } from './support/grant';
 // substitute the actual constants used by spec 12.
 
 test.describe('admin-tests CRUD (real RBAC)', () => {
-    test('scoped national test_editor can create within scope and is denied outside', async ({ page }) => {
-        await grant({ user: 'USCCB_EDITOR', relation: 'editor', object: 'national_calendar_test:USA' });
+    test('scoped national test_editor can create within scope and is denied outside', async ({
+        page,
+    }) => {
+        await grant({
+            user: 'USCCB_EDITOR',
+            relation: 'editor',
+            object: 'national_calendar_test:USA',
+        });
         await actingAs(page, 'USCCB_EDITOR');
 
         await page.goto('/admin-tests.php');
@@ -2108,12 +2476,16 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
         await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
         await page.locator('#testEventKey').dispatchEvent('change');
         await page.locator('#saveTestBtn').click();
-        await expect(page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' })).toBeVisible();
+        await expect(
+            page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' }),
+        ).toBeVisible();
 
         // A General-Roman-scoped row offers no Edit button to this scoped editor
         const grcRow = page.locator('tr', { hasText: 'general_roman' }).first();
         if (await grcRow.count()) {
-            await expect(grcRow.getByRole('button', { name: 'Edit' })).toHaveCount(0);
+            await expect(
+                grcRow.getByRole('button', { name: 'Edit' }),
+            ).toHaveCount(0);
         }
     });
 
@@ -2123,7 +2495,9 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
         const row = page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' });
         await row.getByRole('button', { name: 'Delete' }).click();
         await page.locator('#confirmDeleteTestBtn').click();
-        await expect(page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' })).toHaveCount(0);
+        await expect(
+            page.locator('tr', { hasText: 'PlaywrightUsaScopedTest' }),
+        ).toHaveCount(0);
     });
 });
 ```
@@ -2192,7 +2566,7 @@ git commit -m "docs(admin-tests): mark phase 2 plan steps complete"
 - Per-row Edit (editor scope) / Delete (admin scope) gating from `/auth/test-scopes`; API backstop (403 surfaced) → Tasks 8, 9, 10.
 - Ported editor: test-type buttons + icons (`fa-vial`/`fa-right-from-bracket`/`fa-right-to-bracket`/`fa-square-root-variable`), `/events` datalist
   with `data-month/day/grade`, base date, dual-range slider (`multi-range-slider.css` verbatim), per-year cards with `eventExists AND hasExpectedDate
-  ↔ eventNotExists` toggle + color coding → Tasks 3, 5, 6, 9.
+↔ eventNotExists` toggle + color coding → Tasks 3, 5, 6, 9.
 - Modernizations: Isotope dropped (native CSS grid), state-first (`serialize()` reads the model), `<textarea>` not contenteditable → Tasks 2–5 (+ Task 12 grep gate).
 - `name` read-only when editing; rename = delete+recreate → Task 9.
 - Create `PUT /tests`, edit `PATCH /tests/{name}`, delete `DELETE /tests/{name}` → Tasks 9, 10.

--- a/docs/superpowers/plans/2026-07-05-admin-tests-year-grid-utilities.md
+++ b/docs/superpowers/plans/2026-07-05-admin-tests-year-grid-utilities.md
@@ -43,79 +43,84 @@ PHP/gettext for markup + i18n.
 Append to `assets/js/__tests__/AssertionsBuilder.test.js` (the `event` fixture — `{ event_key: 'StIgnatiusOfLoyola', …, month: 7, day: 31 }` — is already defined at module level):
 
 ```javascript
-describe("excludeYear / includeYear", () => {
-  const build = () => {
-    const b = new AssertionsBuilder({ locale: "en" });
-    b.setMeta({ event_key: event.event_key, test_type: "exactCorrespondence" });
-    b.generate({ event, minYear: 2024, maxYear: 2026 });
-    return b;
-  };
+describe('excludeYear / includeYear', () => {
+    const build = () => {
+        const b = new AssertionsBuilder({ locale: 'en' });
+        b.setMeta({
+            event_key: event.event_key,
+            test_type: 'exactCorrespondence',
+        });
+        b.generate({ event, minYear: 2024, maxYear: 2026 });
+        return b;
+    };
 
-  it("excludeYear removes the assertion and records the exclusion (sorted, deduped)", () => {
-    const b = build();
-    b.excludeYear(2025).excludeYear(2024).excludeYear(2025);
-    expect(b.model.excludes).toEqual([2024, 2025]);
-    expect(b.model.assertions.map((a) => a.year)).toEqual([2026]);
-  });
-
-  it("excludeYear is a no-op for years without an assertion", () => {
-    const b = build();
-    b.excludeYear(1999);
-    expect(b.model.excludes).toBe(null);
-    expect(b.model.assertions).toHaveLength(3);
-  });
-
-  it("includeYear restores an exact assertion with expected_value from baseMonthDay", () => {
-    const b = build();
-    b.excludeYear(2025).includeYear(2025);
-    expect(b.model.excludes).toBe(null);
-    const a = b.model.assertions.find((x) => x.year === 2025);
-    expect(a.assert).toBe("eventExists AND hasExpectedDate");
-    expect(a.expected_value).toBe("2025-07-31T00:00:00+00:00");
-    expect(b.model.assertions.map((x) => x.year)).toEqual([2024, 2025, 2026]);
-  });
-
-  it("includeYear respects the since-pivot (restores eventNotExists before it)", () => {
-    const b = new AssertionsBuilder({ locale: "en" });
-    b.setMeta({
-      event_key: event.event_key,
-      test_type: "exactCorrespondenceSince",
+    it('excludeYear removes the assertion and records the exclusion (sorted, deduped)', () => {
+        const b = build();
+        b.excludeYear(2025).excludeYear(2024).excludeYear(2025);
+        expect(b.model.excludes).toEqual([2024, 2025]);
+        expect(b.model.assertions.map((a) => a.year)).toEqual([2026]);
     });
-    b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2026 });
-    b.excludeYear(2024).includeYear(2024);
-    const a = b.model.assertions.find((x) => x.year === 2024);
-    expect(a.assert).toBe("eventNotExists");
-    expect(a.assertion).toContain("should not exist on");
-  });
 
-  it("serialize emits excludes while excluded and drops the key after restore", () => {
-    const b = build();
-    b.excludeYear(2026);
-    expect(b.serialize().excludes).toEqual([2026]);
-    b.includeYear(2026);
-    expect("excludes" in b.serialize()).toBe(false);
-  });
-
-  it("includeYear is a no-op when the year is not excluded", () => {
-    const b = build();
-    b.includeYear(2025);
-    expect(b.model.excludes).toBe(null);
-    expect(b.model.assertions).toHaveLength(3);
-  });
-
-  it("generate skips excludedYears so regeneration preserves exclusions", () => {
-    // model-level guarantee behind the regenerate() wiring in admin-tests.js
-    const b = build();
-    b.excludeYear(2025);
-    b.generate({
-      event,
-      minYear: 2024,
-      maxYear: 2026,
-      excludedYears: b.model.excludes ?? [],
+    it('excludeYear is a no-op for years without an assertion', () => {
+        const b = build();
+        b.excludeYear(1999);
+        expect(b.model.excludes).toBe(null);
+        expect(b.model.assertions).toHaveLength(3);
     });
-    expect(b.model.assertions.map((a) => a.year)).toEqual([2024, 2026]);
-    expect(b.model.excludes).toEqual([2025]);
-  });
+
+    it('includeYear restores an exact assertion with expected_value from baseMonthDay', () => {
+        const b = build();
+        b.excludeYear(2025).includeYear(2025);
+        expect(b.model.excludes).toBe(null);
+        const a = b.model.assertions.find((x) => x.year === 2025);
+        expect(a.assert).toBe('eventExists AND hasExpectedDate');
+        expect(a.expected_value).toBe('2025-07-31T00:00:00+00:00');
+        expect(b.model.assertions.map((x) => x.year)).toEqual([
+            2024, 2025, 2026,
+        ]);
+    });
+
+    it('includeYear respects the since-pivot (restores eventNotExists before it)', () => {
+        const b = new AssertionsBuilder({ locale: 'en' });
+        b.setMeta({
+            event_key: event.event_key,
+            test_type: 'exactCorrespondenceSince',
+        });
+        b.generate({ event, minYear: 2024, maxYear: 2026, pivotYear: 2026 });
+        b.excludeYear(2024).includeYear(2024);
+        const a = b.model.assertions.find((x) => x.year === 2024);
+        expect(a.assert).toBe('eventNotExists');
+        expect(a.assertion).toContain('should not exist on');
+    });
+
+    it('serialize emits excludes while excluded and drops the key after restore', () => {
+        const b = build();
+        b.excludeYear(2026);
+        expect(b.serialize().excludes).toEqual([2026]);
+        b.includeYear(2026);
+        expect('excludes' in b.serialize()).toBe(false);
+    });
+
+    it('includeYear is a no-op when the year is not excluded', () => {
+        const b = build();
+        b.includeYear(2025);
+        expect(b.model.excludes).toBe(null);
+        expect(b.model.assertions).toHaveLength(3);
+    });
+
+    it('generate skips excludedYears so regeneration preserves exclusions', () => {
+        // model-level guarantee behind the regenerate() wiring in admin-tests.js
+        const b = build();
+        b.excludeYear(2025);
+        b.generate({
+            event,
+            minYear: 2024,
+            maxYear: 2026,
+            excludedYears: b.model.excludes ?? [],
+        });
+        expect(b.model.assertions.map((a) => a.year)).toEqual([2024, 2026]);
+        expect(b.model.excludes).toEqual([2025]);
+    });
 });
 ```
 
@@ -238,7 +243,7 @@ In `assets/css/admin-tests.css`, replace:
 
 ```css
 .year-grid .testYearSpan.deleted {
-  opacity: 0.3;
+    opacity: 0.3;
 }
 ```
 
@@ -247,32 +252,32 @@ with (striped-bar values ported verbatim from `UnitTestInterface/assets/css/admi
 ```css
 .year-grid .testYearSpan.deleted,
 .legend-chip.deleted {
-  background: repeating-linear-gradient(
-    45deg,
-    red,
-    red 5px,
-    white 8px,
-    white 12px
-  );
-  cursor: not-allowed;
+    background: repeating-linear-gradient(
+        45deg,
+        red,
+        red 5px,
+        white 8px,
+        white 12px
+    );
+    cursor: not-allowed;
 }
 
 /* The base .testYearSpan padding stays in effect, so the clickable area is
    ~19px wide even though the visible stripe content is 3px (same as the
    original, where the 3px width sat inside the span's 3px/5px padding). */
 .year-grid .testYearSpan.deleted {
-  width: 3px;
-  height: 32px;
+    width: 3px;
+    height: 32px;
 }
 
 .year-grid .testYearSpan .hammerYear,
 .year-grid .testYearSpan .removeYear {
-  cursor: pointer;
+    cursor: pointer;
 }
 
 .year-grid .testYearSpan .hammerYear:hover,
 .year-grid .testYearSpan .removeYear:hover {
-  opacity: 1 !important;
+    opacity: 1 !important;
 }
 ```
 
@@ -288,77 +293,81 @@ In `assets/js/admin-tests.js`, replace the whole current `renderYearGrid()` func
  * no fixed month/day).
  */
 function yearDateAttrs(year) {
-  if (!builder.baseMonthDay) return { title: "", sunday: false };
-  const d = new Date(
-    Date.UTC(year, builder.baseMonthDay.month - 1, builder.baseMonthDay.day),
-  );
-  const sunday = d.getUTCDay() === 0;
-  const fmt = new Intl.DateTimeFormat(config.locale, {
-    dateStyle: "long",
-    timeZone: "UTC",
-  });
-  const title = sunday
-    ? i18n.sundayInYear
-        .replace("%1$s", String(year))
-        .replace("%2$s", fmt.format(d))
-    : fmt.format(d);
-  return { title, sunday };
+    if (!builder.baseMonthDay) return { title: '', sunday: false };
+    const d = new Date(
+        Date.UTC(
+            year,
+            builder.baseMonthDay.month - 1,
+            builder.baseMonthDay.day,
+        ),
+    );
+    const sunday = d.getUTCDay() === 0;
+    const fmt = new Intl.DateTimeFormat(config.locale, {
+        dateStyle: 'long',
+        timeZone: 'UTC',
+    });
+    const title = sunday
+        ? i18n.sundayInYear
+              .replace('%1$s', String(year))
+              .replace('%2$s', fmt.format(d))
+        : fmt.format(d);
+    return { title, sunday };
 }
 
 function renderYearGrid() {
-  const grid = document.getElementById("yearGrid");
-  const { minYear, maxYear } = sliderYears();
-  const tt = builder.model.test_type;
-  const excluded = new Set(builder.model.excludes ?? []);
-  const notExists = new Set(
-    builder.model.assertions
-      .filter((a) => a.assert === AssertType.EventNotExists)
-      .map((a) => a.year),
-  );
-  const pivot =
-    tt === TestType.ExactCorrespondenceSince
-      ? builder.model.year_since
-      : tt === TestType.ExactCorrespondenceUntil
-        ? builder.model.year_until
-        : null;
-  const showHammer = tt !== TestType.ExactCorrespondence;
-  grid.innerHTML = "";
-  for (let y = minYear; y <= maxYear; y++) {
-    const span = document.createElement("span");
-    span.className = `testYearSpan year-${y}`;
-    span.dataset.year = String(y);
-    if (excluded.has(y)) {
-      span.classList.add("deleted");
-      span.title = i18n.excludedRestore.replace("%s", String(y));
-      grid.appendChild(span);
-      continue;
+    const grid = document.getElementById('yearGrid');
+    const { minYear, maxYear } = sliderYears();
+    const tt = builder.model.test_type;
+    const excluded = new Set(builder.model.excludes ?? []);
+    const notExists = new Set(
+        builder.model.assertions
+            .filter((a) => a.assert === AssertType.EventNotExists)
+            .map((a) => a.year),
+    );
+    const pivot =
+        tt === TestType.ExactCorrespondenceSince
+            ? builder.model.year_since
+            : tt === TestType.ExactCorrespondenceUntil
+              ? builder.model.year_until
+              : null;
+    const showHammer = tt !== TestType.ExactCorrespondence;
+    grid.innerHTML = '';
+    for (let y = minYear; y <= maxYear; y++) {
+        const span = document.createElement('span');
+        span.className = `testYearSpan year-${y}`;
+        span.dataset.year = String(y);
+        if (excluded.has(y)) {
+            span.classList.add('deleted');
+            span.title = i18n.excludedRestore.replace('%s', String(y));
+            grid.appendChild(span);
+            continue;
+        }
+        if (showHammer) {
+            const hammer = document.createElement('i');
+            hammer.className = 'fas fa-hammer me-1 opacity-50 hammerYear';
+            hammer.setAttribute('role', 'button');
+            hammer.setAttribute('aria-hidden', 'true');
+            hammer.title = i18n.setYear;
+            span.appendChild(hammer);
+        }
+        span.appendChild(document.createTextNode(String(y)));
+        const xmark = document.createElement('i');
+        xmark.className = 'fas fa-circle-xmark ms-1 opacity-50 removeYear';
+        xmark.setAttribute('role', 'button');
+        xmark.setAttribute('aria-hidden', 'true');
+        xmark.title = i18n.removeYear;
+        span.appendChild(xmark);
+        const { title, sunday } = yearDateAttrs(y);
+        if (title) span.title = title;
+        if (y === pivot) {
+            span.classList.add('bg-info');
+        } else if (notExists.has(y)) {
+            span.classList.add('bg-warning');
+        } else if (sunday) {
+            span.classList.add('bg-light');
+        }
+        grid.appendChild(span);
     }
-    if (showHammer) {
-      const hammer = document.createElement("i");
-      hammer.className = "fas fa-hammer me-1 opacity-50 hammerYear";
-      hammer.setAttribute("role", "button");
-      hammer.setAttribute("aria-hidden", "true");
-      hammer.title = i18n.setYear;
-      span.appendChild(hammer);
-    }
-    span.appendChild(document.createTextNode(String(y)));
-    const xmark = document.createElement("i");
-    xmark.className = "fas fa-circle-xmark ms-1 opacity-50 removeYear";
-    xmark.setAttribute("role", "button");
-    xmark.setAttribute("aria-hidden", "true");
-    xmark.title = i18n.removeYear;
-    span.appendChild(xmark);
-    const { title, sunday } = yearDateAttrs(y);
-    if (title) span.title = title;
-    if (y === pivot) {
-      span.classList.add("bg-info");
-    } else if (notExists.has(y)) {
-      span.classList.add("bg-warning");
-    } else if (sunday) {
-      span.classList.add("bg-light");
-    }
-    grid.appendChild(span);
-  }
 }
 ```
 
@@ -370,28 +379,32 @@ Append to `e2e/admin-tests.spec.ts` (reuses the existing `stubEditor` helper and
 ONLY rendering; the exclude/restore interaction test is added in Task 3, where the click handler exists — every commit stays green.
 
 ```typescript
-test.describe("admin-tests year grid (stubbed)", () => {
-  test("spans carry hammer/x icons and Sunday highlighting", async ({
-    page,
-  }) => {
-    await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
-    await page.goto("/admin-tests.php");
-    await page.locator("#createTestBtn").click();
-    await page.locator("#tt-variable").check({ force: true });
-    await page.locator("#testEventKey").fill("StIgnatiusOfLoyola");
-    await page.locator("#testEventKey").dispatchEvent("change");
+test.describe('admin-tests year grid (stubbed)', () => {
+    test('spans carry hammer/x icons and Sunday highlighting', async ({
+        page,
+    }) => {
+        await stubEditor(page, {
+            is_global_admin: true,
+            editor: [],
+            admin: [],
+        });
+        await page.goto('/admin-tests.php');
+        await page.locator('#createTestBtn').click();
+        await page.locator('#tt-variable').check({ force: true });
+        await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+        await page.locator('#testEventKey').dispatchEvent('change');
 
-    const span2005 = page.locator("#yearGrid .testYearSpan.year-2005");
-    await expect(span2005).toBeVisible();
-    // variable type → hammer present; x always present; 2005-07-31 is a Sunday
-    await expect(span2005.locator(".hammerYear")).toHaveCount(1);
-    await expect(span2005.locator(".removeYear")).toHaveCount(1);
-    await expect(span2005).toHaveClass(/bg-light/);
-    // exactCorrespondence type → hammer absent
-    await page.locator("#tt-exact").check({ force: true });
-    await expect(span2005.locator(".hammerYear")).toHaveCount(0);
-    await expect(span2005.locator(".removeYear")).toHaveCount(1);
-  });
+        const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
+        await expect(span2005).toBeVisible();
+        // variable type → hammer present; x always present; 2005-07-31 is a Sunday
+        await expect(span2005.locator('.hammerYear')).toHaveCount(1);
+        await expect(span2005.locator('.removeYear')).toHaveCount(1);
+        await expect(span2005).toHaveClass(/bg-light/);
+        // exactCorrespondence type → hammer absent
+        await page.locator('#tt-exact').check({ force: true });
+        await expect(span2005.locator('.hammerYear')).toHaveCount(0);
+        await expect(span2005.locator('.removeYear')).toHaveCount(1);
+    });
 });
 ```
 
@@ -418,7 +431,7 @@ git commit -m "feat(admin-tests): year-grid icons, Sunday highlighting, striped 
 **Files:**
 
 - Modify: `assets/js/admin-tests.js` — replace the existing `#yearGrid` click handler (the block starting with the comment `// For Since/Until types, clicking a year in the
-  overview grid sets the pivot`), and one line in `regenerate()`
+overview grid sets the pivot`), and one line in `regenerate()`
 
 **Interfaces:**
 
@@ -433,18 +446,18 @@ In `assets/js/admin-tests.js`, replace this entire existing block:
 ```javascript
 // For Since/Until types, clicking a year in the overview grid sets the pivot
 // (year_since / year_until) and re-splits the assertions around it.
-document.getElementById("yearGrid").addEventListener("click", (ev) => {
-  const span = ev.target.closest(".testYearSpan");
-  if (!span) return;
-  const tt = selectedTestType();
-  if (
-    tt !== TestType.ExactCorrespondenceSince &&
-    tt !== TestType.ExactCorrespondenceUntil
-  )
-    return;
-  builder.setPivot(Number(span.dataset.year));
-  builder.render(assertionsContainer);
-  renderYearGrid();
+document.getElementById('yearGrid').addEventListener('click', (ev) => {
+    const span = ev.target.closest('.testYearSpan');
+    if (!span) return;
+    const tt = selectedTestType();
+    if (
+        tt !== TestType.ExactCorrespondenceSince &&
+        tt !== TestType.ExactCorrespondenceUntil
+    )
+        return;
+    builder.setPivot(Number(span.dataset.year));
+    builder.render(assertionsContainer);
+    renderYearGrid();
 });
 ```
 
@@ -456,29 +469,29 @@ with:
 //   x-mark  → exclude the year (collapses to the striped bar)
 //   striped bar → restore the year
 //   span body   → no action (the icons are the affordances)
-document.getElementById("yearGrid").addEventListener("click", (ev) => {
-  const span = ev.target.closest(".testYearSpan");
-  if (!span) return;
-  const year = Number(span.dataset.year);
-  if (span.classList.contains("deleted")) {
-    builder.includeYear(year);
-  } else if (ev.target.closest(".removeYear")) {
-    builder.excludeYear(year);
-  } else if (ev.target.closest(".hammerYear")) {
-    const tt = selectedTestType();
-    if (
-      tt === TestType.ExactCorrespondenceSince ||
-      tt === TestType.ExactCorrespondenceUntil
-    ) {
-      builder.setPivot(year);
-    } else if (tt === TestType.VariableCorrespondence) {
-      builder.toggleAssert(year);
+document.getElementById('yearGrid').addEventListener('click', (ev) => {
+    const span = ev.target.closest('.testYearSpan');
+    if (!span) return;
+    const year = Number(span.dataset.year);
+    if (span.classList.contains('deleted')) {
+        builder.includeYear(year);
+    } else if (ev.target.closest('.removeYear')) {
+        builder.excludeYear(year);
+    } else if (ev.target.closest('.hammerYear')) {
+        const tt = selectedTestType();
+        if (
+            tt === TestType.ExactCorrespondenceSince ||
+            tt === TestType.ExactCorrespondenceUntil
+        ) {
+            builder.setPivot(year);
+        } else if (tt === TestType.VariableCorrespondence) {
+            builder.toggleAssert(year);
+        }
+    } else {
+        return;
     }
-  } else {
-    return;
-  }
-  builder.render(assertionsContainer);
-  renderYearGrid();
+    builder.render(assertionsContainer);
+    renderYearGrid();
 });
 ```
 
@@ -497,11 +510,11 @@ to:
 // skips excluded years, so without this every regeneration would
 // silently restore them.
 builder.generate({
-  event,
-  minYear,
-  maxYear,
-  pivotYear: pivot,
-  excludedYears: builder.model.excludes ?? [],
+    event,
+    minYear,
+    maxYear,
+    pivotYear: pivot,
+    excludedYears: builder.model.excludes ?? [],
 });
 ```
 
@@ -510,33 +523,33 @@ builder.generate({
 Inside the `test.describe("admin-tests year grid (stubbed)", …)` block added in Task 2, add:
 
 ```typescript
-  test("exclude collapses to the striped bar and restore brings the card back", async ({
+test('exclude collapses to the striped bar and restore brings the card back', async ({
     page,
-  }) => {
+}) => {
     await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
-    await page.goto("/admin-tests.php");
-    await page.locator("#createTestBtn").click();
-    await page.locator("#tt-variable").check({ force: true });
-    await page.locator("#testEventKey").fill("StIgnatiusOfLoyola");
-    await page.locator("#testEventKey").dispatchEvent("change");
+    await page.goto('/admin-tests.php');
+    await page.locator('#createTestBtn').click();
+    await page.locator('#tt-variable').check({ force: true });
+    await page.locator('#testEventKey').fill('StIgnatiusOfLoyola');
+    await page.locator('#testEventKey').dispatchEvent('change');
 
-    const span2005 = page.locator("#yearGrid .testYearSpan.year-2005");
+    const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
     await expect(span2005).toBeVisible();
 
     // exclude: card disappears, span collapses to the striped bar
-    await span2005.locator(".removeYear").click();
+    await span2005.locator('.removeYear').click();
     await expect(span2005).toHaveClass(/deleted/);
     await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
-      0,
+        0,
     );
 
     // restore: card returns, stripes gone
     await span2005.click();
     await expect(span2005).not.toHaveClass(/deleted/);
     await expect(page.locator('.assertion-card[data-year="2005"]')).toHaveCount(
-      1,
+        1,
     );
-  });
+});
 ```
 
 Run: `yarn playwright test e2e/admin-tests.spec.ts --project=chromium -g "year grid"`
@@ -596,18 +609,18 @@ Append to `assets/css/admin-tests.css` (AFTER the shared `.deleted` rule from Ta
 ```css
 /* Legend chips reuse the exact grid classes so legend and grid cannot drift. */
 .legend-chip {
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  border: 1px solid var(--bs-border-color);
-  border-radius: 0.25rem;
-  vertical-align: text-bottom;
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.25rem;
+    vertical-align: text-bottom;
 }
 
 .legend-chip.deleted {
-  width: 5px;
-  height: 1.25rem;
-  border: none;
+    width: 5px;
+    height: 1.25rem;
+    border: none;
 }
 ```
 
@@ -616,14 +629,14 @@ Append to `assets/css/admin-tests.css` (AFTER the shared `.deleted` rule from Ta
 Inside the `test.describe('admin-tests year grid (stubbed)', …)` block from Task 2, add:
 
 ```typescript
-test("legend row is visible with all five chips", async ({ page }) => {
-  await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
-  await page.goto("/admin-tests.php");
-  await page.locator("#createTestBtn").click();
-  const legend = page.locator("#yearGridLegend");
-  await expect(legend).toBeVisible();
-  await expect(legend.locator(".legend-chip")).toHaveCount(5);
-  await expect(legend.locator(".legend-chip.deleted")).toHaveCount(1);
+test('legend row is visible with all five chips', async ({ page }) => {
+    await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
+    await page.goto('/admin-tests.php');
+    await page.locator('#createTestBtn').click();
+    const legend = page.locator('#yearGridLegend');
+    await expect(legend).toBeVisible();
+    await expect(legend.locator('.legend-chip')).toHaveCount(5);
+    await expect(legend.locator('.legend-chip.deleted')).toHaveCount(1);
 });
 ```
 

--- a/docs/superpowers/plans/2026-07-11-admin-decrees-page.md
+++ b/docs/superpowers/plans/2026-07-11-admin-decrees-page.md
@@ -34,15 +34,19 @@ endpoints.
 **Interfaces:**
 
 - Produces (consumed by Task 4):
-  - `DecreeAction` — frozen enum `{ CreateNew: 'createNew', SetPropertyGrade: 'setProperty:grade', SetPropertyName: 'setProperty:name', MakeDoctor: 'makeDoctor' }`
-  - `buildDecreePayload(form)` — `form` is a plain object (see test below); returns the API payload object
-  - `validateDecreePayload(payload, baseLocale, isCreate)` — returns `string[]` of error messages (empty = valid), mirroring the server matrix
+    - `DecreeAction` — frozen enum `{ CreateNew: 'createNew', SetPropertyGrade: 'setProperty:grade', SetPropertyName: 'setProperty:name', MakeDoctor: 'makeDoctor' }`
+    - `buildDecreePayload(form)` — `form` is a plain object (see test below); returns the API payload object
+    - `validateDecreePayload(payload, baseLocale, isCreate)` — returns `string[]` of error messages (empty = valid), mirroring the server matrix
 
 - [ ] **Step 1: Write the failing tests**
 
 ```javascript
 import { describe, it, expect } from 'vitest';
-import { DecreeAction, buildDecreePayload, validateDecreePayload } from '../DecreePayload.js';
+import {
+    DecreeAction,
+    buildDecreePayload,
+    validateDecreePayload,
+} from '../DecreePayload.js';
 
 const createNewForm = () => ({
     action: DecreeAction.CreateNew,
@@ -83,7 +87,11 @@ describe('buildDecreePayload', () => {
     });
 
     it('builds a mobile createNew payload with strtotime and no day/month', () => {
-        const form = { ...createNewForm(), event_type: 'mobile', strtotime: 'Monday after Pentecost' };
+        const form = {
+            ...createNewForm(),
+            event_type: 'mobile',
+            strtotime: 'Monday after Pentecost',
+        };
         delete form.day;
         delete form.month;
         const p = buildDecreePayload(form);
@@ -92,7 +100,12 @@ describe('buildDecreePayload', () => {
     });
 
     it('splits setProperty actions into action + property', () => {
-        const p = buildDecreePayload({ ...createNewForm(), action: DecreeAction.SetPropertyGrade, i18n: undefined, readings: undefined });
+        const p = buildDecreePayload({
+            ...createNewForm(),
+            action: DecreeAction.SetPropertyGrade,
+            i18n: undefined,
+            readings: undefined,
+        });
         expect(p.metadata.action).toBe('setProperty');
         expect(p.metadata.property).toBe('grade');
         expect(p).not.toHaveProperty('i18n');
@@ -102,28 +115,49 @@ describe('buildDecreePayload', () => {
 
 describe('validateDecreePayload', () => {
     it('accepts a complete createNew payload on create', () => {
-        expect(validateDecreePayload(buildDecreePayload(createNewForm()), 'en', true)).toEqual([]);
+        expect(
+            validateDecreePayload(
+                buildDecreePayload(createNewForm()),
+                'en',
+                true,
+            ),
+        ).toEqual([]);
     });
 
     it('requires i18n with the base locale for name-bearing actions', () => {
-        const p = buildDecreePayload({ ...createNewForm(), i18n: { it: 'San Test' } });
+        const p = buildDecreePayload({
+            ...createNewForm(),
+            i18n: { it: 'San Test' },
+        });
         const errors = validateDecreePayload(p, 'en', true);
         expect(errors.some((e) => e.includes('en'))).toBe(true);
     });
 
     it('rejects i18n for setProperty:grade', () => {
-        const p = buildDecreePayload({ ...createNewForm(), action: DecreeAction.SetPropertyGrade, readings: undefined });
+        const p = buildDecreePayload({
+            ...createNewForm(),
+            action: DecreeAction.SetPropertyGrade,
+            readings: undefined,
+        });
         expect(validateDecreePayload(p, 'en', false).length).toBeGreaterThan(0);
     });
 
     it('requires readings on create only for createNew', () => {
-        const noReadings = buildDecreePayload({ ...createNewForm(), readings: undefined });
-        expect(validateDecreePayload(noReadings, 'en', true).length).toBeGreaterThan(0);
+        const noReadings = buildDecreePayload({
+            ...createNewForm(),
+            readings: undefined,
+        });
+        expect(
+            validateDecreePayload(noReadings, 'en', true).length,
+        ).toBeGreaterThan(0);
         expect(validateDecreePayload(noReadings, 'en', false)).toEqual([]);
     });
 
     it('rejects readings on create for makeDoctor', () => {
-        const p = buildDecreePayload({ ...createNewForm(), action: DecreeAction.MakeDoctor });
+        const p = buildDecreePayload({
+            ...createNewForm(),
+            action: DecreeAction.MakeDoctor,
+        });
         expect(validateDecreePayload(p, 'en', true).length).toBeGreaterThan(0);
     });
 });
@@ -143,10 +177,10 @@ Expected: FAIL — module not found.
  * remains authoritative; this exists for fast form feedback.
  */
 export const DecreeAction = Object.freeze({
-    CreateNew:        'createNew',
+    CreateNew: 'createNew',
     SetPropertyGrade: 'setProperty:grade',
-    SetPropertyName:  'setProperty:name',
-    MakeDoctor:       'makeDoctor',
+    SetPropertyName: 'setProperty:name',
+    MakeDoctor: 'makeDoctor',
 });
 
 const splitAction = (action) => {
@@ -161,7 +195,11 @@ export const buildDecreePayload = (form) => {
         calendar: 'GENERAL ROMAN',
         ...(form.event_type === 'mobile'
             ? { strtotime: form.strtotime, type: 'mobile' }
-            : { day: Number(form.day), month: Number(form.month), type: 'fixed' }),
+            : {
+                  day: Number(form.day),
+                  month: Number(form.month),
+                  type: 'fixed',
+              }),
         ...(form.grade !== undefined ? { grade: Number(form.grade) } : {}),
         ...(form.color ? { color: form.color } : {}),
         ...(form.common ? { common: form.common } : {}),
@@ -191,25 +229,37 @@ export const buildDecreePayload = (form) => {
 export const validateDecreePayload = (payload, baseLocale, isCreate) => {
     const errors = [];
     const { action, property } = payload.metadata;
-    const nameBearing = action === 'createNew' || action === 'makeDoctor'
-        || (action === 'setProperty' && property === 'name');
+    const nameBearing =
+        action === 'createNew' ||
+        action === 'makeDoctor' ||
+        (action === 'setProperty' && property === 'name');
 
     if (nameBearing) {
         if (!payload.i18n || Object.keys(payload.i18n).length === 0) {
-            errors.push(`Action "${action}" requires at least one translated event name (i18n)`);
+            errors.push(
+                `Action "${action}" requires at least one translated event name (i18n)`,
+            );
         } else if (!(baseLocale in payload.i18n)) {
-            errors.push(`The i18n object must include an entry for your locale "${baseLocale}"`);
+            errors.push(
+                `The i18n object must include an entry for your locale "${baseLocale}"`,
+            );
         }
     } else if (payload.i18n) {
-        errors.push('A grade change does not affect the event name: remove the i18n translations');
+        errors.push(
+            'A grade change does not affect the event name: remove the i18n translations',
+        );
     }
 
     if (isCreate) {
         if (action === 'createNew' && !payload.readings) {
-            errors.push('A new liturgical event must define its lectionary readings');
+            errors.push(
+                'A new liturgical event must define its lectionary readings',
+            );
         }
         if (action !== 'createNew' && payload.readings) {
-            errors.push(`Action "${action}" does not accept readings on creation; correct readings via an edit instead`);
+            errors.push(
+                `Action "${action}" does not accept readings on creation; correct readings via an edit instead`,
+            );
         }
     }
     return errors;
@@ -351,12 +401,23 @@ async function detectCapabilities() {
     if (config.isGlobalAdmin) {
         return { canView: true, canEdit: true, canAdmin: true };
     }
-    const check = (relation) => fetchJson(
-        'GET',
-        `/admin/permissions/check?object_type=general_roman_calendar&object_id=decrees&relation=${relation}`
-    ).then((r) => r.allowed === true).catch(() => false);
-    const [viewer, editor, admin] = await Promise.all([check('viewer'), check('editor'), check('admin')]);
-    return { canView: viewer || editor || admin, canEdit: editor || admin, canAdmin: admin };
+    const check = (relation) =>
+        fetchJson(
+            'GET',
+            `/admin/permissions/check?object_type=general_roman_calendar&object_id=decrees&relation=${relation}`,
+        )
+            .then((r) => r.allowed === true)
+            .catch(() => false);
+    const [viewer, editor, admin] = await Promise.all([
+        check('viewer'),
+        check('editor'),
+        check('admin'),
+    ]);
+    return {
+        canView: viewer || editor || admin,
+        canEdit: editor || admin,
+        canAdmin: admin,
+    };
 }
 ```
 
@@ -413,10 +474,10 @@ JS toggling: on `#decreeAction` change, show/hide blocks:
 
 ```javascript
 const MATRIX = {
-    'createNew':        { i18n: true,  readingsOnCreate: true  },
-    'makeDoctor':       { i18n: true,  readingsOnCreate: false },
-    'setProperty:name': { i18n: true,  readingsOnCreate: false },
-    'setProperty:grade':{ i18n: false, readingsOnCreate: false },
+    createNew: { i18n: true, readingsOnCreate: true },
+    makeDoctor: { i18n: true, readingsOnCreate: false },
+    'setProperty:name': { i18n: true, readingsOnCreate: false },
+    'setProperty:grade': { i18n: false, readingsOnCreate: false },
 };
 ```
 
@@ -453,7 +514,11 @@ git commit -m "feat: action-driven decree editor modal"
 ```javascript
 async function saveDecree(payload, isCreate) {
     const method = isCreate ? 'PUT' : 'PATCH';
-    await fetchJson(method, `/decrees/${encodeURIComponent(payload.decree_id)}`, payload);
+    await fetchJson(
+        method,
+        `/decrees/${encodeURIComponent(payload.decree_id)}`,
+        payload,
+    );
     showToast(isCreate ? config.i18n.created : config.i18n.updated);
     await reloadDecrees();
 }

--- a/docs/superpowers/plans/2026-07-12-admin-dashboard-fga-gating.md
+++ b/docs/superpowers/plans/2026-07-12-admin-dashboard-fga-gating.md
@@ -483,24 +483,24 @@ Three edits:
 
 1. In the `use` block, next to the existing `AdminScopesHandler` import, add:
 
-   ```php
-   use LiturgicalCalendar\Api\Handlers\Auth\DashboardScopesHandler;
-   ```
+    ```php
+    use LiturgicalCalendar\Api\Handlers\Auth\DashboardScopesHandler;
+    ```
 
 2. In the auth dispatch chain, after the `test-scopes` elseif (~line 371-375):
 
-   ```php
-                       } elseif ($authRoute === 'dashboard-scopes') {
-                           // GET /auth/dashboard-scopes - Batched admin/viewer scopes for the frontend admin dashboard
-                           $dashboardScopesHandler = new DashboardScopesHandler();
-                           $this->handler          = $dashboardScopesHandler;
-   ```
+    ```php
+                        } elseif ($authRoute === 'dashboard-scopes') {
+                            // GET /auth/dashboard-scopes - Batched admin/viewer scopes for the frontend admin dashboard
+                            $dashboardScopesHandler = new DashboardScopesHandler();
+                            $this->handler          = $dashboardScopesHandler;
+    ```
 
 3. In the OIDC-protected auth route list (~line 622), add `'dashboard-scopes'`:
 
-   ```php
-   in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications', 'admin-scopes', 'test-scopes', 'dashboard-scopes'], true)
-   ```
+    ```php
+    in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications', 'admin-scopes', 'test-scopes', 'dashboard-scopes'], true)
+    ```
 
 - [ ] **Step 5: Run tests to verify they pass, plus static analysis and lint**
 
@@ -647,11 +647,11 @@ git commit -m "docs(openapi): document GET /auth/dashboard-scopes"
 - Consumes: `GET {apiBase}/auth/dashboard-scopes` (Task 2 shape); existing private `buildCookieHeader()`,
   `ApiConfig::getInstance()->apiBaseUrl`, `API_INTERNAL_URL` env override.
 - Produces (Task 5 consumes exactly these):
-  - `public function dashboardScopes(): array` —
-    `array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}`
-  - `public function canViewResource(string $objectType, string $objectId): bool`
-  - `public function canViewAnyResourceOfType(string ...$objectTypes): bool`
-  - `public static function fetchDashboardScopes(string $apiBaseUrl, ?string $cookieHeader, ?\GuzzleHttp\Client $client = null): array`
+    - `public function dashboardScopes(): array` —
+      `array{is_global_admin: bool, is_resource_admin: bool, admin_scopes: array<int, array{object_type: string, object_id: string}>, viewer_scopes: array<string, list<string>>}`
+    - `public function canViewResource(string $objectType, string $objectId): bool`
+    - `public function canViewAnyResourceOfType(string ...$objectTypes): bool`
+    - `public static function fetchDashboardScopes(string $apiBaseUrl, ?string $cookieHeader, ?\GuzzleHttp\Client $client = null): array`
 
 - [ ] **Step 1: Create the branch**
 
@@ -1094,7 +1094,7 @@ fail. FGA tuples ARE evaluated live, so tuple grants at runtime remain fine.
 Widen the role union:
 
 ```ts
-    role: 'admin' | 'calendar_editor' | 'test_editor';
+role: 'admin' | 'calendar_editor' | 'test_editor';
 ```
 
 (also update the `mk()` parameter type if it repeats the union). Add to `USERS`:
@@ -1120,30 +1120,65 @@ interface Expected {
     reviewCard: boolean;
 }
 
-const ALWAYS_VISIBLE = ['sanctorale', 'widerregion', 'national', 'diocesan'] as const;
+const ALWAYS_VISIBLE = [
+    'sanctorale',
+    'widerregion',
+    'national',
+    'diocesan',
+] as const;
 
 const MATRIX: Record<string, Expected> = {
     // Global admin: role bypasses all FGA gates — all six blocks.
-    'super-admin': { visibleBlocks: [...ALWAYS_VISIBLE, 'temporale', 'decrees'], hiddenBlocks: [], globalAdminSection: true, reviewCard: false },
+    'super-admin': {
+        visibleBlocks: [...ALWAYS_VISIBLE, 'temporale', 'decrees'],
+        hiddenBlocks: [],
+        globalAdminSection: true,
+        reviewCard: false,
+    },
     // calendar_editors WITHOUT any general_roman_calendar relation: temporale + decrees hidden.
-    'cei-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
-    'cei-editor': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: false },
-    'usccb-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
+    'cei-admin': {
+        visibleBlocks: [...ALWAYS_VISIBLE],
+        hiddenBlocks: ['temporale', 'decrees'],
+        globalAdminSection: false,
+        reviewCard: true,
+    },
+    'cei-editor': {
+        visibleBlocks: [...ALWAYS_VISIBLE],
+        hiddenBlocks: ['temporale', 'decrees'],
+        globalAdminSection: false,
+        reviewCard: false,
+    },
+    'usccb-admin': {
+        visibleBlocks: [...ALWAYS_VISIBLE],
+        hiddenBlocks: ['temporale', 'decrees'],
+        globalAdminSection: false,
+        reviewCard: true,
+    },
     // admin@general_roman_calendar:temporale → temporale visible (viewer via admin), decrees still hidden.
-    'grc-admin': { visibleBlocks: [...ALWAYS_VISIBLE, 'temporale'], hiddenBlocks: ['decrees'], globalAdminSection: false, reviewCard: true },
-    'europe-admin': { visibleBlocks: [...ALWAYS_VISIBLE], hiddenBlocks: ['temporale', 'decrees'], globalAdminSection: false, reviewCard: true },
+    'grc-admin': {
+        visibleBlocks: [...ALWAYS_VISIBLE, 'temporale'],
+        hiddenBlocks: ['decrees'],
+        globalAdminSection: false,
+        reviewCard: true,
+    },
+    'europe-admin': {
+        visibleBlocks: [...ALWAYS_VISIBLE],
+        hiddenBlocks: ['temporale', 'decrees'],
+        globalAdminSection: false,
+        reviewCard: true,
+    },
 };
 ```
 
 In `assertMatrix()`, replace the six-card loop with:
 
 ```ts
-    for (const id of expected.visibleBlocks) {
-        await expect(page.locator(SEL.calendarBlock(id))).toBeVisible();
-    }
-    for (const id of expected.hiddenBlocks) {
-        await expect(page.locator(SEL.calendarBlock(id))).toHaveCount(0);
-    }
+for (const id of expected.visibleBlocks) {
+    await expect(page.locator(SEL.calendarBlock(id))).toBeVisible();
+}
+for (const id of expected.hiddenBlocks) {
+    await expect(page.locator(SEL.calendarBlock(id))).toHaveCount(0);
+}
 ```
 
 Rewrite the header comment's "NOTE on scope narrowing" section: the dashboard NOW narrows Temporale/Decrees block
@@ -1184,7 +1219,9 @@ test.describe.serial('15 — dashboard Tests-card matrix', () => {
         await revokeScope('tests-editor');
     });
 
-    test('test_editor WITH a test scope sees the Tests card', async ({ browser }) => {
+    test('test_editor WITH a test scope sees the Tests card', async ({
+        browser,
+    }) => {
         const page = await actingAs(browser, 'tests-editor');
         await page.goto('/admin-dashboard.php');
         await expect(page.locator(HEADING)).toBeVisible();
@@ -1192,7 +1229,9 @@ test.describe.serial('15 — dashboard Tests-card matrix', () => {
         await page.context().close();
     });
 
-    test('test_editor WITHOUT a test scope does NOT see the Tests card', async ({ browser }) => {
+    test('test_editor WITHOUT a test scope does NOT see the Tests card', async ({
+        browser,
+    }) => {
         const page = await actingAs(browser, 'tests-editor-noscope');
         await page.goto('/admin-dashboard.php');
         await expect(page.locator(HEADING)).toBeVisible();

--- a/docs/superpowers/plans/2026-08-11-usage-rite-selector.md
+++ b/docs/superpowers/plans/2026-08-11-usage-rite-selector.md
@@ -295,6 +295,7 @@ Add to `assets/js/__tests__/subscriptionUrl.test.js`. Also add `CurrentEndpoint.
 describe('CurrentEndpoint rite segment', () => {
     beforeEach(reset);
 
+    // Removed during final review as tautological — see the note at Step 4.
     it('defaults to the roman rite', () => {
         expect(CurrentEndpoint.rite).toBe('roman');
     });
@@ -386,6 +387,12 @@ currentEndpoint += `/${CurrentEndpoint.rite}`;
 Run: `yarn test:unit assets/js/__tests__/subscriptionUrl.test.js`
 
 Expected: PASS, 11 tests.
+
+> **Superseded:** the file now holds **10**. The `'defaults to the roman rite'`
+> case below was removed during final review as tautological — `reset()` runs in
+> `beforeEach` and force-sets the very value the test asserted, so it could not
+> fail even if the class default changed. Task 2 did produce 11; the count
+> dropped afterwards.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-11-usage-rite-selector.md
+++ b/docs/superpowers/plans/2026-08-11-usage-rite-selector.md
@@ -1,0 +1,988 @@
+# Rite Selector and Rite-Aware Subscription URL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Give `usage.php`'s calendar-subscription card a rite selector, and make the subscription URL it builds rite-explicit.
+
+**Architecture:** The subscription card's dropdown moves from the server-rendered PHP `CalendarSelect` to the
+JS `CalendarSelect` + `RiteSelect` from liturgy-components-js, linked with `linkToRiteSelect()` so the
+calendar list repartitions when the rite changes. The URL model (`CalendarType`, `RequestPayload`,
+`CurrentEndpoint`) is extracted out of `usage.js` into a dependency-free module so it can be unit-tested, and
+gains a rite path segment. Finally the now-unused PHP-components bootstrap is gated to the one page that still
+needs it.
+
+**Tech Stack:** PHP 8.4, vanilla ES6 modules, liturgy-components-js 2.1.0 (CDN importmap, or
+`assets/components-js` symlink in dev), Vitest + jsdom for unit tests, Playwright for e2e.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-11-usage-rite-selector-design.md`. Read it before starting.
+- **The rite segment is always emitted, `roman` included.** `/calendar/roman/nation/IT`, never `/calendar/nation/IT`.
+- **The rite segment goes immediately after the API base and before `/{calendarType}/{calendarId}`.**
+  `CurrentEndpoint.apiBase` already ends in `/calendar`, so the result is `/calendar/roman/nation/IT`.
+  Appending the rite later yields `/calendar/nation/IT/roman`, which the API rejects.
+- **`liturgical-calendar/components` stays in `composer.json` at `^4.2`.** It is load-bearing for the embedded PHP example, which skips its own autoloader. Do not remove it.
+- **`includes/common.php`'s `ApiClient::getInstance()` block is not deleted, only gated.** The embedded PHP example uses that singleton.
+- **gettext uses numbered placeholders** (`%1$s`, not `%s`) if any new format string is added.
+- **Never `git commit --no-verify`.** Pre-commit hooks run `composer lint` and `composer lint:md`.
+- **`assets/js/subscriptionUrl.js` must not import from `@liturgical-calendar/components-js`.** That package
+  is not in `node_modules` — it resolves only via the browser importmap — so a Vitest test importing it
+  transitively would fail. The rite crosses the boundary as a plain string.
+
+## File Structure
+
+| File                                                | Responsibility                                                                                       |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `assets/js/subscriptionUrl.js` (new)                | Pure URL model: `CalendarType`, `RequestPayload`, `CurrentEndpoint`. No imports, no DOM, no globals. |
+| `assets/js/__tests__/subscriptionUrl.test.js` (new) | Vitest coverage of URL composition.                                                                  |
+| `assets/js/usage.js` (modify)                       | Imports the URL model and the JS components; builds and wires the selects.                           |
+| `usage.php` (modify)                                | Drops the PHP `CalendarSelect`; renders two empty containers and two new label strings.              |
+| `includes/common.php` (modify)                      | Gates the PHP-components bootstrap to `examples.php`.                                                |
+| `e2e/usage.spec.ts` (new)                           | Playwright coverage of the rendered page.                                                            |
+
+---
+
+### Task 1: Extract the URL model into a testable module
+
+Pure refactor — no behaviour change. `usage.js` currently defines `CalendarType`, `RequestPayload` and
+`CurrentEndpoint` inline, with `CurrentEndpoint.apiBase` reading the `CalendarUrl` global. Moving them out
+lets Task 2 unit-test the rite segment without a browser.
+
+**Files:**
+
+- Create: `assets/js/subscriptionUrl.js`
+- Create: `assets/js/__tests__/subscriptionUrl.test.js`
+- Modify: `assets/js/usage.js:1-59` (remove the three definitions), `assets/js/usage.js:223` (set `apiBase`)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `CalendarType` (frozen object, `NATIONAL: 'nation'`, `DIOCESAN: 'diocese'`); `RequestPayload`
+  (class with static fields `epiphany`, `ascension`, `corpus_christi`, `eternal_high_priest`, `locale`,
+  `return_type = 'ICS'`, `year_type = 'CIVIL'`); `CurrentEndpoint` (class with static fields `apiBase = ''`,
+  `calendarType = null`, `calendarId = null`, `calendarYear = null`, and static method `serialize(): string`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `assets/js/__tests__/subscriptionUrl.test.js`:
+
+```js
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    CalendarType,
+    RequestPayload,
+    CurrentEndpoint,
+} from '../subscriptionUrl.js';
+
+const reset = () => {
+    CurrentEndpoint.apiBase = 'https://example.test/calendar';
+    CurrentEndpoint.calendarType = null;
+    CurrentEndpoint.calendarId = null;
+    CurrentEndpoint.calendarYear = null;
+    RequestPayload.epiphany = null;
+    RequestPayload.ascension = null;
+    RequestPayload.corpus_christi = null;
+    RequestPayload.eternal_high_priest = null;
+    RequestPayload.locale = null;
+    RequestPayload.return_type = 'ICS';
+    RequestPayload.year_type = 'CIVIL';
+};
+
+describe('CurrentEndpoint.serialize', () => {
+    beforeEach(reset);
+
+    it('emits the bare base with its query parameters when nothing is selected', () => {
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits a national calendar path', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = 'IT';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/nation/IT?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits a diocesan calendar path', () => {
+        CurrentEndpoint.calendarType = CalendarType.DIOCESAN;
+        CurrentEndpoint.calendarId = 'romamo_it';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/diocese/romamo_it?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('omits the calendar segment when the id is null', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = null;
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('skips null and empty payload fields', () => {
+        RequestPayload.locale = '';
+        RequestPayload.epiphany = 'JAN6';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar?epiphany=JAN6&return_type=ICS&year_type=CIVIL',
+        );
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `yarn test:unit assets/js/__tests__/subscriptionUrl.test.js`
+
+Expected: FAIL — `Failed to resolve import "../subscriptionUrl.js"`.
+
+- [ ] **Step 3: Create the module**
+
+Create `assets/js/subscriptionUrl.js` by moving the definitions from `assets/js/usage.js:1-59` verbatim, with
+one change: `apiBase` becomes a plain static field instead of a getter reading the `CalendarUrl` global, so
+the module has no global dependency and the test can set it.
+
+```js
+/**
+ * The subscription URL model for usage.php's calendar-subscription card.
+ *
+ * Deliberately free of imports, DOM access and globals: `usage.js` injects
+ * `CurrentEndpoint.apiBase` at startup, and the rite arrives as a plain string.
+ * `@liturgical-calendar/components-js` resolves only through the browser
+ * importmap, so importing it here would break the Vitest suite.
+ */
+
+/**
+ * Enum CalendarType
+ * Used in building the endpoint URL for requests to the API /calendar endpoint
+ */
+const CalendarType = Object.freeze({
+    NATIONAL: 'nation',
+    DIOCESAN: 'diocese',
+});
+
+/**
+ * Represents the query parameters for the API /calendar endpoint request
+ */
+class RequestPayload {
+    static epiphany = null;
+    static ascension = null;
+    static corpus_christi = null;
+    static eternal_high_priest = null;
+    static locale = null;
+    static return_type = 'ICS';
+    static year_type = 'CIVIL';
+}
+
+/**
+ * Class CurrentEndpoint
+ * Builds the full endpoint URL used as the calendar subscription URL.
+ */
+class CurrentEndpoint {
+    /** @type {string} Set by usage.js from the CalendarUrl global; already ends in `/calendar`. */
+    static apiBase = '';
+    static calendarType = null;
+    static calendarId = null;
+    static calendarYear = null;
+
+    static serialize = () => {
+        let currentEndpoint = CurrentEndpoint.apiBase;
+        if (
+            CurrentEndpoint.calendarType !== null &&
+            CurrentEndpoint.calendarId !== null
+        ) {
+            currentEndpoint += `/${CurrentEndpoint.calendarType}/${CurrentEndpoint.calendarId}`;
+        }
+        if (CurrentEndpoint.calendarYear !== null) {
+            currentEndpoint += `/${CurrentEndpoint.calendarYear}`;
+        }
+        const parameters = [];
+        for (const key in RequestPayload) {
+            if (RequestPayload[key] !== null && RequestPayload[key] !== '') {
+                parameters.push(
+                    key + '=' + encodeURIComponent(RequestPayload[key]),
+                );
+            }
+        }
+        const urlParams = parameters.length ? `?${parameters.join('&')}` : '';
+        return `${currentEndpoint}${urlParams}`;
+    };
+}
+
+export { CalendarType, RequestPayload, CurrentEndpoint };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `yarn test:unit assets/js/__tests__/subscriptionUrl.test.js`
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Wire `usage.js` to the new module**
+
+In `assets/js/usage.js`, delete lines 1–59 (the `CalendarType`, `RequestPayload` and `CurrentEndpoint` definitions and their doc comments) and replace them with:
+
+```js
+import {
+    CalendarType,
+    RequestPayload,
+    CurrentEndpoint,
+} from './subscriptionUrl.js';
+```
+
+Then, inside the `DOMContentLoaded` handler, set the base **before** the existing `updateSubscriptionURL()` call:
+
+```js
+document.addEventListener('DOMContentLoaded', () => {
+    CurrentEndpoint.apiBase = CalendarUrl;
+    handleHashChange();
+    updateSubscriptionURL();
+```
+
+`RequestPayload` is imported because `CurrentEndpoint.serialize()` closes over the module's own copy; the
+import in `usage.js` keeps the symbol available should later code set a payload field. If ESLint reports it as
+unused, drop it from the import list.
+
+- [ ] **Step 6: Verify nothing regressed**
+
+Run: `yarn lint && yarn test:unit`
+
+Expected: ESLint clean, all unit tests pass.
+
+Then, with the docker stack up, confirm the page still renders the same URL as before:
+
+```bash
+docker compose up -d --force-recreate litcal-frontend
+curl -s http://localhost:3000/usage.php | grep -c 'id="calSubscriptionUrl"'
+```
+
+Expected: `1`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add assets/js/subscriptionUrl.js assets/js/__tests__/subscriptionUrl.test.js assets/js/usage.js
+git commit -m "refactor: extract the subscription URL model out of usage.js
+
+Moves CalendarType, RequestPayload and CurrentEndpoint into their own
+module so the URL composition can be unit-tested without a browser, and
+makes apiBase an injected field rather than a read of the CalendarUrl
+global. No behaviour change."
+```
+
+---
+
+### Task 2: Add the rite segment to the URL model
+
+**Files:**
+
+- Modify: `assets/js/subscriptionUrl.js`
+- Modify: `assets/js/__tests__/subscriptionUrl.test.js`
+
+**Interfaces:**
+
+- Consumes: `CurrentEndpoint`, `RequestPayload`, `CalendarType` from Task 1.
+- Produces: `CurrentEndpoint.rite` — a static string field defaulting to `'roman'`, emitted as a path segment on every `serialize()` call.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `assets/js/__tests__/subscriptionUrl.test.js`. Also add `CurrentEndpoint.rite = 'roman';` to the `reset()` helper so each test starts from the default.
+
+```js
+describe('CurrentEndpoint rite segment', () => {
+    beforeEach(reset);
+
+    it('defaults to the roman rite', () => {
+        expect(CurrentEndpoint.rite).toBe('roman');
+    });
+
+    it('emits the roman segment explicitly', () => {
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/roman?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits the rite before a national calendar', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = 'IT';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/roman/nation/IT?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits the ambrosian rite before a diocesan calendar', () => {
+        CurrentEndpoint.rite = 'ambrosian';
+        CurrentEndpoint.calendarType = CalendarType.DIOCESAN;
+        CurrentEndpoint.calendarId = 'lugano_ch';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/ambrosian/diocese/lugano_ch?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('emits the rite alone for the ambrosian rite-level calendar', () => {
+        CurrentEndpoint.rite = 'ambrosian';
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/ambrosian?return_type=ICS&year_type=CIVIL',
+        );
+    });
+
+    it('keeps the year after the calendar segment', () => {
+        CurrentEndpoint.calendarType = CalendarType.NATIONAL;
+        CurrentEndpoint.calendarId = 'IT';
+        CurrentEndpoint.calendarYear = 2026;
+        expect(CurrentEndpoint.serialize()).toBe(
+            'https://example.test/calendar/roman/nation/IT/2026?return_type=ICS&year_type=CIVIL',
+        );
+    });
+});
+```
+
+The five tests written in Task 1 now expect the pre-rite URLs, so update their expectations to include `/roman`:
+
+- `.../calendar?return_type=...` becomes `.../calendar/roman?return_type=...`
+- `.../calendar/nation/IT?...` becomes `.../calendar/roman/nation/IT?...`
+- `.../calendar/diocese/romamo_it?...` becomes `.../calendar/roman/diocese/romamo_it?...`
+- the "omits the calendar segment" and "skips null and empty payload fields" cases likewise gain `/roman`
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `yarn test:unit assets/js/__tests__/subscriptionUrl.test.js`
+
+Expected: FAIL — the rite tests report `undefined` for `CurrentEndpoint.rite`, and the updated Task 1 expectations report a missing `/roman` segment.
+
+- [ ] **Step 3: Implement the rite segment**
+
+In `assets/js/subscriptionUrl.js`, add the field and emit it first:
+
+```js
+    /**
+     * The liturgical rite, as a plain string (`'roman'` / `'ambrosian'`) rather
+     * than the components-js `Rite` enum, which this module cannot import.
+     *
+     * Emitted unconditionally, `roman` included. The API's
+     * `Router::extractRiteSegment()` accepts the explicit spelling and treats
+     * `/calendar/roman/nation/IT` and `/calendar/nation/IT` as the same request,
+     * so rite-explicit URLs are the default from here on and users transition
+     * onto them. URLs already pasted into calendar apps keep resolving.
+     *
+     * @type {string}
+     */
+    static rite = 'roman';
+```
+
+and in `serialize()`, immediately after `let currentEndpoint = CurrentEndpoint.apiBase;`:
+
+```js
+// Before the calendar segment, never after: apiBase already ends in
+// `/calendar`, and `/calendar/nation/IT/roman` is not a route.
+currentEndpoint += `/${CurrentEndpoint.rite}`;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `yarn test:unit assets/js/__tests__/subscriptionUrl.test.js`
+
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/js/subscriptionUrl.js assets/js/__tests__/subscriptionUrl.test.js
+git commit -m "feat: make the subscription URL rite-explicit
+
+Adds a rite path segment between the API base and the calendar segment,
+emitted for every rite including roman. Rite-explicit URLs become the
+default so users transition onto them rather than leaving roman an
+implicit special case; the implicit spelling keeps resolving, so URLs
+already pasted into calendar apps are unaffected."
+```
+
+---
+
+### Task 3: Replace the PHP CalendarSelect with the JS components
+
+**Files:**
+
+- Modify: `usage.php:1-22` (drop the import and construction, add two label strings), `usage.php:134-142` (containers)
+- Modify: `assets/js/usage.js`
+
+**Interfaces:**
+
+- Consumes: `CurrentEndpoint` from Task 2.
+- Produces: DOM ids `#riteSelect` and `#calendarSelect`, and containers `#riteSelectContainer` and `#calendarSelectContainer`, which Task 5's e2e spec selects on.
+
+- [ ] **Step 1: Strip the PHP component out of `usage.php`**
+
+Delete line 3 (`use LiturgicalCalendar\Components\CalendarSelect;`) and line 7 (`$CalendarSelect = new CalendarSelect(['locale' => $i18n->LOCALE]);`).
+
+Add two entries to the `$messages` array so the labels stay in gettext rather than being duplicated in a JS translation map:
+
+```php
+    /** translators: label for dropdown to select which calendar to subscribe to */
+    'Select calendar'          => _('Select calendar'),
+    /** translators: label for dropdown to select the liturgical rite (Roman or Ambrosian) */
+    'Select rite'              => _('Select rite'),
+```
+
+- [ ] **Step 2: Replace the rendered select with containers**
+
+Replace the `<div class="form-group col-md">` block at `usage.php:134-142` — the one containing `echo $CalendarSelect ... ->getSelect();` — with:
+
+```html
+<div class="form-group col-md" id="riteSelectContainer"></div>
+<div class="form-group col-md" id="calendarSelectContainer"></div>
+```
+
+- [ ] **Step 3: Verify the page still loads without the PHP component**
+
+```bash
+docker compose up -d --force-recreate litcal-frontend
+curl -s http://localhost:3000/usage.php | grep -ciE "fatal error|uncaught"
+curl -s http://localhost:3000/usage.php | grep -c 'id="calendarSelectContainer"'
+```
+
+Expected: `0` errors, `1` container. The dropdown is absent at this point — Step 4 supplies it.
+
+- [ ] **Step 4: Build the components in `usage.js`**
+
+Add to the import block at the top of `assets/js/usage.js`:
+
+```js
+import {
+    ApiClient,
+    CalendarSelect,
+    RiteSelect,
+    Rite,
+} from '@liturgical-calendar/components-js';
+```
+
+Add this function above the `DOMContentLoaded` handler:
+
+```js
+/**
+ * Builds the rite and calendar selects and wires them to the subscription URL.
+ *
+ * The two selects are linked so that changing the rite repartitions the calendar
+ * list: the Ambrosian rite has no national tier and a different set of diocesan
+ * calendars, so a selection under one rite is never carried into the other.
+ */
+const buildCalendarControls = async () => {
+    await ApiClient.init(BaseUrl);
+
+    const lang = currentLocale.language;
+
+    // Must be in the DOM before linkToRiteSelect() below, which reads its
+    // element to attach the rite-change listener.
+    const riteSelect = new RiteSelect(lang)
+        .class('form-select')
+        .id('riteSelect')
+        .label({ text: Messages['Select rite'], class: 'form-label' });
+    riteSelect.appendTo('#riteSelectContainer');
+
+    const calendarSelect = new CalendarSelect(lang)
+        .class('form-select')
+        .id('calendarSelect')
+        .label({ text: Messages['Select calendar'], class: 'form-label' })
+        .allowNull(true);
+    calendarSelect.appendTo('#calendarSelectContainer');
+
+    calendarSelect.linkToRiteSelect(riteSelect);
+
+    // Default to the rite-level calendar rather than the first nation, so the
+    // card opens on the General Roman Calendar.
+    calendarSelect._domElement.value = '';
+
+    document.getElementById('riteSelect').addEventListener('change', (ev) => {
+        CurrentEndpoint.rite = ev.target.value;
+        updateSubscriptionURL();
+    });
+    document
+        .getElementById('calendarSelect')
+        .addEventListener('change', updateSubscriptionURL);
+
+    updateSubscriptionURL();
+};
+```
+
+- [ ] **Step 5: Replace the old change listener with the async build**
+
+In the `DOMContentLoaded` handler at the bottom of `assets/js/usage.js`, delete the trailing block:
+
+```js
+// Event: Calendar select change
+const calendarSelect = document.getElementById('calendarSelect');
+if (calendarSelect) {
+    calendarSelect.addEventListener('change', updateSubscriptionURL);
+}
+```
+
+and replace it with:
+
+```js
+// The selects are built asynchronously, so their change listeners are
+// attached inside buildCalendarControls() once the elements exist.
+buildCalendarControls().catch((error) => {
+    console.error(
+        `Could not build the calendar subscription controls: ${error.message}`,
+    );
+});
+```
+
+`updateSubscriptionURL()` is still called earlier in the handler; it returns early when `#calendarSelect` is absent, so the pre-build call is harmless.
+
+- [ ] **Step 6: Set the initial rite from the enum**
+
+`CurrentEndpoint.rite` defaults to the string `'roman'`. Assert that this matches the library's enum by
+setting it explicitly at the top of `buildCalendarControls()`, right after `await ApiClient.init(BaseUrl);`:
+
+```js
+CurrentEndpoint.rite = Rite.ROMAN;
+```
+
+- [ ] **Step 7: Verify in a browser**
+
+```bash
+docker compose up -d --force-recreate litcal-frontend
+yarn lint
+```
+
+Then run this throwaway script from the repo root (it needs the project's `node_modules` to resolve `playwright`):
+
+```js
+// verify.tmp.mjs
+import { chromium } from 'playwright';
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push(e.message));
+await page.goto('http://localhost:3000/usage.php', {
+    waitUntil: 'networkidle',
+});
+await page.click('button[data-bs-target="#calSubscription"]');
+await page.waitForSelector('#calendarSelect', { state: 'visible' });
+const read = () => page.locator('#calSubscriptionUrl').innerText();
+console.log('roman, empty   ->', await read());
+await page.selectOption('#calendarSelect', 'IT');
+console.log('roman, IT      ->', await read());
+await page.selectOption('#riteSelect', 'ambrosian');
+console.log('ambrosian      ->', await read());
+await page.selectOption('#calendarSelect', 'lugano_ch');
+console.log('ambr, lugano   ->', await read());
+console.log('errors:', errors.length ? errors : 'none');
+await browser.close();
+```
+
+Run: `node verify.tmp.mjs && rm verify.tmp.mjs`
+
+Expected:
+
+```text
+roman, empty   -> http://localhost:8000/calendar/roman?return_type=ICS&year_type=CIVIL
+roman, IT      -> http://localhost:8000/calendar/roman/nation/IT?return_type=ICS&year_type=CIVIL
+ambrosian      -> http://localhost:8000/calendar/ambrosian?return_type=ICS&year_type=CIVIL
+ambr, lugano   -> http://localhost:8000/calendar/ambrosian/diocese/lugano_ch?return_type=ICS&year_type=CIVIL
+errors: none
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add usage.php assets/js/usage.js
+git commit -m "feat: add a rite selector to the calendar subscription card
+
+Replaces the server-rendered PHP CalendarSelect with the JS CalendarSelect
+and RiteSelect, linked so the calendar list repartitions when the rite
+changes -- the Ambrosian rite has no national tier and a different set of
+diocesan calendars, neither of which a server-rendered select can reflect
+without a round trip.
+
+allowNull makes the rite-level calendar selectable, so the General Roman
+Calendar and the Ambrosian Calendar can now be subscribed to; previously
+only a nation or a diocese could."
+```
+
+---
+
+### Task 4: Gate the PHP-components bootstrap to `examples.php`
+
+With Task 3 landed, nothing in the frontend's own pages uses the PHP components. The bootstrap survives only
+for the embedded PHP example, which resolves the host's singleton because its own `ApiClient::getInstance()`
+sits inside a `$directAccess` branch that does not run when included.
+
+**Files:**
+
+- Modify: `includes/common.php:290-338`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Confirm the block has no other consumer**
+
+```bash
+grep -rn '\$httpClient\|\$cache\|\$logger\|\$filesystemAdapter' --include=*.php . \
+  | grep -v '^./vendor\|^./examples\|^./includes/common.php'
+```
+
+Expected: no output. If anything appears, stop and reassess — the gate would break it.
+
+- [ ] **Step 2: Wrap the bootstrap**
+
+In `includes/common.php`, wrap lines **290–338**: from the `try {` that opens `$logger = new
+Logger('liturgical-calendar');` down to and including the `]);` that closes `ApiClient::getInstance([`.
+
+Note there is a second, unrelated `try {` at line 200 — do not start there. Do **not** wrap the `$logsDir`
+setup at lines 276–288; it runs unconditionally and the wrapped block reads `$logsDir` from it.
+
+Verified: no `$logger`, `$cache` or `$httpClient` reference appears after line 338 in this file, so nothing below the gate breaks.
+
+Add a comment recording why the gate is safe:
+
+```php
+// The PHP components library is configured only for the embedded PHP example
+// (examples.php?example=PHP). That example detects it is being included rather
+// than requested directly, skips its own autoloader and its own
+// ApiClient::getInstance(), and resolves both from this host — see
+// examples/php/index.php. No other page consumes $logger, $cache or
+// $httpClient, and every page that declares $apiClient immediately reassigns
+// it with LiturgicalCalendar\Frontend\ApiClient, a different class.
+if ('examples' === basename($_SERVER['SCRIPT_FILENAME'], '.php')) {
+    // ... existing logger / cache / httpClient / ApiClient block, unchanged ...
+}
+```
+
+Indent the wrapped block by one level. Do not change any statement inside it.
+
+- [ ] **Step 3: Verify the example still works and other pages are unaffected**
+
+```bash
+docker compose up -d --force-recreate litcal-frontend
+
+# The example must still render its calendar
+curl -s -X POST "http://localhost:3000/examples.php?example=PHP" \
+  -d "rite=roman&national_calendar=IT&year=2026" | grep -c '<table id="LitCalTable">'
+
+# Every page must stay error-free
+for f in $(ls *.php | grep -v phpstan-bootstrap); do
+  errs=$(curl -s "http://localhost:3000/$f" | grep -ciE "Fatal error|Uncaught|Warning:</b>")
+  printf "%-28s errors:%s\n" "$f" "$errs"
+done
+```
+
+Expected: `1` for the table, and `errors:0` for every page.
+
+- [ ] **Step 4: Run the PHP gates**
+
+Run: `composer parallel-lint && composer lint && composer analyse && composer test`
+
+Expected: all clean, 13 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/common.php
+git commit -m "perf: gate the PHP-components bootstrap to the page that uses it
+
+The Monolog logger, filesystem cache adapter, production Guzzle client and
+ApiClient singleton were constructed on all 19 pages but consumed by one:
+the embedded PHP example, which skips its own autoloader and singleton when
+included and resolves both from the host. Nothing outside common.php reads
+\$httpClient, \$cache or \$logger."
+```
+
+---
+
+### Task 5: Permanent Playwright coverage
+
+`usage.php` has broken twice from library changes with no test to catch it. This spec locks in the rite behaviour and the URL shape.
+
+**Files:**
+
+- Create: `e2e/usage.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `#riteSelect`, `#calendarSelect`, `#calSubscriptionUrl` and the accordion toggle `button[data-bs-target="#calSubscription"]` from Task 3.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the spec**
+
+Create `e2e/usage.spec.ts`:
+
+```ts
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Tests for the calendar subscription card on usage.php.
+ *
+ * The card's rite and calendar selects are rendered client-side by
+ * liturgy-components-js, and the subscription URL is rite-explicit: the rite
+ * segment is emitted for every rite, `roman` included.
+ */
+
+const BASE = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+/** Opens usage.php and expands the collapsed subscription accordion. */
+async function openSubscriptionCard(page: Page): Promise<void> {
+    await page.goto(`${BASE}/usage.php`);
+    await page.waitForLoadState('networkidle');
+    await page.click('button[data-bs-target="#calSubscription"]');
+    await page.waitForSelector('#calendarSelect', { state: 'visible' });
+    await page.waitForSelector('#riteSelect', { state: 'visible' });
+}
+
+const subscriptionUrl = (page: Page) =>
+    page.locator('#calSubscriptionUrl').innerText();
+
+test.describe('usage.php - calendar subscription URL', () => {
+    test('both selects render client-side', async ({ page }) => {
+        await openSubscriptionCard(page);
+        await expect(page.locator('#riteSelect')).toBeVisible();
+        await expect(page.locator('#calendarSelect')).toBeVisible();
+    });
+
+    test('the roman rite-level calendar is selectable and rite-explicit', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#calendarSelect', '');
+        expect(await subscriptionUrl(page)).toContain('/calendar/roman?');
+    });
+
+    test('a roman national calendar carries the explicit rite', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#calendarSelect', 'IT');
+        expect(await subscriptionUrl(page)).toContain(
+            '/calendar/roman/nation/IT?',
+        );
+    });
+
+    test('a roman diocesan calendar carries the explicit rite', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#calendarSelect', 'romamo_it');
+        expect(await subscriptionUrl(page)).toContain(
+            '/calendar/roman/diocese/romamo_it?',
+        );
+    });
+
+    test('the ambrosian rite-level calendar', async ({ page }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#calendarSelect', '');
+        expect(await subscriptionUrl(page)).toContain('/calendar/ambrosian?');
+    });
+
+    test('an ambrosian diocese', async ({ page }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#calendarSelect', 'lugano_ch');
+        expect(await subscriptionUrl(page)).toContain(
+            '/calendar/ambrosian/diocese/lugano_ch?',
+        );
+    });
+
+    test('every emitted URL carries an explicit rite segment', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        for (const [rite, calendar] of [
+            ['roman', ''],
+            ['roman', 'IT'],
+            ['ambrosian', ''],
+            ['ambrosian', 'lugano_ch'],
+        ]) {
+            await page.selectOption('#riteSelect', rite);
+            await page.selectOption('#calendarSelect', calendar);
+            expect(await subscriptionUrl(page)).toMatch(
+                /\/calendar\/(roman|ambrosian)(\/|\?)/,
+            );
+        }
+    });
+
+    test('the query parameters are preserved', async ({ page }) => {
+        await openSubscriptionCard(page);
+        const url = await subscriptionUrl(page);
+        expect(url).toContain('return_type=ICS');
+        expect(url).toContain('year_type=CIVIL');
+    });
+});
+
+test.describe('usage.php - rite repartitions the calendar list', () => {
+    test('the ambrosian rite drops the national tier and offers its own dioceses', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+
+        const nationalCount = await page
+            .locator('#calendarSelect option[data-calendartype="national"]')
+            .count();
+        expect(nationalCount).toBe(0);
+
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => o.value),
+        );
+        for (const diocese of [
+            'milano_it',
+            'bergam_it',
+            'novara_it',
+            'lugano_ch',
+        ]) {
+            expect(values).toContain(diocese);
+        }
+    });
+
+    test('switching back to the roman rite restores the national tier', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#riteSelect', 'roman');
+
+        const nationalCount = await page
+            .locator('#calendarSelect option[data-calendartype="national"]')
+            .count();
+        expect(nationalCount).toBeGreaterThan(0);
+
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => o.value),
+        );
+        expect(values).not.toContain('lugano_ch');
+    });
+});
+```
+
+- [ ] **Step 2: Type-check the spec**
+
+Run: `yarn typecheck`
+
+Expected: clean.
+
+- [ ] **Step 3: Run the spec**
+
+Run: `yarn test:ci:chromium e2e/usage.spec.ts`
+
+Expected: 10 tests pass.
+
+If the `data-calendartype` assertions fail, check the `switch` in `updateSubscriptionURL()` in
+`assets/js/usage.js`: its cases must read `'national'` / `'diocesan'`. components-js 2.1.0 and components-php
+v4 emit those short forms, not the older `nationalcalendar` / `diocesancalendar`.
+
+- [ ] **Step 4: Run the whole suite for regressions**
+
+Run: `yarn test:ci:chromium`
+
+Expected: no new failures relative to the pre-change baseline. Record any pre-existing failures rather than fixing them here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/usage.spec.ts
+git commit -m "test: cover the rite selector and subscription URL on usage.php
+
+usage.php has broken twice from components library changes with no test to
+catch it. Locks in the rite-explicit URL shape across rite x
+{rite-level, nation, diocese}, and the repartitioning of the calendar list
+when the rite changes."
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+- Modify: `.serena/memories/project_overview.md`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Record the pattern in `CLAUDE.md`**
+
+Under `## Important Patterns`, after the "Accept-Language Header and CalendarSelect" subsection, add:
+
+```markdown
+### Rite awareness
+
+The API routes a rite as a bare path segment between `calendar` and any nation or
+diocese pair — `/calendar/ambrosian/diocese/lugano_ch`. There is no
+`/calendar/rite/{rite}` spelling and no query parameter.
+
+`usage.php` emits the segment for **every** rite, `roman` included, so users
+transition onto rite-explicit URLs. The implicit spelling keeps resolving, so
+subscription URLs already pasted into calendar apps are unaffected.
+
+The Ambrosian rite has no national tier and its own set of diocesan calendars
+(`milano_it`, `bergam_it`, `novara_it`, `lugano_ch`), so a `CalendarSelect` must
+be linked to a `RiteSelect` — via `calendarSelect.linkToRiteSelect(riteSelect)`,
+or `ApiOptions.linkToCalendarSelect().linkToRiteSelect()` when an `ApiOptions`
+form is already present — to repartition its list when the rite changes.
+
+### PHP vs JS components
+
+Frontend pages use **liturgy-components-js**. The PHP library
+(`liturgical-calendar/components`) is a dependency solely for the embedded PHP
+example: `examples/php/index.php` detects that it is being included rather than
+requested directly, skips its own autoloader and its own `ApiClient` singleton,
+and resolves both from the host. `includes/common.php` therefore keeps its
+`ApiClient::getInstance()` bootstrap, gated to `examples.php`. Do not remove the
+composer dependency — the example crashes without it.
+```
+
+- [ ] **Step 2: Update the Serena memory**
+
+In `.serena/memories/project_overview.md`, the PHP deps line already reads `^4.2`. Append a clause to the
+`liturgy-components-js` bullet noting that frontend pages use the JS library and the PHP one serves the
+embedded example only.
+
+- [ ] **Step 3: Format and lint**
+
+Run: `yarn format:md && composer lint:md`
+
+Expected: no issues.
+
+`.prettierrc` (`tabWidth: 4`, `singleQuote: true`) and `.markdownlint.yaml`
+(`MD007: indent: 4`) agree, so the tree is already a fixed point of both tools:
+`format:md` must touch only the files this task edited. If it reformats
+anything else, something regressed in those configs — investigate rather than
+committing the churn.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md .serena/memories/project_overview.md
+git commit -m "docs: record rite awareness and the PHP/JS component split"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run every gate**
+
+```bash
+composer parallel-lint && composer lint && composer analyse && composer test
+yarn lint && yarn typecheck && yarn test:unit
+composer lint:md
+yarn test:ci:chromium
+```
+
+- [ ] **Confirm the deliverables**
+
+- The subscription card shows a rite select and a calendar select, both client-rendered.
+- Selecting Ambrosian repartitions the calendar list and reaches all four Ambrosian dioceses.
+- Every subscription URL carries an explicit rite segment.
+- The General Roman Calendar and the Ambrosian Calendar are both subscribable.
+- `examples.php?example=PHP` still renders a calendar.
+- `usage.php` contains no reference to `LiturgicalCalendar\Components`.

--- a/docs/superpowers/specs/2026-06-21-scoped-admin-review-design.md
+++ b/docs/superpowers/specs/2026-06-21-scoped-admin-review-design.md
@@ -25,7 +25,7 @@ The **frontend** is the only thing locking resource-admins out:
 
 - `admin-permissions.php` (the sole access-request review UI) redirects anyone without the global `admin`
   role (lines 20–26: `$isAdmin = $authHelper->hasRole('admin'); if (!$isAdmin) { header('Location:
-  admin-dashboard.php'); exit; }`).
+admin-dashboard.php'); exit; }`).
 - `admin-dashboard.php` renders the admin section (incl. the "Role Requests" / "Permissions" cards that
   link to `admin-permissions.php`) only inside `if ($isAdmin)` — so resource-admins see no entry point.
 - `notifications.js` fixes its mode at init to `Auth.hasRole('admin') ? 'admin' : 'user'`, so a
@@ -79,11 +79,9 @@ Response shape:
 
 ```json
 {
-  "is_global_admin": false,
-  "is_resource_admin": true,
-  "admin_scopes": [
-    { "object_type": "national_calendar", "object_id": "IT" }
-  ]
+    "is_global_admin": false,
+    "is_resource_admin": true,
+    "admin_scopes": [{ "object_type": "national_calendar", "object_id": "IT" }]
 }
 ```
 
@@ -173,7 +171,7 @@ still sees their own request outcomes on `permission-requests.php`). The `seen` 
 Hiding the FGA-tuple UI from resource-admins is **not** the security boundary — the API
 (`PermissionAdminHandler`, which already checks `isResourceAdmin` per tuple op) and the access-request
 admin endpoints (`filterByAdminAccess` / `requireAdminForAllResources`) remain the enforcement points. The
-frontend changes only widen *who the UI lets in* and *what it shows*; every privileged action is still
+frontend changes only widen _who the UI lets in_ and _what it shows_; every privileged action is still
 authorized server-side against OpenFGA. `/auth/admin-scopes` returns scopes for the authenticated caller
 only.
 

--- a/docs/superpowers/specs/2026-06-22-rbac-e2e-phase2-execution-design.md
+++ b/docs/superpowers/specs/2026-06-22-rbac-e2e-phase2-execution-design.md
@@ -15,11 +15,11 @@ resource-admin scoping the scoped-admin-review feature now enables. The suite fo
 
 ## Why this is now buildable
 
-The original design's scenarios assumed resource-admins could *review through the UI*. They could not — the
+The original design's scenarios assumed resource-admins could _review through the UI_. They could not — the
 frontend locked them out — which is why Phase 2 paused to build the scoped-admin-review feature. That
 feature is now merged (API on `development` via #656; frontend on #345), so every scenario that depends on a
 resource-admin seeing/acting on a scoped request is unblocked. This document records the decisions that turn
-the original design into an executable plan; the scenario *intent* is unchanged from the original design.
+the original design into an executable plan; the scenario _intent_ is unchanged from the original design.
 
 ## Decisions (this round)
 
@@ -35,8 +35,8 @@ the original design into an executable plan; the scenario *intent* is unchanged 
 
 ## Seeding model
 
-Three user classes in the `users.ts` matrix (11 users — unchanged matrix; what changes is *what gets
-seeded when*):
+Three user classes in the `users.ts` matrix (11 users — unchanged matrix; what changes is _what gets
+seeded when_):
 
 The 11 users split by **how they enter the system** (the two `REGISTRATION_USER_IDS` —
 `cei-admin`, `usccb-editor` — are never seeded; everyone else is) and **whether their FGA grant is seeded
@@ -48,10 +48,10 @@ or earned via the UI**:
   `calendar_editor` role + login + their `admin` FGA tuple (stable, seeded at setup; lets them review).
 - **Seeded requester-editors** — `cei-editor`, `rome-editor`, `grc-editor`, `europe-editor`. Seeded:
   account + `calendar_editor` role + login, **no FGA tuple**. Grant is earned via `request-access.php`
-  in-spec (the approval outcome); a spec needing it as a *precondition* (e.g. scenario 10) seeds it
+  in-spec (the approval outcome); a spec needing it as a _precondition_ (e.g. scenario 10) seeds it
   explicitly.
 - **Registration users** — `cei-admin`, `usccb-editor`. **Not seeded at all**: they drive the real Zitadel
-  self-registration UI + Mailpit verification in-spec (scenarios 01/04). When a *later* spec needs
+  self-registration UI + Mailpit verification in-spec (scenarios 01/04). When a _later_ spec needs
   `cei-admin` to already be an IT admin (e.g. scenario 02), it seeds `cei-admin = admin@IT` as a
   precondition.
 
@@ -71,7 +71,7 @@ leaves the two registration users untouched.
    address, extract the verification link. Used by the 2 real-registration scenarios. **Highest-risk piece**
    (real registration UI + cross-org Zitadel fix + email round-trip).
 4. **`cleanup.ts`** (extend) — beyond truncating `access_requests`/`audit_log`/`user_notification_state`
-   and deleting seeded users + their *seeded* tuples, it must remove FGA tuples + role grants **created
+   and deleting seeded users + their _seeded_ tuples, it must remove FGA tuples + role grants **created
    during specs** (approval outcomes) and run `gitRestoreApiData()` to revert scenario 10's calendar edits.
    Approach: derive tuples-to-delete from the matrix + any per-spec grants, and reset API source data via the
    existing git-restore mechanism the original design references.
@@ -88,7 +88,7 @@ independent and seeds its own preconditions.
 2. **02 — `cei-editor` requests `edit`@IT** (precond: seed `cei-admin = admin@IT`). Assert **both**
    `super-admin` and `cei-admin` see it via the scoped review UI, `usccb-admin` does **not** → cei-admin
    rejects → super-admin sees the rejection → cei-editor revises → cei-admin grants → super-admin sees the
-   grant. *(Exercises the scoped-admin-review feature head-on.)*
+   grant. _(Exercises the scoped-admin-review feature head-on.)_
 3. **03 — `usccb-admin` requests `admin`@USA** (real or seeded-precondition admin). Assert **`cei-admin`
    does NOT see it**, only `super-admin` → super-admin grants.
 4. **04 — `usccb-editor` requests `edit`@USA (real registration).** Register via UI + Mailpit → request →

--- a/docs/superpowers/specs/2026-06-29-admin-tests-page-design.md
+++ b/docs/superpowers/specs/2026-06-29-admin-tests-page-design.md
@@ -40,7 +40,7 @@ only the live test **runner**.
 - **An editor already exists** in `UnitTestInterface/admin.php` + `assets/js/admin.js`
   (`AccuracyTestDefinition`, save via `PUT /tests` create / `PATCH /tests/{name}` update) +
   `assets/js/AssertionsBuilder.js` (the per-year assertion grid). No DELETE in that UI today.
-- **Frontend admin conventions.** The closest analog to a form-CRUD admin page is the *bespoke*
+- **Frontend admin conventions.** The closest analog to a form-CRUD admin page is the _bespoke_
   `admin-permissions.js` (create via `POST`, delete via `DELETE`, dynamic `CalendarSelect`-by-type
   fields, scope gating via an `isGlobalAdmin` config flag + the resource-admin distinction). The
   `createAdminModule` factory (`admin-module-base.js`) is **status-workflow-specific**
@@ -51,7 +51,7 @@ only the live test **runner**.
 
 ## Decisions
 
-1. **Scope:** CRUD of test *definitions* only; the runner stays in UnitTestInterface.
+1. **Scope:** CRUD of test _definitions_ only; the runner stays in UnitTestInterface.
 2. **Permission UX:** Hybrid — list/view all tests for any authenticated user; gate edit/delete
    buttons per-row using the caller's exact scopes; API is the hard backstop.
 3. **Old editor:** Retire the editing UI in `UnitTestInterface/admin.php` (single source of truth).
@@ -76,20 +76,24 @@ pages (which call `/auth/admin-scopes`) don't incur the extra OpenFGA `listObjec
 - **Service:** extend `ResourceAdminService` with
   `resolveTestScopes(string $sub): array{editor: list<Scope>, admin: list<Scope>}`, looping the
   three test object types `['national_calendar_test','diocesan_calendar_test',
-  'general_roman_calendar_test']` and calling the existing
+'general_roman_calendar_test']` and calling the existing
   `OpenFgaClient::listObjects($fgaUser, 'editor'|'admin', $type)` (`OpenFgaClient.php:299–328`).
   `editor` ⊇ `admin` because the model defines `editor = this ∪ computedUserset(admin)`.
 - **Route:** add `GET /auth/test-scopes` behind the same JWT/OIDC auth middleware as
   `/auth/admin-scopes` (authenticated; returns the caller's scopes only — no elevation).
 - **Response:**
 
-  ```json
-  {
-    "is_global_admin": false,
-    "editor": [{ "object_type": "national_calendar_test", "object_id": "USA" }],
-    "admin":  [{ "object_type": "diocesan_calendar_test", "object_id": "..." }]
-  }
-  ```
+    ```json
+    {
+        "is_global_admin": false,
+        "editor": [
+            { "object_type": "national_calendar_test", "object_id": "USA" }
+        ],
+        "admin": [
+            { "object_type": "diocesan_calendar_test", "object_id": "..." }
+        ]
+    }
+    ```
 
 - **Grounding:** test scopes are **independent** of calendar scopes in the current OpenFGA model
   (`scripts/openfga-model.json` test types use only `this` + same-type `computedUserset`; no
@@ -106,10 +110,10 @@ pages (which call `/auth/admin-scopes`) don't incur the extra OpenFGA `listObjec
 - **`assets/js/admin-tests.js`** — bespoke module (initialized on `DOMContentLoaded`), importing
   `ApiClient` / `CalendarSelect` / `CalendarSelectFilter` like `admin-permissions.js`. Internally
   organized as:
-  - **Generic seam** (extraction candidates for the future factory): `fetchJson(method, path,
-    body)`, `renderTable(rows, columns)`, `showModalAlert(...)`, `gateByScope(...)`,
-    auth/scope bootstrap (`/auth/me` + `/auth/test-scopes`).
-  - **Test-specific:** scope grouping for the list, the editor form, and `AssertionsBuilder` glue.
+    - **Generic seam** (extraction candidates for the future factory): `fetchJson(method, path,
+body)`, `renderTable(rows, columns)`, `showModalAlert(...)`, `gateByScope(...)`,
+      auth/scope bootstrap (`/auth/me` + `/auth/test-scopes`).
+    - **Test-specific:** scope grouping for the list, the editor form, and `AssertionsBuilder` glue.
 - **`assets/js/AssertionsBuilder.js`** — ported from UnitTestInterface with a tight interface:
   `load(testDefinition)` to populate, `serialize()` to produce the assertions array. The per-year
   assertion grid keyed by `test_type` (exact/variable correspondence) is preserved.
@@ -139,7 +143,7 @@ workflow, presented as a stepped modal:
    auto-fills the description and feeds the base date + Sunday highlighting.
 3. **Year range** — the dual-range slider ported as-is from UnitTestInterface
    (`assets/css/multi-range-slider.css`), bounded 1970–2050, feeding `year_since`/`year_until` (for
-   the *Since*/*Until* types) and the set of years to assert on.
+   the _Since_/_Until_ types) and the set of years to assert on.
 4. **Base date** — `<input type=date>` pre-filled from the event's fixed `month`/`day` (or Jan 1 of
    the first year); expands to per-year `expected_value` (RFC 3339,
    `YYYY-MM-DDT00:00:00+00:00`).
@@ -150,7 +154,7 @@ workflow, presented as a stepped modal:
    (`fa-comment-medical` / `fa-comment-dots`). Per-type behavior: exact = uniform across years;
    since/until = years before/after the pivot forced to `eventNotExists`; variable = each year
    toggled independently. A **year-grid overview** shades the pivot year and the years it forces
-   to `eventNotExists`; for the *Since*/*Until* types, clicking a year sets the pivot.
+   to `eventNotExists`; for the _Since_/_Until_ types, clicking a year sets the pivot.
    (Click-to-exclude — editing the `excludes` list from the grid — is deferred to a follow-up;
    the model and `generate()` already accept `excludedYears`.)
 
@@ -219,7 +223,7 @@ Reuses Bootstrap 5 + FontAwesome (already present in the frontend).
 
 - **Coordinated admin-page form-CRUD factory.** decrees/missals/calendars admin are piecemeal and
   incomplete; `admin-tests` is built with a clean generic/specific seam so it can serve as a clean
-  reference example. A unified factory (covering form-CRUD *and* the existing status-workflow
+  reference example. A unified factory (covering form-CRUD _and_ the existing status-workflow
   pattern) is a separate initiative with its own spec, studying all real pages — not designed from
   this one example.
 - **Pooling calendar-editor and test-editor scopes.** Test-editor scopes are independent of
@@ -237,7 +241,7 @@ Reuses Bootstrap 5 + FontAwesome (already present in the frontend).
 - `event_key` datalist depends on `GET /events` returning the event catalog for the chosen scope;
   confirm the shape/locale handling when wiring the field.
 - Renaming a test is not an in-place edit — `name` is the resource key for `PATCH/DELETE
-  /tests/{name}`, so a rename is delete + recreate. The editor must render `name` read-only when
+/tests/{name}`, so a rename is delete + recreate. The editor must render `name` read-only when
   editing an existing test.
 - (Resolved) Year-range control: port the original custom dual-range slider
   (`multi-range-slider.css`) as-is to preserve the familiar feel — carried over verbatim alongside

--- a/docs/superpowers/specs/2026-07-07-admin-tests-dialog-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-07-admin-tests-dialog-redesign-design.md
@@ -79,10 +79,10 @@ Scopes come from `GET /auth/test-scopes` as
 
 - **Global admin** → current full picker (scope-type select + `CalendarSelect`).
 - **Non-global admin** → authorized scopes = `editor ∪ admin` (deduped):
-  - **Exactly one** authorized scope → render it as **static read-only text**
-    (e.g. "Diocese: rotter_nl"), pre-set as the scope. No control.
-  - **Several** → a `<select>` limited to just those authorized scopes (not the
-    full calendar catalog).
+    - **Exactly one** authorized scope → render it as **static read-only text**
+      (e.g. "Diocese: rotter_nl"), pre-set as the scope. No control.
+    - **Several** → a `<select>` limited to just those authorized scopes (not the
+      full calendar catalog).
 
 The selected scope still feeds `selectedScope()` / the save payload's `applies_to`.
 

--- a/docs/superpowers/specs/2026-07-12-admin-dashboard-fga-gating-design.md
+++ b/docs/superpowers/specs/2026-07-12-admin-dashboard-fga-gating-design.md
@@ -40,10 +40,10 @@ Response shape:
 {
     "is_global_admin": false,
     "is_resource_admin": false,
-    "admin_scopes": [ { "object_type": "national_calendar", "object_id": "NL" } ],
+    "admin_scopes": [{ "object_type": "national_calendar", "object_id": "NL" }],
     "viewer_scopes": {
-        "general_roman_calendar": [ "temporale", "decrees" ],
-        "national_calendar_test": [ "NL" ],
+        "general_roman_calendar": ["temporale", "decrees"],
+        "national_calendar_test": ["NL"],
         "diocesan_calendar_test": [],
         "general_roman_calendar_test": []
     }
@@ -87,14 +87,14 @@ performs exactly **one**.
 
 ### Card gating matrix (non-admin rules; global admins always see their cards)
 
-| Card / block                                        | Visibility rule for non-admins                                            |
-|-----------------------------------------------------|---------------------------------------------------------------------------|
-| Temporale block (admin-blocks grid)                 | `calendar_editor` role AND viewer+ on `general_roman_calendar:temporale`  |
-| Decrees block (grid) and dedicated Decrees card     | `calendar_editor` role AND viewer+ on `general_roman_calendar:decrees`    |
-| Tests card                                          | `test_editor` role AND viewer+ on any `*_test` object                     |
-| Access Requests card                                | unchanged rule, read from `dashboardScopes()['is_resource_admin']`        |
-| Sanctorale, Wider Region, National, Diocesan blocks | unchanged (role-gated as today)                                           |
-| Users, Applications, Permissions cards              | unchanged (`isAdmin` only)                                                |
+| Card / block                                        | Visibility rule for non-admins                                           |
+| --------------------------------------------------- | ------------------------------------------------------------------------ |
+| Temporale block (admin-blocks grid)                 | `calendar_editor` role AND viewer+ on `general_roman_calendar:temporale` |
+| Decrees block (grid) and dedicated Decrees card     | `calendar_editor` role AND viewer+ on `general_roman_calendar:decrees`   |
+| Tests card                                          | `test_editor` role AND viewer+ on any `*_test` object                    |
+| Access Requests card                                | unchanged rule, read from `dashboardScopes()['is_resource_admin']`       |
+| Sanctorale, Wider Region, National, Diocesan blocks | unchanged (role-gated as today)                                          |
+| Users, Applications, Permissions cards              | unchanged (`isAdmin` only)                                               |
 
 ### Mechanics
 

--- a/docs/superpowers/specs/2026-07-12-admin-decrees-interface-design.md
+++ b/docs/superpowers/specs/2026-07-12-admin-decrees-interface-design.md
@@ -44,13 +44,13 @@ companion spec.
 - **ES modules** with named exports; pure logic (payload construction, the action↔suffix map, validation)
   lives in `DecreePayload.js` and is unit-tested in isolation.
 - **Localization:** all UI chrome uses gettext compiled into `AdminDecreesConfig.i18n`. Client-side
-  *validation-error* strings are currently English-only (they mirror the server's English messages and
+  _validation-error_ strings are currently English-only (they mirror the server's English messages and
   would move to gettext together).
 
 ## Locale handling
 
 - The page UI locale is `AdminDecreesConfig.locale` (BCP-47, e.g. `en-US`); its **primary subtag** (`en`)
-  is the *base locale* used throughout.
+  is the _base locale_ used throughout.
 - The decrees list is fetched with `Accept-Language: <page locale>` so card names — and the locale **labels**
   in the translations panel — agree. (Omitting the header lets the browser's own Accept-Language drive the
   response, which mislabels e.g. an Italian name as the `en` row.)
@@ -77,7 +77,7 @@ Gating rules:
   away (to the login/home surface) before any decree UI renders, so capability detection only ever runs
   for an authenticated caller.
 - **Dashboard card** (`admin-dashboard.php`): renders only when `isAdmin || (calendar_editor && FGA
-  viewer-or-above)`; the same self-check the page uses. The card and page use the same scroll icon
+viewer-or-above)`; the same self-check the page uses. The card and page use the same scroll icon
   (`fa-scroll`).
 - **No access** (`!canView`): the page shows a muted "no permission" notice instead of cards.
 - **The "New Decree" button is gated on `canEdit`, not on mere authentication.** It deliberately omits
@@ -118,7 +118,7 @@ the same URL). A locale with no readings shows a muted "No readings defined for 
 toggle always appears for `createNew` decrees (readings are guaranteed by the write contract), and otherwise
 only when the event carries readings.
 
-**Source links** (footer) — depends on the URL shape (see the API spec's *Metadata* section):
+**Source links** (footer) — depends on the URL shape (see the API spec's _Metadata_ section):
 
 - **No `%s` placeholder:** a single "Source" link to the URL.
 - **`%s` + `url_lang_map`:** one link per language (the `urls_langs`), each the URL with `%s` expanded to
@@ -173,12 +173,12 @@ both are editable fields. (This mirrors how the tests editor pins a locked scope
 
 Selecting an action reveals exactly the blocks that action's payload allows:
 
-| Action              | Event details | Common | Grade | Translations (i18n) | Readings         |
-| ------------------- |:-------------:|:------:|:-----:|:-------------------:|:----------------:|
-| `createNew`         | ✓             | ✓      |       | ✓                   | ✓ (required PUT) |
-| `makeDoctor`        |               | ✓      |       | ✓                   |                  |
-| `setProperty:name`  |               |        |       | ✓                   |                  |
-| `setProperty:grade` |               |        | ✓     |                     |                  |
+| Action              | Event details | Common | Grade | Translations (i18n) |     Readings     |
+| ------------------- | :-----------: | :----: | :---: | :-----------------: | :--------------: |
+| `createNew`         |       ✓       |   ✓    |       |          ✓          | ✓ (required PUT) |
+| `makeDoctor`        |               |   ✓    |       |          ✓          |                  |
+| `setProperty:name`  |               |        |       |          ✓          |                  |
+| `setProperty:grade` |               |        |   ✓   |                     |                  |
 
 ### Event details — fixed vs mobile date (createNew)
 
@@ -188,17 +188,17 @@ relative date. A fixed/mobile radio toggles between:
 - **Fixed:** month and day number inputs.
 - **Mobile:** three structured inputs that build the relative-date object
   `{ day_of_the_week, relative_time, event_key }` — never a free-text/JSON string:
-  - **day_of_the_week** — a `<select>` whose *values* are the English weekday names (the schema enum,
-    `Sunday`…`Saturday`) and whose *labels* are localized in the UI locale (server-rendered via
-    `IntlDateFormatter`).
-  - **relative_time** — a `<select>` of `before` / `after`.
-  - **event_key** — a datalist-backed input (`#grcEventKeysDatalist`) populated from the GRC event catalog
-    (`GET /events`), searchable by event key or localized name. The anchor is usually a temporale movable
-    feast (Pentecost, Easter, …); those are present because `/events` now includes the Temporale (see the
-    API companion spec).
+    - **day_of_the_week** — a `<select>` whose _values_ are the English weekday names (the schema enum,
+      `Sunday`…`Saturday`) and whose _labels_ are localized in the UI locale (server-rendered via
+      `IntlDateFormatter`).
+    - **relative_time** — a `<select>` of `before` / `after`.
+    - **event_key** — a datalist-backed input (`#grcEventKeysDatalist`) populated from the GRC event catalog
+      (`GET /events`), searchable by event key or localized name. The anchor is usually a temporale movable
+      feast (Pentecost, Easter, …); those are present because `/events` now includes the Temporale (see the
+      API companion spec).
 
-  All three are required for a mobile `createNew` (client-validated); the payload's `liturgical_event`
-  carries `strtotime` as the object and omits `month`/`day`.
+    All three are required for a mobile `createNew` (client-validated); the payload's `liturgical_event`
+    carries `strtotime` as the object and omits `month`/`day`.
 
 ### Translations (i18n) rows — GRC-live minimum + all defined
 
@@ -223,14 +223,14 @@ that has defined readings, base locale first. Locale fields are the same ISO dat
 - A single URL field, plus a **"Source available in multiple languages"** switch (default off).
 - **Off:** just the URL.
 - **On:** the URL takes a `%s` placeholder and a **`url_lang_map` editor** appears — dynamic rows of
-  *(ISO 639-1 language ▸ Vatican token)* with a live **preview** expanding `%s` per language.
-  - The **language** field is the `#isoLangDatalist` input (any ISO 639-1 code). A pre-selected code outside
-    the offered list is preserved (edit round-trips never silently drop a mapping).
-  - The **token** field is bound to a per-language suggestion datalist (`#urlCodes-{iso}`) built from the
-    Vatican tokens actually used for that language across current decrees (see below) — suggestions only,
-    never a constraint; it rebinds as the language changes.
-  - **Duplicate ISO** rows are detected at save time and block submission with a per-duplicate validation
-    error (they would otherwise silently overwrite).
+  _(ISO 639-1 language ▸ Vatican token)_ with a live **preview** expanding `%s` per language.
+    - The **language** field is the `#isoLangDatalist` input (any ISO 639-1 code). A pre-selected code outside
+      the offered list is preserved (edit round-trips never silently drop a mapping).
+    - The **token** field is bound to a per-language suggestion datalist (`#urlCodes-{iso}`) built from the
+      Vatican tokens actually used for that language across current decrees (see below) — suggestions only,
+      never a constraint; it rebinds as the language changes.
+    - **Duplicate ISO** rows are detected at save time and block submission with a per-duplicate validation
+      error (they would otherwise silently overwrite).
 - On **edit**, the switch auto-activates when the decree has a `url_lang_map` or a `%s` URL, and the rows
   are prefilled.
 

--- a/docs/superpowers/specs/2026-08-11-usage-rite-selector-design.md
+++ b/docs/superpowers/specs/2026-08-11-usage-rite-selector-design.md
@@ -75,17 +75,17 @@ is needed. Following the `liturgyOfAnyDay.js` precedent:
 const apiClient = await ApiClient.init(BaseUrl);
 
 const riteSelect = new RiteSelect(lang)
-  .class("form-select")
-  .id("riteSelect")
-  .label({ text: Messages["Select rite"], class: "form-label" });
-riteSelect.appendTo("#riteSelectContainer");
+    .class('form-select')
+    .id('riteSelect')
+    .label({ text: Messages['Select rite'], class: 'form-label' });
+riteSelect.appendTo('#riteSelectContainer');
 
 const calendarSelect = new CalendarSelect(lang)
-  .class("form-select")
-  .id("calendarSelect")
-  .label({ text: Messages["Select calendar"], class: "form-label" })
-  .allowNull(true);
-calendarSelect.appendTo("#calendarSelectContainer");
+    .class('form-select')
+    .id('calendarSelect')
+    .label({ text: Messages['Select calendar'], class: 'form-label' })
+    .allowNull(true);
+calendarSelect.appendTo('#calendarSelectContainer');
 
 calendarSelect.linkToRiteSelect(riteSelect);
 ```

--- a/docs/superpowers/specs/2026-08-11-usage-rite-selector-design.md
+++ b/docs/superpowers/specs/2026-08-11-usage-rite-selector-design.md
@@ -1,0 +1,198 @@
+# Rite selector and rite-aware subscription URL on usage.php
+
+**Date:** 2026-08-11
+**Status:** Approved, pending implementation
+
+## Problem
+
+`usage.php`'s calendar-subscription card offers a nation/diocese dropdown and renders a
+subscription URL from it. It has no notion of liturgical rite, so:
+
+- The four Ambrosian dioceses (`milano_it`, `bergam_it`, `novara_it`, `lugano_ch`) are
+  unreachable. A `CalendarSelect` defaults to the Roman rite and, as of
+  liturgy-components-php v4.0.0, correctly partitions dioceses by rite.
+- The Ambrosian rite-level calendar (`/calendar/ambrosian`) is unreachable.
+- The General Roman Calendar itself is unreachable: the dropdown has no empty option, so
+  only a nation or a diocese can be subscribed to.
+
+The dropdown is rendered server-side by the PHP `CalendarSelect`. A rite selector has to
+repartition that list when the rite changes, which a server-rendered select cannot do
+without a round trip.
+
+## Decisions
+
+1. **The subscription card moves to liturgy-components-js.** `RiteSelect` and
+   `CalendarSelect` render client-side and are linked with `linkToRiteSelect()`.
+2. **The calendar select gains `allowNull(true)`**, making the rite-level calendar
+   selectable. The empty option is self-labelling in components-js 2.1.0 — "General Roman
+   Calendar" / "Ambrosian Calendar".
+3. **The rite segment is always emitted, `roman` included.** Rite-explicit URLs become the
+   default so users transition onto them, rather than leaving Roman an implicit special
+   case. Existing implicit URLs keep resolving.
+4. **The PHP-components bootstrap in `includes/common.php` is gated to `examples.php`.**
+5. **Permanent Playwright coverage** is added as `e2e/usage.spec.ts`.
+
+## Constraint: the PHP library stays a dependency
+
+The frontend stops _rendering_ PHP components, but must keep hosting the library, because
+the embedded PHP example borrows the host's autoloader and singletons:
+
+- `examples/php/index.php:42` sets `$directAccess = false` when included rather than
+  requested directly, and then **skips its own autoloader**. Embedded, it resolves `Rite`,
+  `RiteSelect`, `LocaleResolver` and `ScopedLocale` from the frontend's `vendor/`. This is
+  exactly what crashed when the frontend was pinned to `^3.3`.
+- Its own `ApiClient::getInstance()` (line 193) sits inside the `$directAccess` block, so
+  embedded, its `$apiClient->calendar()` (line 467) and
+  `MetadataProvider::isValidDioceseForNation()` (line 433) run against the **host**
+  singleton from `includes/common.php`.
+
+Therefore `composer.json` keeps `liturgical-calendar/components: ^4.2`, and the
+`ApiClient::getInstance()` bootstrap keeps existing — just no longer on every page.
+
+## Changes
+
+### `usage.php`
+
+Remove `use LiturgicalCalendar\Components\CalendarSelect;`, the `new CalendarSelect(...)`
+construction, and the `->getSelect()` render. In their place, two empty containers:
+
+```html
+<div class="form-group col-md" id="riteSelectContainer"></div>
+<div class="form-group col-md" id="calendarSelectContainer"></div>
+```
+
+Label text stays in gettext rather than duplicating a translation map. `usage.php` already
+serialises a `Messages` object to JS; `_('Select calendar')` and a new `_('Select rite')`
+ride along in it. (`liturgyOfAnyDay.js` hand-rolls a 12-language map because the library's
+`Messages` export is internal; here PHP already holds the strings.)
+
+### `assets/js/usage.js`
+
+Already loads as `type="module"` with the components-js importmap present, so no plumbing
+is needed. Following the `liturgyOfAnyDay.js` precedent:
+
+```js
+const apiClient = await ApiClient.init(BaseUrl);
+
+const riteSelect = new RiteSelect(lang)
+  .class("form-select")
+  .id("riteSelect")
+  .label({ text: Messages["Select rite"], class: "form-label" });
+riteSelect.appendTo("#riteSelectContainer");
+
+const calendarSelect = new CalendarSelect(lang)
+  .class("form-select")
+  .id("calendarSelect")
+  .label({ text: Messages["Select calendar"], class: "form-label" })
+  .allowNull(true);
+calendarSelect.appendTo("#calendarSelectContainer");
+
+calendarSelect.linkToRiteSelect(riteSelect);
+```
+
+`linkToRiteSelect()` is called directly on `CalendarSelect`. `liturgyOfAnyDay.js` routes
+the link through `ApiOptions` only because it also needs the locale input; this page does
+not, so no `ApiOptions` instance is created.
+
+**Ordering matters:** `riteSelect.appendTo()` must run before `linkToRiteSelect()`, which
+reads the rite select's element to attach its change listener. This is the same constraint
+noted at `liturgyOfAnyDay.js:119-121`.
+
+Both selects get a `change` listener calling `updateSubscriptionURL()`. The listeners
+attach to `#riteSelect` / `#calendarSelect` via `getElementById`, matching how
+`updateSubscriptionURL()` already reaches the calendar select, rather than reaching into
+component internals.
+
+### The URL builder
+
+`CurrentEndpoint` gains a `rite` field, and the segment is emitted **unconditionally** —
+including `roman`:
+
+```js
+currentEndpoint += `/${CurrentEndpoint.rite}`;
+```
+
+The rite is a **path segment between `/calendar` and the nation/diocese pair** — there is
+no `/calendar/rite/{rite}` spelling and no query parameter.
+
+Note that `CurrentEndpoint.apiBase` is the `CalendarUrl` global, which already ends in
+`/calendar`. The rite segment is therefore appended immediately after `apiBase` and
+**before** the existing `/{calendarType}/{calendarId}` block — appending it later would
+produce `/calendar/nation/IT/ambrosian`, which the API rejects.
+
+This is the library's `explicitRite = true` behaviour, and it is deliberate: rite-explicit
+URLs are the default from here on, and emitting `roman` starts moving users onto them
+rather than leaving the Roman rite as an implicit special case. It also matches what
+components-js itself renders on a page with a linked rite select — `ApiOptions` sets
+`explicitRite = true` whenever `linkToRiteSelect()` runs (`ApiOptions.js:1047`).
+
+This changes the URL the card displays for Roman selections, so it is a visible change, but
+not a breaking one:
+
+- `Router::extractRiteSegment()` accepts `roman` explicitly. Verified against both the local
+  API and production (`litcal.johnromanodorazio.com/api/dev`): `/calendar/roman`,
+  `/calendar/roman/nation/IT` and `/calendar/roman/diocese/romamo_it` all return `200`, and
+  the ICS body of `/calendar/roman/nation/IT` is byte-identical to `/calendar/nation/IT`
+  (modulo `DTSTAMP`/`UID`/`PRODID`).
+- The bare forms keep resolving, so subscription URLs users have **already** pasted into
+  Google Calendar, iPhone or Outlook continue to work untouched. Only newly copied URLs
+  carry the explicit segment.
+
+With `allowNull`, an empty selection nulls `calendarType`/`calendarId`, yielding
+`/calendar/roman` or `/calendar/ambrosian`.
+
+### `includes/common.php`
+
+Gate the PHP-components bootstrap — Monolog logger, `FilesystemAdapter`, `Psr16Cache`,
+`HttpClientFactory::createProductionClient()`, `ApiClient::getInstance()` — on the page that
+consumes it, reusing the `$pageName` idiom already used in `layout/footer.php`:
+
+```php
+$pageName = basename($_SERVER['SCRIPT_FILENAME'], '.php');
+if ('examples' === $pageName) {
+    // ... existing bootstrap unchanged ...
+}
+```
+
+Verified safe: `$httpClient`, `$cache`, `$logger` and `$filesystemAdapter` have no consumer
+outside `common.php`. Every page that declares `$apiClient` immediately reassigns it with
+the frontend's own `LiturgicalCalendar\Frontend\ApiClient` (`easter.php:47`,
+`extending.php:43`, `missals-editor.php:37`), which is a different class.
+
+Behaviour on `examples.php` stays byte-identical; 18 other pages stop constructing a
+decorated Guzzle client, a filesystem cache adapter and a Monolog handler per request.
+
+## Error handling
+
+`ApiClient.init()` rejects on failure as of components-js 2.0.0. Use the same
+`startPage()` / `.catch()` shape as `liturgyOfAnyDay.js:247`. On failure the two containers
+stay empty and the card still shows its static subscription instructions and tabs, so the
+page degrades rather than breaking.
+
+## Testing
+
+`e2e/usage.spec.ts`, running under the existing `chromium` project (which supplies
+`storageState`; the page itself needs no auth). The subscription card is inside a collapsed
+accordion, so each test expands `button[data-bs-target="#calSubscription"]` first.
+
+Assertions:
+
+| Rite      | Selection   | Expected subscription URL                         |
+| --------- | ----------- | ------------------------------------------------- |
+| Roman     | empty       | `/calendar/roman?return_type=ICS&year_type=CIVIL` |
+| Roman     | nation `IT` | `/calendar/roman/nation/IT?...`                   |
+| Roman     | diocese     | `/calendar/roman/diocese/romamo_it?...`           |
+| Ambrosian | empty       | `/calendar/ambrosian?...`                         |
+| Ambrosian | diocese     | `/calendar/ambrosian/diocese/lugano_ch?...`       |
+
+Plus: switching to Ambrosian repartitions the list (no `optgroup`s, no national options,
+the four Ambrosian dioceses present), and switching back to Roman restores the national
+tier. A guard asserts every emitted URL carries an explicit rite segment, so a regression
+back to the implicit Roman spelling fails the suite.
+
+## Out of scope
+
+- Adding a year to the subscription URL. It is intentionally absent so the subscription
+  tracks the current year.
+- Rite awareness anywhere else on the site.
+- Removing `liturgical-calendar/components` from `composer.json` — load-bearing, see above.

--- a/e2e/usage.spec.ts
+++ b/e2e/usage.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Tests for the calendar subscription card on usage.php.
+ *
+ * The card's rite and calendar selects are rendered client-side by
+ * liturgy-components-js, and the subscription URL is rite-explicit: the rite
+ * segment is emitted for every rite, `roman` included.
+ */
+
+const BASE = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+/** Opens usage.php and expands the collapsed subscription accordion. */
+async function openSubscriptionCard(page: Page): Promise<void> {
+    await page.goto(`${BASE}/usage.php`);
+    await page.waitForLoadState('networkidle');
+    await page.click('button[data-bs-target="#calSubscription"]');
+    await page.waitForSelector('#calendarSelect', { state: 'visible' });
+    await page.waitForSelector('#riteSelect', { state: 'visible' });
+}
+
+const subscriptionUrl = (page: Page) =>
+    page.locator('#calSubscriptionUrl').innerText();
+
+test.describe('usage.php - calendar subscription URL', () => {
+    test('both selects render client-side', async ({ page }) => {
+        await openSubscriptionCard(page);
+        await expect(page.locator('#riteSelect')).toBeVisible();
+        await expect(page.locator('#calendarSelect')).toBeVisible();
+    });
+
+    test('the roman rite-level calendar is selectable and rite-explicit', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#calendarSelect', '');
+        expect(await subscriptionUrl(page)).toContain('/calendar/roman?');
+    });
+
+    test('a roman national calendar carries the explicit rite', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#calendarSelect', 'IT');
+        expect(await subscriptionUrl(page)).toContain(
+            '/calendar/roman/nation/IT?',
+        );
+    });
+
+    test('a roman diocesan calendar carries the explicit rite', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#calendarSelect', 'romamo_it');
+        expect(await subscriptionUrl(page)).toContain(
+            '/calendar/roman/diocese/romamo_it?',
+        );
+    });
+
+    test('the ambrosian rite-level calendar', async ({ page }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#calendarSelect', '');
+        expect(await subscriptionUrl(page)).toContain('/calendar/ambrosian?');
+    });
+
+    test('an ambrosian diocese', async ({ page }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#calendarSelect', 'lugano_ch');
+        expect(await subscriptionUrl(page)).toContain(
+            '/calendar/ambrosian/diocese/lugano_ch?',
+        );
+    });
+
+    test('every emitted URL carries an explicit rite segment', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        for (const [rite, calendar] of [
+            ['roman', ''],
+            ['roman', 'IT'],
+            ['ambrosian', ''],
+            ['ambrosian', 'lugano_ch'],
+        ]) {
+            await page.selectOption('#riteSelect', rite);
+            await page.selectOption('#calendarSelect', calendar);
+            expect(await subscriptionUrl(page)).toMatch(
+                /\/calendar\/(roman|ambrosian)(\/|\?)/,
+            );
+        }
+    });
+
+    test('the query parameters are preserved', async ({ page }) => {
+        await openSubscriptionCard(page);
+        const url = await subscriptionUrl(page);
+        expect(url).toContain('return_type=ICS');
+        expect(url).toContain('year_type=CIVIL');
+    });
+});
+
+test.describe('usage.php - rite repartitions the calendar list', () => {
+    test('the ambrosian rite drops the national tier and offers its own dioceses', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+
+        const nationalCount = await page
+            .locator('#calendarSelect option[data-calendartype="national"]')
+            .count();
+        expect(nationalCount).toBe(0);
+
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        for (const diocese of [
+            'milano_it',
+            'bergam_it',
+            'novara_it',
+            'lugano_ch',
+        ]) {
+            expect(values).toContain(diocese);
+        }
+    });
+
+    test('switching back to the roman rite restores the national tier', async ({
+        page,
+    }) => {
+        await openSubscriptionCard(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#riteSelect', 'roman');
+
+        const nationalCount = await page
+            .locator('#calendarSelect option[data-calendartype="national"]')
+            .count();
+        expect(nationalCount).toBeGreaterThan(0);
+
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        expect(values).not.toContain('lugano_ch');
+    });
+});

--- a/includes/common.php
+++ b/includes/common.php
@@ -287,52 +287,61 @@ if (!is_dir($logsDir)) {
     }
 }
 
-try {
-    $logger = new Logger('liturgical-calendar');
-    $logger->pushHandler(new StreamHandler(
-        $logsDir . '/litcal.log',
-        $debugMode ? Level::Debug : Level::Warning
-    ));
-    if ($debugMode) {
-        error_log('Logger initialized successfully');
+// The PHP components library is configured only for the embedded PHP example
+// (examples.php?example=PHP). That example detects it is being included rather
+// than requested directly, skips its own autoloader and its own
+// ApiClient::getInstance(), and resolves both from this host — see
+// examples/php/index.php. No other page consumes $logger, $cache or
+// $httpClient, and every page that declares $apiClient immediately reassigns
+// it with LiturgicalCalendar\Frontend\ApiClient, a different class.
+if ('examples' === basename($_SERVER['SCRIPT_FILENAME'], '.php')) {
+    try {
+        $logger = new Logger('liturgical-calendar');
+        $logger->pushHandler(new StreamHandler(
+            $logsDir . '/litcal.log',
+            $debugMode ? Level::Debug : Level::Warning
+        ));
+        if ($debugMode) {
+            error_log('Logger initialized successfully');
+        }
+        $logger->info('Logger initialized successfully');
+    } catch (Exception $e) {
+        error_log('Error creating logger: ' . $e->getMessage());
+        $logger = null;
     }
-    $logger->info('Logger initialized successfully');
-} catch (Exception $e) {
-    error_log('Error creating logger: ' . $e->getMessage());
-    $logger = null;
-}
 
-if ($debugMode && $logger !== null) {
-    $logger->debug('Debug mode enabled');
-}
-
-// 2. Setup Cache - Filesystem cache (if available) or ArrayCache fallback
-$cacheDir = dirname(__DIR__) . '/cache';
-if (!is_dir($cacheDir)) {
-    if (!mkdir($cacheDir, 0755, true)) {
-        error_log('Failed to create cache directory: ' . $cacheDir);
+    if ($debugMode && $logger !== null) {
+        $logger->debug('Debug mode enabled');
     }
+
+    // 2. Setup Cache - Filesystem cache (if available) or ArrayCache fallback
+    $cacheDir = dirname(__DIR__) . '/cache';
+    if (!is_dir($cacheDir)) {
+        if (!mkdir($cacheDir, 0755, true)) {
+            error_log('Failed to create cache directory: ' . $cacheDir);
+        }
+    }
+
+    $filesystemAdapter = new FilesystemAdapter(
+        'litcal',
+        3600 * 24,
+        $cacheDir
+    );
+
+    $cache = new Psr16Cache($filesystemAdapter);
+
+    // 3. Create Production-Ready HTTP Client
+    $httpClient = HttpClientFactory::createProductionClient(
+        cache: $cache,
+        logger: $logger,
+        cacheTtl: 3600 * 24,
+        maxRetries: 3,
+        failureThreshold: 5
+    );
+
+    // 4. Initialize ApiClient Singleton
+    $apiClient = ApiClient::getInstance([
+        'apiUrl'     => $apiConfig->internalBaseUrl,
+        'httpClient' => $httpClient
+    ]);
 }
-
-$filesystemAdapter = new FilesystemAdapter(
-    'litcal',
-    3600 * 24,
-    $cacheDir
-);
-
-$cache = new Psr16Cache($filesystemAdapter);
-
-// 3. Create Production-Ready HTTP Client
-$httpClient = HttpClientFactory::createProductionClient(
-    cache: $cache,
-    logger: $logger,
-    cacheTtl: 3600 * 24,
-    maxRetries: 3,
-    failureThreshold: 5
-);
-
-// 4. Initialize ApiClient Singleton
-$apiClient = ApiClient::getInstance([
-    'apiUrl'     => $apiConfig->internalBaseUrl,
-    'httpClient' => $httpClient
-]);

--- a/src/ApiConfig.php
+++ b/src/ApiConfig.php
@@ -33,17 +33,20 @@ class ApiConfig
 
     private function __construct(string $apiBaseUrl, ?string $internalBaseUrl = null)
     {
-        $this->apiBaseUrl         = rtrim($apiBaseUrl, '/');
-        $this->internalBaseUrl    = rtrim($internalBaseUrl ?? $apiBaseUrl, '/');
-        $this->dateOfEasterUrl    = "{$this->apiBaseUrl}/easter";
-        $this->calendarUrl        = "{$this->apiBaseUrl}/calendar";
-        $this->metadataUrl        = "{$this->apiBaseUrl}/calendars";
-        $this->eventsUrl          = "{$this->apiBaseUrl}/events";
-        $this->missalsUrl         = "{$this->apiBaseUrl}/missals";
-        $this->decreesUrl         = "{$this->apiBaseUrl}/decrees";
-        $this->temporaleUrl       = "{$this->apiBaseUrl}/temporale";
-        $this->regionalDataUrl    = "{$this->apiBaseUrl}/data";
-        $this->calSubscriptionUrl = "{$this->apiBaseUrl}/calendar?return_type=ICS&year_type=CIVIL";
+        $this->apiBaseUrl      = rtrim($apiBaseUrl, '/');
+        $this->internalBaseUrl = rtrim($internalBaseUrl ?? $apiBaseUrl, '/');
+        $this->dateOfEasterUrl = "{$this->apiBaseUrl}/easter";
+        $this->calendarUrl     = "{$this->apiBaseUrl}/calendar";
+        $this->metadataUrl     = "{$this->apiBaseUrl}/calendars";
+        $this->eventsUrl       = "{$this->apiBaseUrl}/events";
+        $this->missalsUrl      = "{$this->apiBaseUrl}/missals";
+        $this->decreesUrl      = "{$this->apiBaseUrl}/decrees";
+        $this->temporaleUrl    = "{$this->apiBaseUrl}/temporale";
+        $this->regionalDataUrl = "{$this->apiBaseUrl}/data";
+        // The `roman` rite segment is explicit here on purpose: it must match the
+        // rite-explicit URL the JS produces after hydration, so a user who copies
+        // the URL before hydration finishes gets the same result as one who copies after.
+        $this->calSubscriptionUrl = "{$this->apiBaseUrl}/calendar/roman?return_type=ICS&year_type=CIVIL";
     }
 
     /**

--- a/usage.php
+++ b/usage.php
@@ -23,6 +23,8 @@ $messages = [
     'Select calendar'          => _('Select calendar'),
     /** translators: label for dropdown to select the liturgical rite (Roman or Ambrosian) */
     'Select rite'              => _('Select rite'),
+    /** translators: notification message shown when the calendar list fails to load */
+    'Failed to load calendars' => _('Could not load the calendar list. Please try again later.'),
 ];
 
 ?><!doctype html>

--- a/usage.php
+++ b/usage.php
@@ -1,10 +1,10 @@
 <?php
 
-use LiturgicalCalendar\Components\CalendarSelect;
+/**
+ * Example usage of the API - includes the calendar subscription card.
+ */
 
 include_once 'includes/common.php';
-
-$CalendarSelect = new CalendarSelect(['locale' => $i18n->LOCALE]);
 
 $messages = [
     /** translators: notification title */
@@ -19,6 +19,10 @@ $messages = [
     'Failed to copy URL'       => _('Failed to copy URL to clipboard'),
     /** translators: notification message */
     'Select and copy manually' => _('Please select and copy manually'),
+    /** translators: label for dropdown to select which calendar to subscribe to */
+    'Select calendar'          => _('Select calendar'),
+    /** translators: label for dropdown to select the liturgical rite (Roman or Ambrosian) */
+    'Select rite'              => _('Select rite'),
 ];
 
 ?><!doctype html>
@@ -131,15 +135,8 @@ $messages = [
                         <div class="row">
                             <div class="col-lg">
                                 <div class="row">
-                                    <div class="form-group col-md"><?php
-                                    /** translators: label for dropdown to select which calendar to subscribe to */
-                                    echo $CalendarSelect
-                                        ->class('form-select')
-                                        ->id('calendarSelect')
-                                        ->label(true)
-                                        ->labelText(_('Select calendar'))
-                                        ->getSelect();
-                                    ?></div>
+                                    <div class="form-group col-md" id="riteSelectContainer"></div>
+                                    <div class="form-group col-md" id="calendarSelectContainer"></div>
                                 </div>
                                 <p class="mt-2 mb-1"><?php
                                     /** translators: label above the iCal/ICS subscription URL */


### PR DESCRIPTION
Fixes two live crashes, then gives the calendar-subscription card on `usage.php` a rite selector and makes the subscription URL rite-explicit.

## Reviewing this

~4,300 insertions, but **the reviewable code surface is ~480 lines**. One commit (`e2587854`) is a repo-wide markdown reformat with zero executable code; the design spec and plan account for most of the rest.

```bash
git diff --stat development...HEAD -- assets/js src includes usage.php e2e .github
```

## Why

`usage.php` and `examples.php?example=PHP` were both crashing in production.

- **`usage.php`** hit `TypeError: hasNationalCalendarWithDioceses(): Argument #1 ($item) must be of type NationalCalendar, null given`. The nation pass assumed every diocese's nation owns a national calendar — false for `lugano_ch`, which sits in nation `CH`. Fixed upstream in components v4.0.0.
- **`examples.php?example=PHP`** hit `Class "LiturgicalCalendar\Components\Rite" not found`. `examples/php/index.php` detects that it is being *included* rather than requested directly and deliberately skips its own autoloader, so it resolved the library from this repo's `vendor/` — still on v3.3.1.

Both are fixed by taking `liturgical-calendar/components` v4.2.0.

## What changed

**Dependency and fallout** (`d7fcd093`)
- `liturgical-calendar/components` 3.3.1 → 4.2.0.
- v4.0.0 renamed the `data-calendartype` values, so `usage.js` now reads `national` / `diocesan`. Without this every option fell through to the `default:` branch and the subscription URL silently lost its calendar — no error anywhere.
- Deploy workflow's pinned examples-repo SHA rolled to the tip of `main`.

**Feature** (`1e16bf66` … `4f1272f8`)
- The URL model moves out of `usage.js` into `assets/js/subscriptionUrl.js` — dependency-free, so it is unit-testable without a browser. 11 new Vitest cases.
- `CurrentEndpoint` gains a rite path segment, emitted between the API base and the calendar segment.
- `usage.php`'s server-rendered PHP `CalendarSelect` is replaced by the JS `CalendarSelect` + `RiteSelect`, linked with `linkToRiteSelect()` so the calendar list repartitions on rite change. `allowNull(true)` makes the rite-level calendar selectable — the General Roman Calendar and the Ambrosian Calendar can now be subscribed to at all, which they could not before.
- The four Ambrosian dioceses (`milano_it`, `bergam_it`, `novara_it`, `lugano_ch`) become reachable.
- `includes/common.php`'s PHP-components bootstrap is gated to `examples.php`. It ran on all 19 pages; after this branch its only consumer is the embedded PHP example.

### The rite segment is emitted for `roman` too

Deliberate. `/calendar/roman/nation/IT`, not `/calendar/nation/IT`, so users transition onto rite-explicit URLs rather than leaving Roman an implicit special case. Verified against both the local API and production: the explicit spelling returns `200` on every route, and `/calendar/roman/nation/IT` returns an ICS body byte-identical to `/calendar/nation/IT`. **The implicit spelling still resolves, so subscription URLs already pasted into Google Calendar, iPhone or Outlook are unaffected** — only newly copied URLs carry the segment. This also matches what `liturgy-components-js` itself emits when a rite select is linked.

`ApiConfig::calSubscriptionUrl` was updated to match, so the pre-hydration string equals the hydrated one and the displayed URL does not change on a default page load.

**Tooling** (`e2587854`)
- Adds `.prettierrc` (`tabWidth: 4`, `singleQuote: true`). Without it `yarn format:md` reformatted embedded code blocks to 2-space/double-quoted — the opposite of the JS it documents.
- `tabWidth` also governs markdown list indentation, which then collided with markdownlint's `MD007` (default 2) on every nested list. Set to 4.
- `.serena/.markdownlint.yml` now `extends` the repo config instead of replacing it — markdownlint-cli2 applies only the nearest config, so `MD007` was silently reverting under `.serena/`.
- Note: prettier now formats code *inside* markdown fences, not just markdown structure.

## Verification

`composer parallel-lint` · `composer lint` · `composer analyse` (PHPStan L7) · `composer test` (13) · `yarn lint` · `yarn typecheck` · `yarn test:unit` (129) · `composer lint:md` · `yarn lint:md` — all clean.

`e2e/usage.spec.ts` — 10/10. Browser-verified end to end:

| Rite | Selection | URL |
|---|---|---|
| Roman | rite-level | `/calendar/roman?return_type=ICS&year_type=CIVIL` |
| Roman | nation IT | `/calendar/roman/nation/IT?…` |
| Roman | diocese Roma | `/calendar/roman/diocese/romamo_it?…` |
| Ambrosian | rite-level | `/calendar/ambrosian?…` |
| Ambrosian | Lugano | `/calendar/ambrosian/diocese/lugano_ch?…` |

`examples.php?example=PHP` still renders its calendar after the bootstrap gate.

## Known gaps

- **`e2e/usage.spec.ts` does not run in CI.** `e2e.yml` runs only the `rbac` project on `pull_request`/`schedule`; the `chromium` project is `workflow_dispatch`-only. The regression guard exists but is not automatically enforced.
- The `diocesan-calendar` specs currently fail locally at `waitForAuth()` on a stale `e2e/.auth/user.json`. **Confirmed pre-existing** — the identical failure reproduces on the merge base with none of these changes.
- Nothing automated covers `examples.php?example=PHP`, which this branch makes the sole consumer of the `common.php` bootstrap. Follow-up issue worth filing.
- The markdown lint/format exclusion drift noted above is tracked in #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rite-aware calendar selection to the usage page, including Roman and Ambrosian options.
  * Calendar subscription URLs now explicitly include the selected rite and support national and diocesan calendar paths.
  * Calendar choices update dynamically when the rite changes.

* **Bug Fixes**
  * Improved loading-failure handling so subscription content remains usable when selectors cannot load.

* **Documentation**
  * Updated usage guidance and formatting across project documentation for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->