### PR TITLE
refactor: take components-js v2.2.0 and mount liturgyOfAnyDay through DayViewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,36 @@ rather than requested directly, skips its own autoloader and its own `ApiClient`
 both from the host. `includes/common.php` therefore keeps its `ApiClient::getInstance()` bootstrap, gated
 to `examples.php`. Do not remove the composer dependency — the example crashes without it.
 
+### Meta-components
+
+liturgy-components-js 2.2.0 ships two meta-components that bundle wiring this repo used to re-derive by
+hand:
+
+- **`DayViewer`** — the whole "liturgy of any day" page. Used by `assets/js/liturgyOfAnyDay.js`.
+- **`CalendarResourcePicker`** — a `RiteSelect` plus a filtered `CalendarSelect`, for choosing a national
+  or diocesan resource id.
+
+Prefer them over hand-wiring. A `RiteSelect` needs **two** wires — `linkToRiteSelect()` AND
+`apiClient.listenTo(riteSelect)` — and wiring only the first fails silently: the form reads `ambrosian`
+while every request still goes to `/calendar/roman/`. The meta-components own that.
+
+Two call sites stay hand-wired on purpose:
+
+- `assets/js/usage.js` — `CalendarResourcePicker` rejects `CalendarSelectFilter.NONE` and makes the
+  empty option a disabled placeholder. The subscription card needs an all-calendars list and a
+  _selectable_ empty option meaning the rite-level calendar. Asked upstream as
+  liturgy-components-js#42.
+- `assets/js/index.js` — a PathBuilder/API-explorer page; neither meta-component models it.
+
+**Theme bag notes:** The theme bag's keys are HTML roles (`select`, `label`, `input`, `wrapper`) with
+per-child overrides named for the public getters. Two sharp edges: `label()` is **one-shot**, so once the
+theme bag has themed a child, custom label text must go through the per-child `labelText` key rather than
+`viewer.<child>.label({ text })`, which throws; and `id()` is not one-shot. Separately,
+`Theme.resolveChildTheme()` currently forwards only `class`/`labelClass`/`labelText`/`wrapperClass`/`wrapper`,
+so the eight `LiturgyOfAnyDay` styling keys `DayViewer`'s own constructor tries to read are silently dropped
+— `assets/js/liturgyOfAnyDay.js` sets them post-mount instead. Filed upstream as liturgy-components-js#43;
+move them into the theme bag once that lands.
+
 ## E2E Tests (Playwright)
 
 Test files in `e2e/` verify form submissions match API contracts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,13 +234,27 @@ Prefer them over hand-wiring. A `RiteSelect` needs **two** wires — `linkToRite
 `apiClient.listenTo(riteSelect)` — and wiring only the first fails silently: the form reads `ambrosian`
 while every request still goes to `/calendar/roman/`. The meta-components own that.
 
-Two call sites stay hand-wired on purpose:
+Five call sites still hand-wire a `RiteSelect` plus a `CalendarSelect`. They fall into two groups, and
+the difference matters: one group is a permanent exception, the other is simply not converted yet.
+
+**Permanently hand-wired — do not "fix" these:**
 
 - `assets/js/usage.js` — `CalendarResourcePicker` rejects `CalendarSelectFilter.NONE` and makes the
   empty option a disabled placeholder. The subscription card needs an all-calendars list and a
   _selectable_ empty option meaning the rite-level calendar. Asked upstream as
   liturgy-components-js#42.
 - `assets/js/index.js` — a PathBuilder/API-explorer page; neither meta-component models it.
+
+**Awaiting migration to `CalendarResourcePicker`** — these three are picker-shaped and should be
+converted, just not yet. Treat their current hand-wiring as debt, not as a pattern to copy:
+
+- `assets/js/admin-permissions.js` — the permission-grant resource-id picker.
+- `assets/js/permission-requests.js` — the permission-request picker, including a hand-rolled
+  `is-invalid` failure control the component now provides.
+- `assets/js/admin-tests.js` — the test-scope picker.
+
+The first two are RBAC-critical and covered only by the `rbac` e2e project, which is why they were
+deferred to their own PR rather than bundled with the `DayViewer` conversion.
 
 **Theme bag notes:** The theme bag's keys are HTML roles (`select`, `label`, `input`, `wrapper`) with
 per-child overrides named for the public getters. Two sharp edges: `label()` is **one-shot**, so once the

--- a/assets/js/liturgyOfAnyDay.js
+++ b/assets/js/liturgyOfAnyDay.js
@@ -1,257 +1,113 @@
 /**
- * Liturgy of Any Day - using liturgy-components-js library
+ * Liturgy of Any Day - using the DayViewer meta-component.
  *
- * This module uses the ApiClient, CalendarSelect, ApiOptions, and LiturgyOfAnyDay
- * components from the liturgy-components-js library. The ApiClient automatically handles
- * the Accept-Language header when listening to ApiOptions.
+ * DayViewer bundles the RiteSelect, CalendarSelect, ApiOptions locale input and
+ * LiturgyOfAnyDay widget that this page previously wired by hand, including the
+ * rite's two-wire requirement: linkToRiteSelect() alone rebuilds the calendar
+ * list but does NOT turn the rite into a path segment, so a hand-wired page can
+ * read `ambrosian` while every request still goes to /calendar/roman/.
+ *
+ * The label text that used to come from a hand-rolled 12-language map now comes
+ * from the library's own Messages, which covers 83 languages.
+ *
+ * `theme.liturgy` only forwards `class` to the widget: `Theme.resolveChildTheme()`
+ * copies through `class`/`labelClass`/`labelText`/`wrapperClass`/`wrapper` only, so
+ * any other `theme.liturgy.*` key -- `dateClass`, `dateControlsClass`,
+ * `eventsWrapperClass`, `eventClass`, `eventGradeClass`, `eventCommonClass`,
+ * `eventYearCycleClass` -- is silently dropped before it ever reaches
+ * `DayViewer`'s constructor, even though that constructor's own loop
+ * (DayViewer.js:196-209) tries to read exactly those keys from the resolved
+ * theme. Filed as liturgy-components-js#43: the resolver strips eight keys the
+ * constructor loop expects, making that loop unreachable code. The events
+ * wrapper needs the `card-body` class the old hand-wiring gave it --
+ * e2e/liturgyOfAnyDay.spec.ts locates rendered events via
+ * `#liturgyOfAnyDay > .card-body` -- and the other six reproduce the old page's
+ * Bootstrap styling, so all seven are set post-mount below, the same way the
+ * ids are. Once #43 lands, these can move back into `theme.liturgy`.
+ *
+ * The three date controls (`#day`, `#month`, the year input) hit a distinct,
+ * separate gap: DayViewer.js:214 resolves that child with role `'input'`, so it
+ * looks up `theme.input` -- `theme.select` is never consulted for it -- and
+ * DayViewer.js:240-247 shares ONE resolved object across all three controls, even
+ * though `#month` is a `<select>` needing `form-select` while the other two are
+ * `<input>`s needing `form-control`. Unlike #43, this isn't a key the resolver
+ * drops -- it's a role the theme bag has no way to express at all, since one
+ * resolved object can't hold two different class strings for the same key. So
+ * these three are also set post-mount, one call per control's actual tag.
  */
 
-import {
-    ApiClient,
-    CalendarSelect,
-    RiteSelect,
-    ApiOptions,
-    ApiOptionsFilter,
-    LiturgyOfAnyDay
-} from '@liturgical-calendar/components-js';
+import { ApiClient, DayViewer } from '@liturgical-calendar/components-js';
 
-// Simple translation maps (Messages is not exported from the library)
-const translations = {
-    selectCalendar: {
-        en: 'Select a calendar',
-        it: 'Seleziona un calendario',
-        es: 'Seleccionar un calendario',
-        fr: 'Sélectionner un calendrier',
-        de: 'Kalender auswählen',
-        pt: 'Selecionar um calendário',
-        nl: 'Selecteer een kalender',
-        la: 'Elige calendarium',
-        hu: 'Válasszon naptárat',
-        sk: 'Vyberte kalendár',
-        vi: 'Chọn lịch',
-        id: 'Pilih kalender'
-    },
-    selectRite: {
-        en: 'Select a rite',
-        it: 'Seleziona un rito',
-        es: 'Seleccionar un rito',
-        fr: 'Sélectionner un rite',
-        de: 'Ritus auswählen',
-        pt: 'Selecionar um rito',
-        nl: 'Selecteer een ritus',
-        la: 'Elige ritum',
-        hu: 'Válasszon rítust',
-        sk: 'Vyberte rítus',
-        vi: 'Chọn nghi lễ',
-        id: 'Pilih ritus'
-    },
-    language: {
-        en: 'Language',
-        it: 'Lingua',
-        es: 'Idioma',
-        fr: 'Langue',
-        de: 'Sprache',
-        pt: 'Língua',
-        nl: 'Taal',
-        la: 'Lingua',
-        hu: 'Nyelv',
-        sk: 'Jazyk',
-        vi: 'Ngôn ngữ',
-        id: 'Bahasa'
-    },
-    day: {
-        en: 'Day',
-        it: 'Giorno',
-        es: 'Día',
-        fr: 'Jour',
-        de: 'Tag',
-        pt: 'Dia',
-        nl: 'Dag',
-        la: 'Dies',
-        hu: 'Nap',
-        sk: 'Deň',
-        vi: 'Ngày',
-        id: 'Hari'
-    },
-    month: {
-        en: 'Month',
-        it: 'Mese',
-        es: 'Mes',
-        fr: 'Mois',
-        de: 'Monat',
-        pt: 'Mês',
-        nl: 'Maand',
-        la: 'Mensis',
-        hu: 'Hónap',
-        sk: 'Mesiac',
-        vi: 'Tháng',
-        id: 'Bulan'
-    },
-    year: {
-        en: 'Year',
-        it: 'Anno',
-        es: 'Año',
-        fr: 'Année',
-        de: 'Jahr',
-        pt: 'Ano',
-        nl: 'Jaar',
-        la: 'Annus',
-        hu: 'Év',
-        sk: 'Rok',
-        vi: 'Năm',
-        id: 'Tahun'
-    }
-};
-
-/**
- * Initialize the page with JS components
- */
 const initializePage = async () => {
-    // Initialize ApiClient with the API URL from the global BaseUrl
-    // Since components-js 2.0.0 init() rejects rather than resolving to false, so
-    // the `instanceof` guard this used to need is gone; startPage() below catches
-    // the rejection.
-    const apiClient = await ApiClient.init( BaseUrl );
+    const apiClient = await ApiClient.init(BaseUrl);
 
-    // Get the base language for translations
-    const lang = currentLocale.language;
+    const viewer = await DayViewer.mountInto(
+        {
+            rite: '#riteSelectContainer',
+            calendar: '#calendarSelectContainer',
+            locale: '#localeSelectContainer',
+            liturgy: '#liturgyOfAnyDayContainer',
+        },
+        {
+            locale: currentLocale.language,
+            apiClient,
+            // The widget's own "Liturgy of the Day" heading is redundant: the page
+            // already has an <h3> heading above these controls, exactly as the
+            // hand-wired version hid it via `_titleElement.style.display = 'none'`.
+            showTitle: false,
+            theme: {
+                select: 'form-select',
+                label: 'form-label',
+                liturgy: { class: 'card shadow m-2' },
+                dateControls: {
+                    labelClass: 'form-label',
+                    wrapperClass: 'col-md',
+                },
+            },
+            onError: (error) => {
+                console.error(`Liturgy of any day: ${error.message}`);
+                showToast(Messages['Failed to load'], 'danger');
+            },
+        },
+    );
 
-    // Create RiteSelect component. It must exist in the DOM before it is passed
-    // to linkToRiteSelect() below, which reads its element to attach the
-    // rite-change listener.
-    const riteSelect = new RiteSelect( lang )
-        .class( 'form-select' )
-        .id( 'riteSelect' )
-        .label( { text: translations.selectRite[ lang ] || translations.selectRite.en, class: 'form-label' } );
-    riteSelect.appendTo( '#riteSelectContainer' );
-
-    // Create CalendarSelect component
-    const calendarSelect = new CalendarSelect( lang )
-        .class( 'form-select' )
-        .id( 'calendarSelect' )
-        .label( { text: translations.selectCalendar[ lang ] || translations.selectCalendar.en, class: 'form-label' } )
-        .allowNull( true );
-    calendarSelect.appendTo( '#calendarSelectContainer' );
-
-    // Set CalendarSelect to General Roman Calendar (empty value) instead of Vatican
-    calendarSelect._domElement.value = '';
-
-    // Create ApiOptions with only the locale input filter
-    const apiOptions = new ApiOptions( lang )
-        .filter( ApiOptionsFilter.LOCALE_ONLY )
-        // Linking the rite makes it an explicit part of the endpoint and
-        // rebuilds the calendar select whenever the rite changes: the Ambrosian
-        // rite has no national tier and offers a different set of diocesan
-        // calendars, so a selection from one rite is never carried into another.
-        //
-        // Two calls rather than the deprecated second argument of
-        // linkToCalendarSelect(), which warns as of components-js 2.1.0.
-        .linkToCalendarSelect( calendarSelect )
-        .linkToRiteSelect( riteSelect );
-
-    // Configure the locale input before appending
-    // Set defaultValue to currentLocale.language so it will be selected if available
-    apiOptions._localeInput.id( 'apiOptionsLocale' );
-    apiOptions._localeInput.class( 'form-select' );
-    apiOptions._localeInput.labelClass( 'form-label' );
-    apiOptions._localeInput._labelElement.textContent = translations.language[ lang ] || translations.language.en;
-    apiOptions._localeInput.defaultValue( lang );
-
-    // Append the locale input to its container using the filter
-    apiOptions.appendTo( '#localeSelectContainer' );
-
-    // Try to select the current locale in LocaleInput, fallback to first option if not available
-    // First try exact match, then try matching just the language part (e.g., "en" matches "en_US")
-    const localeOptions = Array.from( apiOptions._localeInput._domElement.options );
-    const exactMatch = localeOptions.find( opt => opt.value === lang );
-    const languageMatch = localeOptions.find( opt => opt.value.split( /[-_]/ )[ 0 ] === lang );
-
-    let selectedLocale;
-    if ( exactMatch ) {
-        selectedLocale = exactMatch.value;
-    } else if ( languageMatch ) {
-        selectedLocale = languageMatch.value;
-    } else if ( localeOptions.length > 0 ) {
-        selectedLocale = localeOptions[ 0 ].value;
-    } else {
-        selectedLocale = lang; // Fallback to original lang if no options available
-    }
-    apiOptions._localeInput._domElement.value = selectedLocale;
-
-    // Create LiturgyOfAnyDay component
-    const liturgyOfAnyDay = new LiturgyOfAnyDay( { locale: lang } )
-        .id( 'liturgyOfAnyDay' )
-        .class( 'card shadow m-2' )
-        .dateClass( 'card-header py-3 d-flex justify-content-between align-items-center' )
-        .dateControlsClass( 'row g-3 p-3' )
-        .eventsWrapperClass( 'card-body' )
-        .eventClass( 'liturgy-event p-3 mb-2 rounded' )
-        .eventGradeClass( 'small' )
-        .eventCommonClass( 'small fst-italic' )
-        .eventYearCycleClass( 'small' )
-        .dayInputConfig( {
-            wrapper: 'div',
-            wrapperClass: 'col-md',
-            class: 'form-control',
-            labelClass: 'form-label',
-            labelText: translations.day[ lang ] || translations.day.en
-        } )
-        .monthInputConfig( {
-            wrapper: 'div',
-            wrapperClass: 'col-md',
-            class: 'form-select',
-            labelClass: 'form-label',
-            labelText: translations.month[ lang ] || translations.month.en
-        } )
-        .yearInputConfig( {
-            wrapper: 'div',
-            wrapperClass: 'col-md',
-            class: 'form-control',
-            labelClass: 'form-label',
-            labelText: translations.year[ lang ] || translations.year.en
-        } )
-        .buildDateControls()
-        .listenTo( apiClient );
-
-    // Hide the component's title since the page already has a heading
-    liturgyOfAnyDay._titleElement.style.display = 'none';
-
-    liturgyOfAnyDay.appendTo( '#liturgyOfAnyDayContainer' );
-
-    // Have ApiClient listen to CalendarSelect, RiteSelect and ApiOptions
-    // This automatically handles Accept-Language headers based on locale selection.
-    //
-    // riteSelect has to be wired here as well as passed to linkToCalendarSelect()
-    // above: that call rebuilds the calendar select on a rite change, but only the
-    // client turns the rite into a path segment. Without it the page offered a rite
-    // select that changed the calendar list while every request still went to
-    // /calendar/roman/.
-    apiClient.listenTo( calendarSelect ).listenTo( riteSelect ).listenTo( apiOptions );
-
-    // Initial fetch - fetch the General Roman Calendar
-    // Note: LiturgyOfAnyDay.listenTo() already configured ApiClient with the correct
-    // year_type (LITURGICAL for Dec 31st to include vigil masses, CIVIL otherwise)
-    //
-    // Since components-js 2.0.0 the fetch methods reject instead of logging and
-    // swallowing, so this promise is handled rather than left bare.
-    apiClient.fetchCalendar( selectedLocale ).catch( error => {
-        console.error( `Could not load the calendar: ${error.message}` );
-    } );
+    // ids are not theme keys, and id() is not one-shot -- unlike label(), which
+    // the theme bag has already called on each child.
+    viewer.riteSelect.id('riteSelect');
+    viewer.calendarSelect.id('calendarSelect');
+    viewer.localeInput.id('apiOptionsLocale');
+    viewer.liturgy.id('liturgyOfAnyDay');
+    // See the file-level note above (liturgy-components-js#43): none of these
+    // seven are reachable through the theme bag, so they are set post-mount,
+    // reproducing the classes the old hand-wired page set directly.
+    viewer.liturgy
+        .dateClass('card-header py-3 d-flex justify-content-between align-items-center')
+        .dateControlsClass('row g-3 p-3')
+        .eventsWrapperClass('card-body')
+        .eventClass('liturgy-event p-3 mb-2 rounded')
+        .eventGradeClass('small')
+        .eventCommonClass('small fst-italic')
+        .eventYearCycleClass('small');
+    // See the file-level note above: the date controls' role-shared theme
+    // object cannot express one class per tag, so each control's class is set
+    // post-mount, matching the old hand-wired page's Bootstrap classes.
+    viewer.liturgy
+        .dayInputConfig({ class: 'form-control' })
+        .monthInputConfig({ class: 'form-select' })
+        .yearInputConfig({ class: 'form-control' });
 };
 
-// Initialize when DOM is ready.
-//
-// initializePage() is async and, since components-js 2.0.0, ApiClient.init() and
-// the fetch methods reject on failure, so the returned promise is handled here
-// rather than left to surface as an unhandled rejection.
 const startPage = () => {
-    initializePage().catch( error => {
-        console.error( `Could not initialize the liturgy of any day page: ${error.message}` );
-    } );
+    initializePage().catch((error) => {
+        console.error(
+            `Could not initialize the liturgy of any day page: ${error.message}`,
+        );
+        showToast(Messages['Failed to load'], 'danger');
+    });
 };
 
-if ( document.readyState === 'loading' ) {
-    document.addEventListener( 'DOMContentLoaded', startPage );
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startPage);
 } else {
     startPage();
 }

--- a/docs/superpowers/plans/2026-08-11-dayviewer-adoption.md
+++ b/docs/superpowers/plans/2026-08-11-dayviewer-adoption.md
@@ -1,0 +1,609 @@
+# DayViewer Adoption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Replace the 257 hand-wired lines of `assets/js/liturgyOfAnyDay.js` with one `DayViewer.mountInto()` call, without changing what the page does.
+
+**Architecture:** Write a characterization Playwright spec against the CURRENT hand-wired page first, so it
+pins existing behaviour. Then convert the JS to `DayViewer` and prove the same spec still passes, unchanged.
+`liturgyOfAnyDay.php` gains only a `$messages` block for one new error string; its four containers already
+match `DayViewer`'s four slot names.
+
+**Tech Stack:** liturgy-components-js 2.2.0 (CDN import map in production, `assets/components-js` symlink in dev), vanilla ES modules, Playwright, PHP 8.4 with gettext.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-11-dayviewer-adoption-design.md`. Read it before starting.
+- **The characterization spec must be written and passing BEFORE any change to `liturgyOfAnyDay.js`,
+  and must not be edited afterwards.** A test written against converted code proves only that the new
+  code does what it does.
+- **Use `showToast(message, 'danger')`, NOT `toastr`.** Raw toastr is loaded only for
+  `['index', 'extending', 'usage', 'missals-editor', 'admin-dashboard', 'examples']`
+  (`layout/footer.php:125`); `liturgyOfAnyDay` is not among them. `window.showToast(message, type)`
+  from `assets/js/toast.js` is loaded for every page at `layout/footer.php:87`.
+- **`label()` is one-shot.** The theme bag calls it. After mounting, `viewer.<child>.label({...})`
+  throws `Label has already been set`. Custom label text goes through the per-child `labelText` theme
+  key. `id()` is NOT one-shot and may be set after the mount.
+- **Do not modify** `composer.json`, `package.json`, `composer.lock`, `vendor/`, or any lint/format
+  config.
+- **Do not convert** `usage.js` or `index.js`. They are deliberately out of scope.
+- **gettext:** numbered placeholders (`%1$s`) if any format string is added.
+- **Never `git commit --no-verify`.**
+- **Element ids that must survive the conversion:** `riteSelect`, `calendarSelect`, `apiOptionsLocale`,
+  `liturgyOfAnyDay`. These four are set explicitly by our code.
+- **The date-control ids are library-generated and are NOT contractual.** They currently render as
+  `day`, `month` and `year-2` — that suffix is the library's own de-duplication, not something we set.
+  Do not assert on them, and do not treat a change there as a regression.
+- **`DayViewer`'s public getters, verified against `src/MetaComponents/DayViewer.js`:** `riteSelect`,
+  `calendarSelect`, `localeInput`, `liturgy`, `selectedLocale`. Use exactly these names.
+
+## File Structure
+
+| File                                     | Responsibility                                                  |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| `e2e/liturgyOfAnyDay.spec.ts` (new)      | Characterization test. Written in Task 1, unchanged thereafter. |
+| `assets/js/liturgyOfAnyDay.js` (rewrite) | One `DayViewer.mountInto()` call plus error routing.            |
+| `liturgyOfAnyDay.php` (modify)           | Adds a `$messages` block and the `const Messages` script.       |
+| `CLAUDE.md` (modify)                     | Records the meta-component pattern and what stays hand-wired.   |
+
+---
+
+### Task 1: Characterization spec against the CURRENT page
+
+Nothing is converted in this task. The spec must pass against today's hand-wired implementation; that
+is what makes it evidence later.
+
+**Files:**
+
+- Create: `e2e/liturgyOfAnyDay.spec.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `e2e/liturgyOfAnyDay.spec.ts`, which Task 2 must leave byte-identical.
+
+- [ ] **Step 1: Confirm the page works before writing anything**
+
+The docker stack is already running (frontend `http://localhost:3000`, API `http://localhost:8000`).
+
+```bash
+curl -s http://localhost:3000/liturgyOfAnyDay.php | grep -c 'id="riteSelectContainer"'
+```
+
+Expected: `1`. If it is `0`, stop and report — the page is broken before you started.
+
+- [ ] **Step 2: Write the spec**
+
+Create `e2e/liturgyOfAnyDay.spec.ts`:
+
+```ts
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Characterization tests for liturgyOfAnyDay.php.
+ *
+ * Written against the hand-wired implementation and deliberately NOT edited when
+ * that implementation is replaced by the DayViewer meta-component, so that the
+ * same assertions prove the conversion preserved behaviour.
+ */
+
+const BASE = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+/** Opens the page and waits for the client-rendered controls to exist. */
+async function openPage(page: Page): Promise<void> {
+    await page.goto(`${BASE}/liturgyOfAnyDay.php`);
+    await page.waitForSelector('#riteSelect', {
+        state: 'visible',
+        timeout: 20000,
+    });
+    await page.waitForSelector('#calendarSelect', { state: 'visible' });
+}
+
+test.describe('liturgyOfAnyDay - controls render', () => {
+    test('all four children mount into their containers', async ({ page }) => {
+        await openPage(page);
+        await expect(
+            page.locator('#riteSelectContainer #riteSelect'),
+        ).toBeVisible();
+        await expect(
+            page.locator('#calendarSelectContainer #calendarSelect'),
+        ).toBeVisible();
+        await expect(
+            page.locator('#localeSelectContainer #apiOptionsLocale'),
+        ).toBeVisible();
+        await expect(
+            page.locator('#liturgyOfAnyDayContainer #liturgyOfAnyDay'),
+        ).toBeVisible();
+    });
+
+    test('the rite select offers roman and ambrosian', async ({ page }) => {
+        await openPage(page);
+        const values = await page.$$eval('#riteSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        expect(values).toContain('roman');
+        expect(values).toContain('ambrosian');
+    });
+
+    test('the locale input is populated', async ({ page }) => {
+        await openPage(page);
+        const count = await page.locator('#apiOptionsLocale option').count();
+        expect(count).toBeGreaterThan(0);
+        const value = await page.locator('#apiOptionsLocale').inputValue();
+        expect(value).not.toBe('');
+    });
+});
+
+test.describe('liturgyOfAnyDay - rite repartitions the calendar list', () => {
+    test('ambrosian drops the national tier and offers its own dioceses', async ({
+        page,
+    }) => {
+        await openPage(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await expect
+            .poll(() =>
+                page
+                    .locator(
+                        '#calendarSelect option[data-calendartype="national"]',
+                    )
+                    .count(),
+            )
+            .toBe(0);
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        for (const diocese of [
+            'milano_it',
+            'bergam_it',
+            'novara_it',
+            'lugano_ch',
+        ]) {
+            expect(values).toContain(diocese);
+        }
+    });
+
+    test('switching back to roman restores the national tier', async ({
+        page,
+    }) => {
+        await openPage(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#riteSelect', 'roman');
+        await expect
+            .poll(() =>
+                page
+                    .locator(
+                        '#calendarSelect option[data-calendartype="national"]',
+                    )
+                    .count(),
+            )
+            .toBeGreaterThan(0);
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        expect(values).not.toContain('lugano_ch');
+    });
+});
+
+test.describe('liturgyOfAnyDay - the rite reaches the request', () => {
+    // The failure mode DayViewer exists to prevent: the form reads `ambrosian`
+    // while every request still goes to /calendar/roman/. Only a network
+    // assertion can see this — the DOM looks correct either way.
+    test('choosing the ambrosian rite produces an /calendar/ambrosian request', async ({
+        page,
+    }) => {
+        await openPage(page);
+        const urls: string[] = [];
+        page.on('request', (r) => {
+            if (r.url().includes('/calendar')) urls.push(r.url());
+        });
+
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await expect
+            .poll(
+                () =>
+                    urls.some((u) => /\/calendar\/ambrosian(\/|\?|$)/.test(u)),
+                {
+                    timeout: 15000,
+                },
+            )
+            .toBe(true);
+        expect(
+            urls.some((u) => /\/calendar\/roman\/(nation|diocese)\//.test(u)),
+        ).toBe(false);
+    });
+});
+
+test.describe('liturgyOfAnyDay - renders events', () => {
+    test('the widget shows liturgical content for the default selection', async ({
+        page,
+    }) => {
+        await openPage(page);
+        const widget = page.locator('#liturgyOfAnyDay');
+        await expect
+            .poll(async () => (await widget.innerText()).trim().length, {
+                timeout: 20000,
+            })
+            .toBeGreaterThan(0);
+    });
+
+    // Deliberately selects the day input by id but the year input by role: the
+    // year input currently renders as `#year-2`, a library-generated suffix that
+    // the conversion may legitimately change. Asserting on it would make this
+    // test fail for a cosmetic reason and undermine its authority.
+    test('changing the date re-fetches and still renders content', async ({
+        page,
+    }) => {
+        await openPage(page);
+        const widget = page.locator('#liturgyOfAnyDay');
+        await expect
+            .poll(async () => (await widget.innerText()).trim().length, {
+                timeout: 20000,
+            })
+            .toBeGreaterThan(0);
+
+        const urls: string[] = [];
+        page.on('request', (r) => {
+            if (r.url().includes('/calendar')) urls.push(r.url());
+        });
+
+        // #day is <input type="number"> and #month is a <select> — verified
+        // against the running page. Do not use selectOption() on #day.
+        await page.locator('#day').fill('15');
+        await page.locator('#day').dispatchEvent('change');
+
+        await expect
+            .poll(() => urls.length, { timeout: 15000 })
+            .toBeGreaterThan(0);
+        await expect
+            .poll(async () => (await widget.innerText()).trim().length, {
+                timeout: 20000,
+            })
+            .toBeGreaterThan(0);
+    });
+});
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `yarn typecheck`
+
+Expected: clean.
+
+- [ ] **Step 4: Run the spec against the CURRENT implementation**
+
+Run: `yarn test:chromium e2e/liturgyOfAnyDay.spec.ts`
+
+Expected: all 8 tests pass (plus the `setup` project's own test, which reports separately).
+
+Do NOT use `yarn test:ci:chromium` — the docker stack already holds ports 3000 and 8000, and
+`test:ci` tries to start its own servers and fails with "port already used".
+
+**If a test fails here, the assertion is wrong, not the page.** Fix the test until it passes against
+the current code. That is the entire point of this task — do not "fix" the page.
+
+- [ ] **Step 5: Clear Playwright artifacts before committing**
+
+Playwright writes `.md` files into the gitignored `test-results/` and `playwright-report/`, and
+markdownlint's glob does not respect `.gitignore`, so the pre-commit hook will fail on them
+(see issue #447):
+
+```bash
+rm -rf test-results playwright-report
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/liturgyOfAnyDay.spec.ts
+git commit -m "test: characterize liturgyOfAnyDay.php before the DayViewer conversion
+
+Written against the hand-wired implementation so the same assertions can
+prove the conversion preserved behaviour. Includes a network-level assertion
+that the Ambrosian rite reaches the request URL -- the silent failure mode
+DayViewer exists to prevent, which no DOM assertion can detect."
+```
+
+---
+
+### Task 2: Convert to DayViewer
+
+**Files:**
+
+- Rewrite: `assets/js/liturgyOfAnyDay.js`
+- Modify: `liturgyOfAnyDay.php`
+
+**Interfaces:**
+
+- Consumes: `e2e/liturgyOfAnyDay.spec.ts` from Task 1 — must pass unchanged.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the error string to `liturgyOfAnyDay.php`**
+
+The file has no `$messages` block. Add one after the `include_once` on line 13, following the pattern
+at `usage.php:9-27`:
+
+```php
+include_once 'includes/common.php';
+
+$messages = [
+    /** translators: error shown when the liturgy page's calendar controls fail to load */
+    'Failed to load' => _('Could not load the liturgy controls. Please try again later.'),
+];
+
+?><!doctype html>
+```
+
+- [ ] **Step 2: Expose it to JavaScript**
+
+`liturgyOfAnyDay.php` has no `const Messages` script. Add one immediately before the footer include,
+mirroring `usage.php:419-421`. Find the `include_once('./layout/footer.php');` line and insert above it:
+
+```php
+    <script>
+        const Messages = <?php echo json_encode($messages, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?>;
+    </script>
+```
+
+- [ ] **Step 3: Verify the PHP renders**
+
+`liturgyOfAnyDay.php` is a top-level PHP file, bind-mounted individually in docker, so an editor that
+writes via temp+rename leaves the container serving the old inode:
+
+```bash
+docker compose up -d --force-recreate litcal-frontend
+curl -s http://localhost:3000/liturgyOfAnyDay.php | grep -c "const Messages"
+```
+
+Expected: `1`.
+
+- [ ] **Step 4: Rewrite `assets/js/liturgyOfAnyDay.js`**
+
+Replace the ENTIRE file with:
+
+```js
+/**
+ * Liturgy of Any Day - using the DayViewer meta-component.
+ *
+ * DayViewer bundles the RiteSelect, CalendarSelect, ApiOptions locale input and
+ * LiturgyOfAnyDay widget that this page previously wired by hand, including the
+ * rite's two-wire requirement: linkToRiteSelect() alone rebuilds the calendar
+ * list but does NOT turn the rite into a path segment, so a hand-wired page can
+ * read `ambrosian` while every request still goes to /calendar/roman/.
+ *
+ * The label text that used to come from a hand-rolled 12-language map now comes
+ * from the library's own Messages, which covers 83 languages.
+ */
+
+import { ApiClient, DayViewer } from '@liturgical-calendar/components-js';
+
+const initializePage = async () => {
+    const apiClient = await ApiClient.init(BaseUrl);
+
+    const viewer = await DayViewer.mountInto(
+        {
+            rite: '#riteSelectContainer',
+            calendar: '#calendarSelectContainer',
+            locale: '#localeSelectContainer',
+            liturgy: '#liturgyOfAnyDayContainer',
+        },
+        {
+            locale: currentLocale.language,
+            apiClient,
+            theme: {
+                select: 'form-select',
+                label: 'form-label',
+                liturgy: { class: 'card shadow m-2' },
+                dateControls: {
+                    labelClass: 'form-label',
+                    wrapperClass: 'col-md',
+                },
+            },
+            onError: (error) => {
+                console.error(`Liturgy of any day: ${error.message}`);
+                showToast(Messages['Failed to load'], 'danger');
+            },
+        },
+    );
+
+    // ids are not theme keys, and id() is not one-shot -- unlike label(), which
+    // the theme bag has already called on each child.
+    viewer.riteSelect.id('riteSelect');
+    viewer.calendarSelect.id('calendarSelect');
+    viewer.localeInput.id('apiOptionsLocale');
+    viewer.liturgy.id('liturgyOfAnyDay');
+};
+
+const startPage = () => {
+    initializePage().catch((error) => {
+        console.error(
+            `Could not initialize the liturgy of any day page: ${error.message}`,
+        );
+        showToast(Messages['Failed to load'], 'danger');
+    });
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startPage);
+} else {
+    startPage();
+}
+```
+
+- [ ] **Step 5: Add the new globals to ESLint**
+
+`showToast` and `Messages` are already declared in `eslint.config.mjs`. `currentLocale` and `BaseUrl`
+are too. Confirm rather than assume:
+
+```bash
+grep -E "showToast|Messages|currentLocale|BaseUrl" eslint.config.mjs
+```
+
+Expected: all four present. If any is missing, add it to the `globals` block as `"readonly"` (or
+`"writable"` for `currentLocale`, matching the existing entry).
+
+- [ ] **Step 6: Lint and type-check**
+
+Run: `yarn lint && yarn typecheck && composer lint`
+
+Expected: all clean.
+
+- [ ] **Step 7: Run the UNCHANGED characterization spec**
+
+```bash
+docker compose up -d --force-recreate litcal-frontend
+yarn test:chromium e2e/liturgyOfAnyDay.spec.ts
+```
+
+Expected: the same 8 tests pass.
+
+**Do not edit the spec to make it pass.** If a test fails, the conversion is wrong. Report the failure
+with the assertion and the actual value. The most likely genuine mismatches, and what they mean:
+
+- `#apiOptionsLocale` missing → `viewer.localeInput` is not the right getter name; check
+  `docs/meta-components.md` in the library repo for the actual getter.
+- `Label has already been set` thrown → something called `label()` after the theme bag did. Move that
+  text into the per-child `labelText` theme key.
+- The ambrosian network assertion fails → the rite is not reaching the request. This is the exact bug
+  the component is supposed to prevent; report it rather than working around it.
+
+- [ ] **Step 8: Verify the deleted translation map really is replaced**
+
+The 86-line map is gone. Prove the labels are still localized rather than falling back to English:
+
+```bash
+cat > i18n-check.tmp.mjs <<'EOF'
+import { chromium } from 'playwright';
+const b = await chromium.launch();
+const ctx = await b.newContext();
+await ctx.addCookies([{ name: 'currentLocale', value: 'it', domain: 'localhost', path: '/' }]);
+const p = await ctx.newPage();
+await p.goto('http://localhost:3000/liturgyOfAnyDay.php', { waitUntil: 'networkidle' });
+await p.waitForSelector('#riteSelect', { state: 'visible', timeout: 20000 });
+const labels = await p.$$eval('label', (ls) => ls.map((l) => l.textContent.trim()).filter(Boolean));
+console.log('labels:', labels);
+await b.close();
+EOF
+node i18n-check.tmp.mjs; rm -f i18n-check.tmp.mjs
+```
+
+Expected: Italian label text (e.g. "Rito", "Lingua"), not English. Record the actual output in your
+report. If the labels are English, the library's `Messages` is not being reached — report it.
+
+- [ ] **Step 9: Confirm the line count actually dropped**
+
+```bash
+wc -l assets/js/liturgyOfAnyDay.js
+```
+
+Expected: roughly 60 lines, down from 257. Record the real number.
+
+- [ ] **Step 10: Clear Playwright artifacts and commit**
+
+```bash
+rm -rf test-results playwright-report
+git add assets/js/liturgyOfAnyDay.js liturgyOfAnyDay.php
+git commit -m "refactor: mount liturgyOfAnyDay.php through the DayViewer meta-component
+
+Replaces 257 lines of hand-wiring with one DayViewer.mountInto() call. The
+library now owns the rite's two-wire requirement -- linkToRiteSelect() alone
+rebuilds the calendar list but does not turn the rite into a path segment --
+along with the locale-matching cascade and the label text that came from a
+hand-rolled 12-language map, against the library's 83.
+
+Mount failures now reach the user through showToast() instead of only the
+console. toastr is not loaded on this page; showToast is loaded on all pages.
+
+The characterization spec added in the previous commit passes unchanged."
+```
+
+---
+
+### Task 3: Documentation
+
+**Files:**
+
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Record the pattern**
+
+In `CLAUDE.md`, under `## Important Patterns`, immediately after the `### PHP vs JS components`
+subsection added previously, insert:
+
+```markdown
+### Meta-components
+
+liturgy-components-js 2.2.0 ships two meta-components that bundle wiring this repo used to
+re-derive by hand:
+
+- **`DayViewer`** — the whole "liturgy of any day" page. Used by `assets/js/liturgyOfAnyDay.js`.
+- **`CalendarResourcePicker`** — a `RiteSelect` plus a filtered `CalendarSelect`, for choosing a
+  national or diocesan resource id.
+
+Prefer them over hand-wiring. A `RiteSelect` needs **two** wires — `linkToRiteSelect()` AND
+`apiClient.listenTo(riteSelect)` — and wiring only the first fails silently: the form reads
+`ambrosian` while every request still goes to `/calendar/roman/`. The meta-components own that.
+
+Two call sites stay hand-wired on purpose:
+
+- `assets/js/usage.js` — `CalendarResourcePicker` rejects `CalendarSelectFilter.NONE` and makes the
+  empty option a disabled placeholder. The subscription card needs an all-calendars list and a
+  _selectable_ empty option meaning the rite-level calendar. Asked upstream as
+  liturgy-components-js#42.
+- `assets/js/index.js` — a PathBuilder/API-explorer page; neither meta-component models it.
+
+Two API notes: the theme bag's keys are HTML roles (`select`, `label`, `input`, `wrapper`) with
+per-child overrides named for the public getters; and `label()` is **one-shot**, so once the theme
+bag has themed a child, custom label text must go through the per-child `labelText` key rather than
+`viewer.<child>.label({ text })`, which throws. `id()` is not one-shot.
+```
+
+- [ ] **Step 2: Format and lint**
+
+```bash
+rm -rf test-results playwright-report
+yarn format:md && composer lint:md && yarn lint:md
+```
+
+Expected: no issues. `format:md` must touch only `CLAUDE.md`. If it reformats anything else, stop and
+report rather than committing the churn.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: record the meta-component pattern and what stays hand-wired"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run every gate**
+
+```bash
+composer parallel-lint && composer lint && composer analyse && composer test
+yarn lint && yarn typecheck && yarn test:unit
+rm -rf test-results playwright-report && composer lint:md && yarn lint:md
+yarn test:chromium e2e/liturgyOfAnyDay.spec.ts
+yarn test:chromium e2e/usage.spec.ts
+```
+
+The `usage.spec.ts` run is a regression check: both pages share `layout/footer.php`'s import map, which
+this branch already bumped to v2.2.0.
+
+- [ ] **Confirm the deliverables**
+
+- `e2e/liturgyOfAnyDay.spec.ts` is byte-identical to its Task 1 commit
+  (`git diff <task-1-sha> -- e2e/liturgyOfAnyDay.spec.ts` is empty).
+- `assets/js/liturgyOfAnyDay.js` no longer contains `translations`, `linkToRiteSelect`, or `listenTo`.
+- The four ids `riteSelect`, `calendarSelect`, `apiOptionsLocale`, `liturgyOfAnyDay` still exist in the
+  rendered page.
+- Labels render in Italian under an `it` locale cookie.
+- `usage.php` still produces rite-explicit subscription URLs.

--- a/docs/superpowers/specs/2026-08-11-dayviewer-adoption-design.md
+++ b/docs/superpowers/specs/2026-08-11-dayviewer-adoption-design.md
@@ -29,7 +29,8 @@ Three things in our file are now library responsibilities:
 1. **Convert `liturgyOfAnyDay.js` to `DayViewer.mountInto()` with a slots object.**
 2. **Write `e2e/liturgyOfAnyDay.spec.ts` FIRST**, as a characterization test against the current
    hand-wired page, then convert and prove it still passes.
-3. **Surface mount failures to the user** via `toastr`, not console-only as today.
+3. **Surface mount failures to the user** via `showToast(message, 'danger')`, not console-only as
+   today. Not `toastr` — see Error handling for why it is unavailable on this page.
 4. **`usage.js` and `index.js` stay hand-wired** (see Out of scope).
 
 ## Why the deletions are safe
@@ -45,7 +46,9 @@ Each removal is backed by a checked fact, not an assumption:
 
 ## Current configuration to preserve
 
-`liturgyOfAnyDay.php` is **not** modified — its four containers already match `DayViewer`'s slot names.
+`liturgyOfAnyDay.php`'s four containers already match `DayViewer`'s slot names, so the markup itself is
+untouched. The file gains only the `$messages` block and the `const Messages` script that Error handling
+below requires — see that section for the exact pattern.
 
 | Slot       | Container                   | Today                                                                                                               |
 | ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/docs/superpowers/specs/2026-08-11-dayviewer-adoption-design.md
+++ b/docs/superpowers/specs/2026-08-11-dayviewer-adoption-design.md
@@ -1,0 +1,130 @@
+# Adopting DayViewer on liturgyOfAnyDay.php
+
+**Date:** 2026-08-11
+**Status:** Approved, pending implementation
+
+## Problem
+
+`assets/js/liturgyOfAnyDay.js` is 257 lines that hand-wire four components — `RiteSelect`,
+`CalendarSelect`, `ApiOptions(LOCALE_ONLY)` and `LiturgyOfAnyDay` — to each other and to an
+`ApiClient`. liturgy-components-js v2.2.0 ships `DayViewer`, which bundles exactly that wiring.
+
+The library's own CHANGELOG names this file as the page the component was extracted from:
+
+> the page this was extracted from mounts its four parts into four separate containers, which a
+> single `appendTo()` target cannot express
+
+Three things in our file are now library responsibilities:
+
+1. **An 86-line `translations` map.** Written because the library's `Messages` is not exported. It
+   supplies six labels: `selectCalendar`, `selectRite`, `language`, `day`, `month`, `year`.
+2. **The rite's two-wire requirement.** `ApiOptions.linkToRiteSelect()` rebuilds the calendar list and
+   disables rite-fixed temporal options; `apiClient.listenTo(riteSelect)` is the only one of the two
+   that turns the rite into a path segment. Wiring just the first fails silently — the form reads
+   `ambrosian` while every request goes to `/calendar/roman/`. Ours is currently correct.
+3. **The locale-matching cascade** — exact match, then language-prefix, then first available.
+
+## Decisions
+
+1. **Convert `liturgyOfAnyDay.js` to `DayViewer.mountInto()` with a slots object.**
+2. **Write `e2e/liturgyOfAnyDay.spec.ts` FIRST**, as a characterization test against the current
+   hand-wired page, then convert and prove it still passes.
+3. **Surface mount failures to the user** via `toastr`, not console-only as today.
+4. **`usage.js` and `index.js` stay hand-wired** (see Out of scope).
+
+## Why the deletions are safe
+
+Each removal is backed by a checked fact, not an assumption:
+
+| Removed                                      | Replaced by                                                        | Verified                                                                                                                                                                                                                                                                  |
+| -------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 86-line `translations` map                   | The children's own localized labels                                | `DayViewer.js:109-113` deliberately omits label `text` so each child supplies its own localized label. v2.2.0 added `DAY`, `LANGUAGE` and `YEAR` to `Messages` — exactly the three of our six keys the library previously lacked. Coverage is **83 languages** vs our 12. |
+| Manual rite double-wiring                    | `DayViewer`'s internal wiring                                      | The component exists for this; the CHANGELOG calls it "the whole reason this component exists".                                                                                                                                                                           |
+| Locale-matching cascade                      | `viewer.selectedLocale`                                            | Documented in `docs/meta-components.md`.                                                                                                                                                                                                                                  |
+| `_localeInput._labelElement.textContent = …` | theme `localeInput.labelText`, or the library's `LANGUAGE` message | Reaching into a private is what the theme bag's `labelText` key exists to replace.                                                                                                                                                                                        |
+
+## Current configuration to preserve
+
+`liturgyOfAnyDay.php` is **not** modified — its four containers already match `DayViewer`'s slot names.
+
+| Slot       | Container                   | Today                                                                                                               |
+| ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `rite`     | `#riteSelectContainer`      | `.class('form-select')`, `#riteSelect`, label `form-label`                                                          |
+| `calendar` | `#calendarSelectContainer`  | `.class('form-select')`, `#calendarSelect`, label `form-label`                                                      |
+| `locale`   | `#localeSelectContainer`    | `#apiOptionsLocale`, `.class('form-select')`, label `form-label`                                                    |
+| `liturgy`  | `#liturgyOfAnyDayContainer` | `#liturgyOfAnyDay`, `.class('card shadow m-2')`, date controls `wrapperClass: 'col-md'`, `labelClass: 'form-label'` |
+
+Expressed as a theme bag:
+
+```javascript
+theme: {
+    select: 'form-select',
+    label: 'form-label',
+    liturgy: { class: 'card shadow m-2' },
+    dateControls: { labelClass: 'form-label', wrapperClass: 'col-md' },
+}
+```
+
+The four element **ids** are not theme keys, and are unaffected by the note below. They are set after
+the mount through the public getters — `viewer.riteSelect.id('riteSelect')`,
+`viewer.calendarSelect.id('calendarSelect')`, `viewer.localeInput.id('apiOptionsLocale')`,
+`viewer.liturgy.id('liturgyOfAnyDay')` — since `id()` is not one-shot.
+
+**`label()` is one-shot, and the theme bag calls it.** Once the theme bag has themed a child's label
+(which the flat `label` key above does for every child), calling
+`viewer.calendarSelect.label({ text: … })` throws `Label has already been set`. Custom label _text_
+must therefore go through the per-child `labelText` theme key instead. We intend to take the library's
+localized defaults, so this should not arise — but it is the trap to watch if a label ever needs
+overriding.
+
+## Error handling
+
+Today the page ends with `initializePage().catch(e => console.error(...))` — invisible to the user.
+
+`mountInto()` accepts `onError`, registered **before** the initial fetch, so a failure of that very
+first request still reaches it. Route it to a visible toast alongside the retained `console.error`.
+
+**Use `showToast(message, 'danger')`, not `toastr`.** An earlier draft of this spec said "toastr is
+already loaded on this page" — that is wrong. `layout/footer.php:125` loads the toastr CDN bundle only
+for `['index', 'extending', 'usage', 'missals-editor', 'admin-dashboard', 'examples']`, and
+`liturgyOfAnyDay` is not among them. What _is_ available is `window.showToast(message, type)` from
+`assets/js/toast.js`, loaded unconditionally for every page at `layout/footer.php:87`. It is also the
+direction the codebase is already moving (`docs/TOAST_MIGRATION_PROPOSAL.md`), and the idiom used by
+`developer-dashboard.js`.
+
+`liturgyOfAnyDay.php` has **no** `$messages` block today, so one must be added following the pattern at
+`usage.php:9-27` — the `$messages` array with `/** translators: */` comments, and the
+`const Messages = <?php echo json_encode(...) ?>;` script at `usage.php:420`.
+
+## Testing
+
+`e2e/liturgyOfAnyDay.spec.ts`, written **before** the conversion and unchanged by it. That ordering is
+the point: a test written against the new code proves only that the new code does what it does.
+
+The page needs no auth, so it runs in the `chromium` project. Note that project does not currently run
+in CI (issue #448) — this spec is a local and manual-dispatch guard until that lands.
+
+Coverage:
+
+- all four children render into their four containers
+- the rite select offers Roman and Ambrosian; switching to Ambrosian repartitions the calendar list
+  (no national options, the four Ambrosian dioceses present)
+- selecting a calendar and a date renders liturgical events
+- **the rite reaches the request** — the crux, and the trap `DayViewer` exists to prevent. Assert on
+  the actual network request URL (`page.on('request')` or `waitForRequest`) that choosing the Ambrosian
+  rite produces `/calendar/ambrosian/...`, not `/calendar/roman/...`. A DOM-only assertion cannot see
+  this failure mode.
+- the locale input lists locales and defaults sensibly
+- labels are localized: load with a non-English `currentLocale` cookie and assert a translated label,
+  proving the library's `Messages` genuinely replaces the deleted map
+
+## Out of scope
+
+- **`usage.js`** — `CalendarResourcePicker` rejects `CalendarSelectFilter.NONE` and makes the empty
+  option a disabled placeholder. `usage.php` needs an all-calendars list and a _selectable_ empty
+  option meaning the rite-level calendar, which shipped in #446. Asked upstream as
+  liturgy-components-js#42.
+- **`index.js`** — a PathBuilder/API-explorer page; neither meta-component models it.
+- **The three `CalendarResourcePicker` call sites** (`admin-permissions.js`, `permission-requests.js`,
+  `admin-tests.js`) — a separate PR once this one proves the pattern. Two of them are RBAC-critical and
+  covered only by the `rbac` e2e project.

--- a/e2e/liturgyOfAnyDay.spec.ts
+++ b/e2e/liturgyOfAnyDay.spec.ts
@@ -215,3 +215,53 @@ test.describe('liturgyOfAnyDay - renders events', () => {
             .not.toBe(before);
     });
 });
+
+test.describe('liturgyOfAnyDay - styling', () => {
+    // Regression guard for the post-mount `*InputConfig()` calls in
+    // assets/js/liturgyOfAnyDay.js: DayViewer shares one resolved theme object
+    // across all three date controls, so nothing in the theme bag can give
+    // `#month` (a `<select>`) a different class than `#day`/the year input
+    // (both `<input>`s). Verified live before the fix: all three rendered with
+    // `class=""`.
+    test('the date controls carry their Bootstrap classes', async ({ page }) => {
+        await openPage(page);
+        await expect(page.locator('#day')).toHaveClass(/form-control/);
+        await expect(page.locator('#month')).toHaveClass(/form-select/);
+        // The year input's id carries a library-generated suffix (`#year-2`)
+        // that is explicitly non-contractual, so it is located by position
+        // instead of by id: it is the last `type="number"` input in the widget.
+        const yearInput = page
+            .locator('#liturgyOfAnyDay input[type="number"]')
+            .last();
+        await expect(yearInput).toHaveClass(/form-control/);
+    });
+
+    test('the date header and a rendered event carry their theme classes', async ({
+        page,
+    }) => {
+        await openPage(page);
+        await expect(
+            page.locator('#liturgyOfAnyDay > .card-header'),
+        ).toHaveClass(/card-header/);
+        const eventsWrapper = page.locator('#liturgyOfAnyDay > .card-body');
+        await expect
+            .poll(() => eventsWrapper.locator('h3').count(), { timeout: 20000 })
+            .toBeGreaterThan(0);
+        await expect(
+            eventsWrapper.locator('.liturgy-event').first(),
+        ).toHaveClass(/liturgy-event/);
+    });
+});
+
+test.describe('liturgyOfAnyDay - localization', () => {
+    // The library's Messages cover 83 languages; this guards against the whole
+    // page silently falling back to English. "Giorno" was read off the live
+    // page with `currentLocale=it` set (see final-fix-report.md), not guessed.
+    test('the it locale renders localized labels', async ({ page, context }) => {
+        await context.addCookies([
+            { name: 'currentLocale', value: 'it', url: BASE },
+        ]);
+        await openPage(page);
+        await expect(page.locator('label[for="day"]')).toHaveText('Giorno');
+    });
+});

--- a/e2e/liturgyOfAnyDay.spec.ts
+++ b/e2e/liturgyOfAnyDay.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Characterization tests for liturgyOfAnyDay.php.
+ *
+ * Written against the hand-wired implementation and deliberately NOT edited when
+ * that implementation is replaced by the DayViewer meta-component, so that the
+ * same assertions prove the conversion preserved behaviour.
+ */
+
+const BASE = process.env.FRONTEND_URL || 'http://localhost:3000';
+
+/** Opens the page and waits for the client-rendered controls to exist. */
+async function openPage(page: Page): Promise<void> {
+    await page.goto(`${BASE}/liturgyOfAnyDay.php`);
+    await page.waitForSelector('#riteSelect', {
+        state: 'visible',
+        timeout: 20000,
+    });
+    await page.waitForSelector('#calendarSelect', { state: 'visible' });
+}
+
+test.describe('liturgyOfAnyDay - controls render', () => {
+    test('all four children mount into their containers', async ({ page }) => {
+        await openPage(page);
+        await expect(
+            page.locator('#riteSelectContainer #riteSelect'),
+        ).toBeVisible();
+        await expect(
+            page.locator('#calendarSelectContainer #calendarSelect'),
+        ).toBeVisible();
+        await expect(
+            page.locator('#localeSelectContainer #apiOptionsLocale'),
+        ).toBeVisible();
+        await expect(
+            page.locator('#liturgyOfAnyDayContainer #liturgyOfAnyDay'),
+        ).toBeVisible();
+    });
+
+    test('the rite select offers roman and ambrosian', async ({ page }) => {
+        await openPage(page);
+        const values = await page.$$eval('#riteSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        expect(values).toContain('roman');
+        expect(values).toContain('ambrosian');
+    });
+
+    test('the locale input is populated', async ({ page }) => {
+        await openPage(page);
+        const count = await page.locator('#apiOptionsLocale option').count();
+        expect(count).toBeGreaterThan(0);
+        const value = await page.locator('#apiOptionsLocale').inputValue();
+        expect(value).not.toBe('');
+    });
+});
+
+test.describe('liturgyOfAnyDay - rite repartitions the calendar list', () => {
+    test('ambrosian drops the national tier and offers its own dioceses', async ({
+        page,
+    }) => {
+        await openPage(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await expect
+            .poll(() =>
+                page
+                    .locator(
+                        '#calendarSelect option[data-calendartype="national"]',
+                    )
+                    .count(),
+            )
+            .toBe(0);
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        for (const diocese of [
+            'milano_it',
+            'bergam_it',
+            'novara_it',
+            'lugano_ch',
+        ]) {
+            expect(values).toContain(diocese);
+        }
+    });
+
+    test('switching back to roman restores the national tier', async ({
+        page,
+    }) => {
+        await openPage(page);
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#riteSelect', 'roman');
+        await expect
+            .poll(() =>
+                page
+                    .locator(
+                        '#calendarSelect option[data-calendartype="national"]',
+                    )
+                    .count(),
+            )
+            .toBeGreaterThan(0);
+        const values = await page.$$eval('#calendarSelect option', (os) =>
+            os.map((o) => (o as HTMLOptionElement).value),
+        );
+        expect(values).not.toContain('lugano_ch');
+    });
+});
+
+test.describe('liturgyOfAnyDay - the rite reaches the request', () => {
+    // The failure mode DayViewer exists to prevent: the form reads `ambrosian`
+    // while every request still goes to /calendar/roman/. Only a network
+    // assertion can see this — the DOM looks correct either way.
+    test('choosing the ambrosian rite produces an /calendar/ambrosian request', async ({
+        page,
+    }) => {
+        await openPage(page);
+        const urls: string[] = [];
+        page.on('request', (r) => {
+            if (r.url().includes('/calendar')) urls.push(r.url());
+        });
+
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await expect
+            .poll(
+                () =>
+                    urls.some((u) => /\/calendar\/ambrosian(\/|\?|$)/.test(u)),
+                {
+                    timeout: 15000,
+                },
+            )
+            .toBe(true);
+        expect(
+            urls.some((u) => /\/calendar\/roman\/(nation|diocese)\//.test(u)),
+        ).toBe(false);
+    });
+});
+
+test.describe('liturgyOfAnyDay - renders events', () => {
+    // Scoped to the events wrapper, not the whole `#liturgyOfAnyDay` widget: the
+    // widget's subtree also contains the date header (`#dateElement`, rendered
+    // synchronously in the constructor before any fetch) and the static
+    // "Day"/"Month"/"Year" input labels, all of which are non-empty even if the
+    // API call fails and zero events ever render. Verified against the live page
+    // (see task-1-report.md "Fix round 1"): the events wrapper is the `.card-body`
+    // div that is a direct child of `#liturgyOfAnyDay`, and each rendered event
+    // gets its own `<h3>` title -- a `<h3>` only exists here when a genuine event
+    // rendered, so asserting on it (rather than on non-empty text, which the "No
+    // liturgical events found" fallback paragraph would also satisfy) is what
+    // actually discriminates "real content rendered" from "container is present".
+    test('the widget shows liturgical content for the default selection', async ({
+        page,
+    }) => {
+        await openPage(page);
+        const eventsWrapper = page.locator('#liturgyOfAnyDay > .card-body');
+        await expect
+            .poll(() => eventsWrapper.locator('h3').count(), {
+                timeout: 20000,
+            })
+            .toBeGreaterThan(0);
+        const title = await eventsWrapper.locator('h3').first().innerText();
+        expect(title.trim().length).toBeGreaterThan(0);
+    });
+
+    // Deliberately selects the day input by id but leaves the year input alone: the
+    // year input currently renders as `#year-2`, a library-generated suffix that
+    // the conversion may legitimately change. Asserting on it would make this
+    // test fail for a cosmetic reason and undermine its authority.
+    //
+    // No network assertion here: the day/month/year controls filter the
+    // already-fetched full-year calendar data client-side (LiturgyOfAnyDay's
+    // `change` handlers call `#handleDateChange()` -> `#renderEvents()`). Only a
+    // year change, or a change that crosses the December 31st year_type boundary,
+    // triggers a new `/calendar` request. Verified directly against the running
+    // page: changing `#day` within the same year fires zero requests. Asserting
+    // `urls.length > 0` here would fail against the very implementation this test
+    // is meant to characterize, so instead this checks what actually happens on a
+    // day change -- the rendered event content updates to reflect the new date.
+    //
+    // Scoped to the events wrapper (see comment above), not the whole widget:
+    // comparing the whole widget's text would trivially differ before/after
+    // because the date header alone changes ("Tuesday, August 11" -> whatever the
+    // new date is) even if the event content underneath stayed stale.
+    //
+    // The target day is computed from the input's current value (`(current % 28)
+    // + 1`) rather than hardcoded: the day input defaults to today's actual day
+    // of month, so a hardcoded target (e.g. 15) would be a no-op -- and this test
+    // would then fail for a reason unrelated to any regression -- on whatever day
+    // of the month it happens to equal the hardcoded value.
+    test('changing the date updates the rendered content', async ({
+        page,
+    }) => {
+        await openPage(page);
+        const eventsWrapper = page.locator('#liturgyOfAnyDay > .card-body');
+        await expect
+            .poll(() => eventsWrapper.locator('h3').count(), {
+                timeout: 20000,
+            })
+            .toBeGreaterThan(0);
+        const before = await eventsWrapper.innerText();
+
+        // #day is <input type="number"> and #month is a <select> — verified
+        // against the running page. Do not use selectOption() on #day.
+        const dayLocator = page.locator('#day');
+        const currentDay = parseInt(await dayLocator.inputValue(), 10);
+        const targetDay = (currentDay % 28) + 1;
+        await dayLocator.fill(String(targetDay));
+        await dayLocator.dispatchEvent('change');
+
+        await expect
+            .poll(() => eventsWrapper.locator('h3').count(), {
+                timeout: 20000,
+            })
+            .toBeGreaterThan(0);
+        await expect
+            .poll(async () => eventsWrapper.innerText(), { timeout: 15000 })
+            .not.toBe(before);
+    });
+});

--- a/e2e/liturgyOfAnyDay.spec.ts
+++ b/e2e/liturgyOfAnyDay.spec.ts
@@ -132,6 +132,49 @@ test.describe('liturgyOfAnyDay - the rite reaches the request', () => {
             urls.some((u) => /\/calendar\/roman\/(nation|diocese)\//.test(u)),
         ).toBe(false);
     });
+
+    // The test above only reaches the rite-LEVEL calendar (`/calendar/ambrosian`).
+    // This one exercises the combination, where the rite segment and the diocese
+    // segment must both land in the right order: an Ambrosian diocese is only
+    // routable as /calendar/ambrosian/diocese/{id}, and /calendar/diocese/{id}
+    // is a 400. usage.spec.ts covers that shape for the URL *builder*; this page
+    // actually fetches it through ApiClient, which is a different code path.
+    test('an ambrosian diocese is fetched under the rite and renders events', async ({
+        page,
+    }) => {
+        await openPage(page);
+        const urls: string[] = [];
+        page.on('request', (r) => {
+            if (r.url().includes('/calendar')) urls.push(r.url());
+        });
+
+        await page.selectOption('#riteSelect', 'ambrosian');
+        await page.selectOption('#calendarSelect', 'lugano_ch');
+
+        await expect
+            .poll(
+                () =>
+                    urls.some((u) =>
+                        /\/calendar\/ambrosian\/diocese\/lugano_ch(\/|\?|$)/.test(
+                            u,
+                        ),
+                    ),
+                { timeout: 20000 },
+            )
+            .toBe(true);
+        // The rite-less spelling the API rejects with a 400.
+        expect(urls.some((u) => /\/calendar\/diocese\//.test(u))).toBe(false);
+
+        // And the fetched calendar actually rendered — a <h3> exists in the
+        // events wrapper only when a genuine event was rendered.
+        await expect
+            .poll(
+                () =>
+                    page.locator('#liturgyOfAnyDay > .card-body h3').count(),
+                { timeout: 20000 },
+            )
+            .toBeGreaterThan(0);
+    });
 });
 
 test.describe('liturgyOfAnyDay - renders events', () => {

--- a/examples.php
+++ b/examples.php
@@ -20,7 +20,7 @@ $JAVASCRIPT_EXAMPLE_CONTENTS = <<<EOT
 <script type="importmap">
     {
         "imports": {
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.1.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.2.0/+esm"
         }
     }
 </script>
@@ -73,7 +73,7 @@ $FULLCALENDAR_EXAMPLE_CONTENTS = <<<EOT
             "@fullcalendar/daygrid": "https://cdn.skypack.dev/@fullcalendar/daygrid@6.1.19",
             "@fullcalendar/list": "https://cdn.skypack.dev/@fullcalendar/list@6.1.19",
             "@fullcalendar/bootstrap5": "https://cdn.skypack.dev/@fullcalendar/bootstrap5@6.1.19",
-            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.1.0/+esm"
+            "@liturgical-calendar/components-js": "https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.2.0/+esm"
         }
     }
 </script>

--- a/layout/footer.php
+++ b/layout/footer.php
@@ -107,7 +107,7 @@ const NotificationTranslations = {
 $isDevelopment   = ( $_ENV['APP_ENV'] ?? 'production' ) === 'development';
 $componentsJsUrl = $isDevelopment
     ? './assets/components-js/index.js'
-    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.1.0/+esm';
+    : 'https://cdn.jsdelivr.net/npm/@liturgical-calendar/components-js@2.2.0/+esm';
 
 $componentsJsImportMap = <<<SCRIPT
 <script type="importmap">

--- a/liturgyOfAnyDay.php
+++ b/liturgyOfAnyDay.php
@@ -12,6 +12,11 @@
 
 include_once 'includes/common.php';
 
+$messages = [
+    /** translators: error shown when the liturgy page's calendar controls fail to load */
+    'Failed to load' => _('Could not load the liturgy controls. Please try again later.'),
+];
+
 ?><!doctype html>
 <html lang="<?php echo $i18n->LOCALE; ?>">
 <head>
@@ -36,6 +41,10 @@ include_once 'includes/common.php';
             <!-- LiturgyOfAnyDay component will be rendered here by JS -->
             <div id="liturgyOfAnyDayContainer"></div>
         </div>
+
+    <script>
+        const Messages = <?php echo json_encode($messages, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?>;
+    </script>
         <?php include_once('./layout/footer.php'); ?>
         <script nomodule defer src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
         <?php /* assets/js/liturgyOfAnyDay.js is injected by layout/footer.php, which


### PR DESCRIPTION
Takes liturgy-components-js v2.2.0 and replaces the hand-wiring on `liturgyOfAnyDay.php` with the new `DayViewer` meta-component. **257 → 113 lines**, and the page gains its first e2e coverage.

## Why

v2.2.0 ships two meta-components that exist specifically because this repo was re-deriving their wiring by hand. From the library's CHANGELOG:

> `LiturgicalCalendarFrontend` had five call sites re-deriving the same wiring by hand, each carrying a paragraph-long comment explaining a trap the library documented but could not enforce — most sharply, that a `RiteSelect` needs **two** separate wires (`linkToRiteSelect()` and `apiClient.listenTo(riteSelect)`) or the form reads `ambrosian` while every request still goes to `/calendar/roman/`.

`assets/js/liturgyOfAnyDay.js` is the page `DayViewer` was extracted from. Its four containers map 1:1 onto the component's four slots.

## What changed

**Pin → v2.2.0** in all three places: `layout/footer.php`'s production CDN import map and both maps embedded in `examples.php`. Purely additive per the CHANGELOG, and verified: between the v2.1.0 and v2.2.0 tags `ApiClient`, `CalendarSelect`, `RiteSelect`, `ApiOptions`, `PathBuilder` and `WebCalendar` are byte-identical. The only behaviour-touching change is `Utils.validateClassName()` becoming strictly more permissive, so nothing valid before can be rejected now.

**The conversion.** One `DayViewer.mountInto()` call with a slots object. The library now owns the rite's two-wire requirement, the locale-matching cascade, and label text.

Deleting the hand-rolled 12-language translation map is an **improvement, not just a wash** — the library covers 83 languages. Verified: Polish previously rendered six English labels and now localizes.

**Ten styling classes are applied post-mount**, not through the theme bag, because the library cannot currently express them. Two distinct gaps, both filed upstream:

- Seven are dropped by `Theme.resolveChildTheme()`, which forwards only `class`/`labelClass`/`labelText`/`wrapperClass`/`wrapper` — so the loop in `DayViewer`'s own constructor that reads them is unreachable code. (Liturgical-Calendar/liturgy-components-js#43)
- The three date-control classes are a *different* problem: `DayViewer` resolves that child with role `'input'` and shares one resolved object across a `<select>` and two `<input>`s, so one theme key cannot supply both `form-select` and `form-control`.

Both move into the theme bag once the library forwards them; the code says so at the call site.

**Error handling.** Mount failures now reach the user via `showToast(...)` instead of only `console.error`. Note `toastr` is *not* loaded on this page — `layout/footer.php:125` loads it for six named pages and this is not one of them — so `showToast` from `assets/js/toast.js`, which every page gets, is the correct helper.

## Testing

`e2e/liturgyOfAnyDay.spec.ts` — 11 tests where there were none.

It was deliberately **written against the old hand-wired page and frozen**, so the same assertions prove the conversion preserved behaviour rather than merely describing the new code. Its blob sha was verified unchanged (`d1ddc4f2…`) at every step across the conversion; the styling and localization guards were added afterwards, in their own commit, to keep that evidence chain intact.

That ordering paid for itself twice:

- Writing it first caught a wrong assumption in the plan — that changing the day refetches. It doesn't; the widget fetches a full year and filters client-side, refetching only on a year change or the Dec-31 boundary.
- The strongest test is network-level, asserting the Ambrosian rite reaches the request URL. That is the one failure mode no DOM assertion can see, and it is exactly what `DayViewer` exists to prevent.

Verified green: `composer parallel-lint`, `composer lint`, `composer analyse` (PHPStan L7), `composer test` (13), `yarn lint`, `yarn typecheck`, `yarn test:unit` (129), `composer lint:md`, `yarn lint:md`, and `liturgyOfAnyDay.spec.ts` + `usage.spec.ts` together (22/22).

Behavioural equivalence was also checked by rendering the old and new versions side by side against the live stack and diffing the whole rendered subtree — DOM, labels in `en` and `it`, locale options, request sequence, event classes, and the Dec-31 `year_type=LITURGICAL` edge case. That comparison found one real regression the spec passed over (the date controls had lost their Bootstrap classes); it is fixed and now guarded by a test.

## Not converted, on purpose

- **`assets/js/usage.js`** — `CalendarResourcePicker` rejects `CalendarSelectFilter.NONE` and makes the empty option a disabled placeholder. The subscription card needs an all-calendars list and a *selectable* empty option meaning the rite-level calendar, which shipped in #446. Asked upstream as Liturgical-Calendar/liturgy-components-js#42.
- **`assets/js/index.js`** — a PathBuilder/API-explorer page; neither meta-component models it.
- **The three `CalendarResourcePicker` call sites** (`admin-permissions.js`, `permission-requests.js`, `admin-tests.js`) — a separate PR once this proves the pattern. Two are RBAC-critical.

`CLAUDE.md` records all of this so the next person doesn't re-litigate it.

## Known gaps

- **`e2e/liturgyOfAnyDay.spec.ts` will not run in CI.** `e2e.yml` runs only the `rbac` project on `pull_request`/`schedule`; the `chromium` project that owns this spec is `workflow_dispatch`-only. Same limitation as `usage.spec.ts`, tracked in #448.
- **A pre-request fetch failure is now silent.** `ApiClient` rejects without emitting `calendarFetchFailed`, and `DayViewer.mountInto` suppresses its own `console.error` when `onError` is registered — so an unserviceable rite or unparseable locale produces neither a toast nor a console line. Narrow, upstream, worth adding to #43.
- The `rbac` e2e project currently fails locally with `Zitadel POST /v2/users -> 404`. **Confirmed unrelated to this branch** — nothing under `e2e/rbac/`, `auth/`, `src/`, `includes/` or `playwright.config.ts` is touched, and those tests drive Zitadel's management API with no frontend involvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the “Liturgy of Any Day” page with integrated rite, calendar, locale, and liturgy controls.
  * Added localized labels and clearer error notifications when content fails to load.
  * Preserved existing date controls, styling, and page behavior.

* **Bug Fixes**
  * Improved propagation of selected rites and dates to displayed liturgical events.

* **Tests**
  * Added end-to-end coverage for controls, localization, calendar behavior, styling, and network requests.

* **Documentation**
  * Documented component usage and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->