### PR TITLE
ci(e2e): put every chromium spec under automated CI (Zitadel auth migration + admin-tests drift)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,13 +88,13 @@ ACCURACY_TESTS_URL=http://localhost:3003
 
 ##
 # Playwright E2E Test Configuration
-# These credentials are used by e2e tests to authenticate with the API
-# They should match a valid user in your API's authentication system
+# The suite needs no credentials of its own: e2e/auth.setup.ts seeds a Zitadel
+# administrator and logs it in through the OIDC flow, using the ZITADEL_* settings
+# below. (It used to authenticate with a TEST_USERNAME/TEST_PASSWORD pair against
+# the API's legacy HS256 /auth/login — see issue #448 for why that stopped working.)
 ##
 # Path to API repository (defaults to ../LiturgicalCalendarAPI)
 # API_REPO_PATH=/path/to/LiturgicalCalendarAPI
-TEST_USERNAME=testuser
-TEST_PASSWORD=testpassword
 
 ##
 # REQUIRED — Zitadel OIDC (sign-in flow)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,8 +25,9 @@ name: E2E
 #       logs it in through the real OIDC flow; it no longer uses the API's
 #       legacy HS256 /auth/login, whose tokens auth/me.php could never accept
 #       (issue #448).
-#   chromium / firefox / webkit — the full per-browser projects, which still
-#       include admin-tests and its pre-existing failures (issue #453)
+#   chromium / firefox / webkit — the full per-browser projects. `chromium` is
+#       now the same set as chromium-ci + chromium-ci-auth combined; firefox and
+#       webkit are the cross-browser sweep, which automated runs do not cover.
 #   all — every project
 #
 # litcal-api builds from #development (the merge target); only litcal-frontend is
@@ -70,10 +71,10 @@ on:
           - rbac
           - chromium-ci
           - chromium-ci-auth
-          # The full chromium project. Still fails today: it also selects
-          # admin-tests, whose 7 failures are pre-existing and tracked in issue
-          # #453, which is why automated runs take the two subsets above
-          # instead. Dispatch this deliberately.
+          # The full chromium project — now equivalent to chromium-ci plus
+          # chromium-ci-auth, since #453 closed the last exclusion. Automated
+          # runs still take the two subsets, so a Zitadel outage cannot fail
+          # the login-free specs along with the rest.
           - chromium
           - firefox
           - webkit

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,19 +9,24 @@ name: E2E
 #     are skipped.
 #   schedule (nightly) — safety-net run on the default branch.
 #   workflow_dispatch — manual, with the `project` selector below.
-# Automated runs (pull_request / schedule) run `rbac` + `chromium-ci` — the
-# `automated` selector below. They used to run `rbac` alone, which meant the
-# whole chromium project was guarded by nothing: `inputs` is empty for a
-# schedule event, so the cron fell through the same `|| 'rbac'` default as
-# everything else. `chromium-ci` is the subset of those specs that passes
-# today; see playwright.config.ts for what is still excluded and why.
+# Automated runs (pull_request / schedule) run `rbac` + `chromium-ci` +
+# `chromium-ci-auth` — the `automated` selector below. They used to run `rbac`
+# alone, which meant the whole chromium project was guarded by nothing: `inputs`
+# is empty for a schedule event, so the cron fell through the same `|| 'rbac'`
+# default as everything else. See playwright.config.ts for what is still
+# excluded and why.
 #
 # The `project` workflow_dispatch input selects which Playwright project runs:
-#   rbac (default) — the scoped-admin-review RBAC suite (rbac-setup seeds users)
-#   chromium / firefox / webkit — the calendar-data form specs
-#       (national / diocesan / wider-region / missals; these depend on the
-#        `setup` project's /auth/login with TEST_USERNAME/TEST_PASSWORD, predate
-#        the Zitadel-based auth, and are NOT yet fixed for CI — see issue #353)
+#   automated (default) — what pull_request and schedule run
+#   rbac — the scoped-admin-review RBAC suite (rbac-setup seeds users)
+#   chromium-ci — the chromium specs needing no login (usage, liturgyOfAnyDay)
+#   chromium-ci-auth — the calendar-data form specs (national / diocesan /
+#       wider-region / missals). The `setup` project seeds a Zitadel admin and
+#       logs it in through the real OIDC flow; it no longer uses the API's
+#       legacy HS256 /auth/login, whose tokens auth/me.php could never accept
+#       (issue #448).
+#   chromium / firefox / webkit — the full per-browser projects, which still
+#       include admin-tests and its pre-existing failures (issue #453)
 #   all — every project
 #
 # litcal-api builds from #development (the merge target); only litcal-frontend is
@@ -58,15 +63,17 @@ on:
         type: choice
         default: automated
         options:
-          # What pull_request and schedule run: rbac + chromium-ci. Kept as the
-          # dispatch default too, so a manual run reproduces CI unless you ask
-          # for something else.
+          # What pull_request and schedule run: rbac + chromium-ci +
+          # chromium-ci-auth. Kept as the dispatch default too, so a manual run
+          # reproduces CI unless you ask for something else.
           - automated
           - rbac
-          # The full chromium project. Most of it fails today -- four specs are
-          # blocked on the auth migration in issue #448, and admin-tests has 7
-          # pre-existing failures -- which is why automated runs take the
-          # chromium-ci subset instead. Dispatch this deliberately.
+          - chromium-ci
+          - chromium-ci-auth
+          # The full chromium project. Still fails today: it also selects
+          # admin-tests, whose 7 failures are pre-existing and tracked in issue
+          # #453, which is why automated runs take the two subsets above
+          # instead. Dispatch this deliberately.
           - chromium
           - firefox
           - webkit
@@ -256,10 +263,11 @@ jobs:
               ;;
             automated)
               # What pull_request and schedule run. `rbac` is the long-standing
-              # suite; `chromium-ci` is the subset of the chromium specs that
-              # passes today (see playwright.config.ts for what is excluded and
-              # why). Both are needed: neither covers the other's pages.
-              yarn playwright test --project=rbac --project=chromium-ci --retries=2 --forbid-only
+              # suite; `chromium-ci` is the login-free chromium specs and
+              # `chromium-ci-auth` the calendar-data ones behind auth.setup.ts.
+              # All three are needed: none covers another's pages. See
+              # playwright.config.ts for what is still excluded and why.
+              yarn playwright test --project=rbac --project=chromium-ci --project=chromium-ci-auth --retries=2 --forbid-only
               ;;
             *)
               yarn playwright test --project="$PROJECT" --retries=2 --forbid-only

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,12 @@ name: E2E
 #     are skipped.
 #   schedule (nightly) — safety-net run on the default branch.
 #   workflow_dispatch — manual, with the `project` selector below.
-# Automated runs (pull_request / schedule) run the `rbac` project only.
+# Automated runs (pull_request / schedule) run `rbac` + `chromium-ci` — the
+# `automated` selector below. They used to run `rbac` alone, which meant the
+# whole chromium project was guarded by nothing: `inputs` is empty for a
+# schedule event, so the cron fell through the same `|| 'rbac'` default as
+# everything else. `chromium-ci` is the subset of those specs that passes
+# today; see playwright.config.ts for what is still excluded and why.
 #
 # The `project` workflow_dispatch input selects which Playwright project runs:
 #   rbac (default) — the scoped-admin-review RBAC suite (rbac-setup seeds users)
@@ -51,9 +56,17 @@ on:
       project:
         description: 'Playwright project to run'
         type: choice
-        default: rbac
+        default: automated
         options:
+          # What pull_request and schedule run: rbac + chromium-ci. Kept as the
+          # dispatch default too, so a manual run reproduces CI unless you ask
+          # for something else.
+          - automated
           - rbac
+          # The full chromium project. Most of it fails today -- four specs are
+          # blocked on the auth migration in issue #448, and admin-tests has 7
+          # pre-existing failures -- which is why automated runs take the
+          # chromium-ci subset instead. Dispatch this deliberately.
           - chromium
           - firefox
           - webkit
@@ -214,7 +227,7 @@ jobs:
 
       - name: Install dependencies + browsers
         env:
-          PROJECT: ${{ inputs.project || 'rbac' }}
+          PROJECT: ${{ inputs.project || 'automated' }}
         run: |
           corepack enable
           yarn install --immutable
@@ -222,7 +235,7 @@ jobs:
             firefox) browsers=firefox ;;
             webkit)  browsers=webkit ;;
             all)     browsers="chromium firefox webkit" ;;
-            *)       browsers=chromium ;;   # rbac, chromium
+            *)       browsers=chromium ;;   # automated, rbac, chromium, chromium-ci
           esac
           yarn playwright install --with-deps $browsers
 
@@ -234,14 +247,24 @@ jobs:
         # an empty CI would otherwise switch off.
         env:
           CI: ""
-          PROJECT: ${{ inputs.project || 'rbac' }}
+          PROJECT: ${{ inputs.project || 'automated' }}
           API_REPO_PATH: ${{ github.workspace }}/api-repo
         run: |
-          if [ "$PROJECT" = "all" ]; then
-            yarn playwright test --retries=2 --forbid-only
-          else
-            yarn playwright test --project="$PROJECT" --retries=2 --forbid-only
-          fi
+          case "$PROJECT" in
+            all)
+              yarn playwright test --retries=2 --forbid-only
+              ;;
+            automated)
+              # What pull_request and schedule run. `rbac` is the long-standing
+              # suite; `chromium-ci` is the subset of the chromium specs that
+              # passes today (see playwright.config.ts for what is excluded and
+              # why). Both are needed: neither covers the other's pages.
+              yarn playwright test --project=rbac --project=chromium-ci --retries=2 --forbid-only
+              ;;
+            *)
+              yarn playwright test --project="$PROJECT" --retries=2 --forbid-only
+              ;;
+          esac
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -68,12 +68,19 @@ Required `.env.development` keys for E2E:
 
 ```
 FRONTEND_URL=http://localhost:3000
+```
+
+The **authenticated** projects (`chromium`, `chromium-ci-auth`, `firefox`, `webkit` via
+`auth.setup.ts`; `rbac` via `rbac.setup.ts`) additionally need:
+
+```
 ZITADEL_ISSUER=…
 ZITADEL_CLIENT_ID=…
 ```
 
-`auth.setup.ts` seeds a Zitadel administrator and logs it in through the OIDC flow, so
-there are no TEST_USERNAME/TEST_PASSWORD credentials any more (issue #448).
+Their setup seeds a Zitadel user and logs it in through the OIDC flow, so there are no
+TEST_USERNAME/TEST_PASSWORD credentials any more (issue #448). `chromium-ci` declares no
+storageState and no setup dependency, so it runs without Zitadel.
 
 ## Pre-commit "everything-green" oneliner
 

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -68,9 +68,12 @@ Required `.env.development` keys for E2E:
 
 ```
 FRONTEND_URL=http://localhost:3000
-TEST_USERNAME=…
-TEST_PASSWORD=…
+ZITADEL_ISSUER=…
+ZITADEL_CLIENT_ID=…
 ```
+
+`auth.setup.ts` seeds a Zitadel administrator and logs it in through the OIDC flow, so
+there are no TEST_USERNAME/TEST_PASSWORD credentials any more (issue #448).
 
 ## Pre-commit "everything-green" oneliner
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,6 @@ API_PROTOCOL=http
 API_HOST=localhost
 API_PORT=8000
 FRONTEND_URL=http://localhost:3000
-TEST_USERNAME=testuser
-TEST_PASSWORD=testpassword
 ```
 
 ### Running the Development Server
@@ -288,9 +286,12 @@ Requires in `.env.development`:
 
 ```env
 FRONTEND_URL=http://localhost:3000
-TEST_USERNAME=your_test_username
-TEST_PASSWORD=your_test_password
 ```
+
+Plus the `ZITADEL_*` settings, which every project now depends on: `e2e/auth.setup.ts` seeds a
+Zitadel administrator and logs it in through the OIDC flow rather than using test credentials
+against the API's legacy HS256 `/auth/login`, whose tokens `auth/me.php` could never accept
+(issue #448).
 
 ### Calendar Schema Differences
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,10 +288,17 @@ Requires in `.env.development`:
 FRONTEND_URL=http://localhost:3000
 ```
 
-Plus the `ZITADEL_*` settings, which every project now depends on: `e2e/auth.setup.ts` seeds a
-Zitadel administrator and logs it in through the OIDC flow rather than using test credentials
+The **authenticated** projects additionally need the `ZITADEL_*` settings, because their setup
+seeds a Zitadel user and logs it in through the OIDC flow rather than using test credentials
 against the API's legacy HS256 `/auth/login`, whose tokens `auth/me.php` could never accept
-(issue #448).
+(issue #448):
+
+- `chromium`, `chromium-ci-auth`, `firefox`, `webkit` — via `e2e/auth.setup.ts`
+- `rbac` — via `e2e/rbac/rbac.setup.ts`
+
+`chromium-ci` needs none of them: it declares no `storageState` and no `setup` dependency, so it
+runs without Zitadel. That is deliberate — it keeps the login-free specs green even when Zitadel
+is unavailable.
 
 ### Calendar Schema Differences
 

--- a/assets/js/missals-editor.js
+++ b/assets/js/missals-editor.js
@@ -556,7 +556,10 @@ jsonFileSelect.addEventListener('change', async () => {
             const response = await fetch(jsonFileFull, {
                 method: 'GET',
                 headers: { 'Accept': 'application/json' },
-                credentials: 'include'
+                // MissalsUrl and DecreesUrl are public reads answering with
+                // Access-Control-Allow-Origin: *, which browsers refuse to pair with
+                // credentials: 'include'. The PUT below is the authenticated call.
+                credentials: 'omit'
             });
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);

--- a/auth/me.php
+++ b/auth/me.php
@@ -9,6 +9,7 @@
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
+use LiturgicalCalendar\Frontend\AuthHelper;
 use LiturgicalCalendar\Frontend\OidcClient;
 
 // Load environment
@@ -41,10 +42,47 @@ if ($accessToken === null) {
 
 // Validate access token as the primary proof of authentication
 try {
+    // Legacy (pre-Zitadel) deployments: with no OIDC configuration there is no JWKS to
+    // validate against, so fall back to the HS256/JWT_SECRET path. This mirrors
+    // AuthHelper::getInstance(), whose OIDC branch is gated on the SAME two variables and
+    // which falls through to legacy validation when they are absent.
+    //
+    // Without this the two paths disagree: drop Zitadel and AuthHelper would authenticate
+    // the user server-side and render the page, while this endpoint told the client that
+    // nobody was logged in — the client/server split diagnosed in issue #448, reached
+    // through configuration rather than through token shape.
+    //
+    // Deliberately NOT a fallback for the case where OIDC IS configured but validation
+    // fails. That would let any JWT_SECRET-signed token satisfy a live Zitadel deployment.
     if (!OidcClient::isConfigured()) {
+        $auth = AuthHelper::getInstance();
+
+        if (!$auth->isAuthenticated) {
+            jsonResponse([
+                'authenticated' => false,
+                'error'         => 'Token validation failed',
+            ]);
+        }
+
+        $legacyExp = $auth->exp ?? 0;
+
+        // Same key set as OidcClient::extractUserFromIdToken(), so assets/js/auth.js sees one
+        // shape regardless of which validation path produced it. Legacy tokens carry only
+        // `sub`, `roles` and `exp`; the OIDC-only profile claims stay null.
         jsonResponse([
-            'authenticated' => false,
-            'error'         => 'OIDC not configured',
+            'authenticated'   => true,
+            'user'            => [
+                'sub'                => $auth->sub,
+                'email'              => $auth->email,
+                'email_verified'     => $auth->emailVerified,
+                'name'               => $auth->name,
+                'given_name'         => $auth->givenName,
+                'family_name'        => $auth->familyName,
+                'preferred_username' => $auth->username,
+                'roles'              => $auth->roles ?? [],
+            ],
+            'expires_at'      => $legacyExp,
+            'token_remaining' => max(0, $legacyExp - time()),
         ]);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,8 @@
         ],
         "lint": "phpcs || ( echo 'Linting failed. Please run composer lint:fix to fix the linting issues.' && exit 1 )",
         "lint:fix": "bash scripts/lint-fix.sh",
-        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\"",
-        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" --fix",
+        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#playwright-report\" \"#test-results\"",
+        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#playwright-report\" \"#test-results\" --fix",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit tests"

--- a/docs/superpowers/specs/2026-08-13-e2e-zitadel-auth-migration-design.md
+++ b/docs/superpowers/specs/2026-08-13-e2e-zitadel-auth-migration-design.md
@@ -95,9 +95,41 @@ failure domains stay separate.
    `TEST_USERNAME` / `TEST_PASSWORD` and issue #353.
 6. Remove dead `TEST_USERNAME` / `TEST_PASSWORD` from `.env.example` and `CLAUDE.md`.
 
+## Found during implementation
+
+Fixing the auth migration made `missals-editor` reachable for the first time, and it immediately
+failed 10 of 14. Neither cause was auth; both were pre-existing bugs that #448 had been hiding,
+in the same way #453's failures hid behind `admin-tests`. Both are fixed here, because
+`missals-editor` cannot join CI otherwise.
+
+- **`assets/js/missals-editor.js`** sent `credentials: 'include'` on the data-source read. Both
+  `MissalsUrl` and `DecreesUrl` answer with `Access-Control-Allow-Origin: *`, which browsers
+  refuse to pair with credentialed requests — exactly the rule the frontend `CLAUDE.md` states.
+  The fetch never resolved, so selecting "Decrees" left the action buttons hidden and the editor
+  silently did nothing. Anywhere the frontend and API are cross-origin, that data source was
+  broken. One word; it fixed 9 of the 10 failures.
+- **`missals-editor.spec.ts:15`** asserted an unauthenticated visitor sees `#loginRequiredMessage`.
+  `missals-editor.php` redirects such a request to `index.php` before rendering anything, so that
+  markup could never be served — dead code, asserted by a test. The assertion now checks the
+  redirect and the markup is removed.
+
 ## Acceptance
 
 - `yarn test:chromium` authenticates through Zitadel with no call to the API's HS256 `/auth/login`.
 - The four migrated specs pass, including the `201`-asserting write tests.
 - `rbac` and `chromium-ci` remain green, and `rbac-setup` cannot delete the chromium identity.
 - Automated coverage rises from 54 to 106 tests.
+
+## Verified
+
+Against the local docker stack, after repairing two unrelated local-environment faults (Zitadel had
+no host port binding because NVIDIA Broadcast held `127.0.0.1:8080`; `.env`/`.env.development`
+pointed at an OpenFGA store that no longer existed).
+
+- `--project=setup` passes, including its new in-browser `Auth.isAuthenticated()` assertion.
+- `--project=chromium-ci-auth` — 52 tests, all passing (3 skipped by design).
+- `--project=chromium-ci` — 22 passing, unchanged.
+- `--project=rbac` — 32 passing, so the `seed.ts` refactor is behaviour-preserving.
+- `auth/me.php` exercised directly in both configurations: with OIDC unconfigured a valid HS256
+  token authenticates and a malformed one does not; with OIDC configured the **same** token is
+  rejected, confirming the fallback did not widen the live-deployment surface.

--- a/docs/superpowers/specs/2026-08-13-e2e-zitadel-auth-migration-design.md
+++ b/docs/superpowers/specs/2026-08-13-e2e-zitadel-auth-migration-design.md
@@ -1,0 +1,103 @@
+# E2E Auth Migration to Zitadel OIDC — Design
+
+**Date:** 2026-08-13
+**Repo:** LiturgicalCalendarFrontend
+**Branch:** `ci/automate-chromium-ci` (folded into PR #452)
+**Issue:** #448
+
+## Goal
+
+Migrate `e2e/auth.setup.ts` off the API's legacy HS256 `POST /auth/login` and onto the Zitadel OIDC
+flow already proven by the `rbac` project, so the four calendar-data specs blocked at
+`ExtendingPageHelper.waitForAuth()` pass again — and can then join the automated CI selector added by
+PR #452.
+
+Alongside it, close a latent bug in `auth/me.php` that the investigation surfaced.
+
+## Context
+
+`auth/me.php:52` validates `litcal_access_token` exclusively through `OidcClient::validateToken()`.
+`e2e/auth.setup.ts` obtains its token from the API's `POST /auth/login`, which issues an HS256 token.
+JWKS validation can never accept that shape, so `auth/me.php` returns `authenticated:false`,
+`Auth.isAuthenticated()` (a pure cache read at `assets/js/auth.js:404`) stays `false`, and
+`waitForAuth()` can only time out.
+
+The same token is accepted **server-side**, because `AuthHelper` has a legacy HS256 fallback that
+`auth/me.php` lacks. The two validation paths have drifted. Full diagnosis in issue #448.
+
+## Decisions
+
+### 1. The HS256 question: config-gated fallback only
+
+Issue #448 left open whether HS256 `POST /auth/login` is meant to remain supported. The answer turns
+on a distinction the issue did not draw — there are **two** different fallbacks behind "add HS256 to
+`auth/me.php`", and the gates make it visible:
+
+| Condition                             | `AuthHelper::getInstance()`     | `auth/me.php`                           |
+| ------------------------------------- | ------------------------------- | --------------------------------------- |
+| OIDC **not configured**               | falls through to HS256 (`:183`) | **bails** `authenticated:false` (`:44`) |
+| OIDC configured, validation **fails** | falls through to HS256          | bails `Token validation failed`         |
+
+Row one is a latent bug, independent of the tests. If Zitadel were dropped — `ZITADEL_ISSUER` /
+`ZITADEL_CLIENT_ID` unset — `AuthHelper` would authenticate users and pages would render, while
+`auth/me.php` told the client nobody is logged in. That is the #448 symptom reached through config
+rather than token shape.
+
+**Decision: implement (a), the config-gated fallback, and not (b), the validation-failure fallback.**
+
+- **(a)** When `OidcClient::isConfigured()` is false, validate via `AuthHelper`'s legacy HS256 path.
+  Mirrors `AuthHelper::getInstance():174-182`'s gate exactly. Delivers the drop-Zitadel escape hatch.
+  Loosens nothing in a Zitadel deployment.
+- **(b)** Falling back when OIDC _is_ configured but validation fails would mean any `JWT_SECRET`-signed
+  token is accepted by a live Zitadel deployment. It is also the change that would have "fixed" the
+  tests without migrating them — and since the tests migrate regardless, it buys nothing.
+
+Response shape is unchanged (`authenticated`, `user`, `roles`), so `assets/js/auth.js` needs no change.
+
+### 2. The E2E identity lives outside `USERS`
+
+`deleteAllSeededUsers()` (`e2e/rbac/support/cleanup.ts:26`) iterates **every** key of `USERS`, and
+`rbac.setup.ts` calls it. Reusing `super-admin`, or adding a new member to `USERS`, would let
+`rbac-setup` delete the chromium project's identity mid-run — precisely when both projects are
+selected, which is what the `automated` selector does.
+
+So the chromium identity is an `E2E_ADMIN` record defined **outside** `USERS`. rbac cleanup then
+structurally cannot reach it. `seedUser` / `loginAndSaveState` are split into record-taking cores plus
+the existing key-taking wrappers, giving both projects one implementation (as #448 asked) with no
+churn across the 16 rbac specs. `loginAndSaveState` gains an optional output path so the state can
+land at `e2e/.auth/user.json`, leaving every spec unchanged.
+
+### 3. No FGA tuples are needed
+
+`E2E_ADMIN` carries Zitadel role `admin` and `fga: null`.
+`OpenFgaAuthorizationMiddleware.php:140-141` in the API bypasses **all** OpenFGA checks for users
+holding the `admin` role, so the specs that assert real `201`s on `PUT` / `PATCH` authorize with zero
+tuples. This settles step 2 of #448's sketch, which flagged it as unconfirmed.
+
+### 4. CI: a second project, not an expanded `chromium-ci`
+
+The four unblocked specs cannot join `chromium-ci` without giving it `storageState` and
+`dependencies: ['setup']`, which would destroy the property PR #452 argued for: that a Zitadel failure
+cannot take it down alongside `rbac`. They also cannot use the existing `chromium` project, which
+still drags in `admin-tests` and its 7 pre-existing failures (issue #453).
+
+So a **`chromium-ci-auth`** project holds the four, with the storageState and setup dependency, and
+joins the `automated` selector alongside `rbac` + `chromium-ci`. `chromium-ci` stays auth-free; the
+failure domains stay separate.
+
+## Work
+
+1. `auth/me.php` — config-gated HS256 fallback via `AuthHelper`.
+2. `e2e/rbac/support/seed.ts` — record-taking cores + optional output path.
+3. `e2e/auth.setup.ts` — rewritten onto the headless OIDC flow with `E2E_ADMIN`.
+4. `playwright.config.ts` — add `chromium-ci-auth`.
+5. `.github/workflows/e2e.yml` — add it to `automated`; refresh the header, which still cites
+   `TEST_USERNAME` / `TEST_PASSWORD` and issue #353.
+6. Remove dead `TEST_USERNAME` / `TEST_PASSWORD` from `.env.example` and `CLAUDE.md`.
+
+## Acceptance
+
+- `yarn test:chromium` authenticates through Zitadel with no call to the API's HS256 `/auth/login`.
+- The four migrated specs pass, including the `201`-asserting write tests.
+- `rbac` and `chromium-ci` remain green, and `rbac-setup` cannot delete the chromium identity.
+- Automated coverage rises from 54 to 106 tests.

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -76,8 +76,10 @@ test.describe('admin-tests editor (stubbed)', () => {
     test('create flow submits a PUT with a schema-shaped body', async ({ page }) => {
         await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
         let putBody: Record<string, unknown> | null = null;
+        let putUrl: string | null = null;
         await page.route(TESTS_ROUTE, (r: Route) => {
             if (r.request().method() === 'PUT') {
+                putUrl = r.request().url();
                 putBody = r.request().postDataJSON() as Record<string, unknown>;
                 return r.fulfill({ json: { ...putBody } });
             }
@@ -94,6 +96,11 @@ test.describe('admin-tests editor (stubbed)', () => {
         await page.locator('#testEventKey').dispatchEvent('change');
         await page.locator('#saveTestBtn').click();
         await expect.poll(() => putBody && putBody['name']).toBe('StIgnatiusOfLoyolaTest');
+        // Pin the PATH, not just the body. TESTS_ROUTE deliberately matches both /tests
+        // and /tests/{name} so one handler can serve the collection GET as well, which
+        // means a regression back to PUT-ing the collection would otherwise still be
+        // intercepted and still pass — the very drift #453 was about.
+        expect(putUrl).toMatch(/\/tests\/StIgnatiusOfLoyolaTest$/);
         expect(putBody!['test_type']).toBe('exactCorrespondence');
         expect((putBody!['assertions'] as unknown[]).length).toBeGreaterThan(0);
         expect((putBody!['assertions'] as Array<{ assert: string }>)[0].assert).toBe('eventExists AND hasExpectedDate');
@@ -129,8 +136,9 @@ test.describe('admin-tests scope RBAC (stubbed)', () => {
     test('single-scope editor: scope is static text (no picker), PUT carries it', async ({ page }) => {
         await stubEditor(page, { is_global_admin: false, editor: [{ object_type: 'national_calendar_test', object_id: 'USA' }], admin: [] });
         let putBody: Record<string, unknown> | null = null;
+        let putUrl: string | null = null;
         await page.route(TESTS_ROUTE, (r: Route) => {
-            if (r.request().method() === 'PUT') { putBody = r.request().postDataJSON() as Record<string, unknown>; return r.fulfill({ json: {} }); }
+            if (r.request().method() === 'PUT') { putUrl = r.request().url(); putBody = r.request().postDataJSON() as Record<string, unknown>; return r.fulfill({ json: {} }); }
             return r.fulfill({ json: sampleTests });
         });
         await page.goto('/admin-tests.php');
@@ -145,6 +153,9 @@ test.describe('admin-tests scope RBAC (stubbed)', () => {
         await page.locator('#testEventKey').dispatchEvent('change');
         await page.locator('#saveTestBtn').click();
         await expect.poll(() => putBody && putBody['applies_to']).toEqual({ national_calendar: 'USA' });
+        // As above: TESTS_ROUTE matches the collection path too, so assert the write
+        // actually went to the name-scoped endpoint.
+        expect(putUrl).toMatch(/\/tests\/StIgnatiusOfLoyolaTest$/);
     });
 
     test('multi-scope editor: a select limited to the authorized scopes', async ({ page }) => {

--- a/e2e/admin-tests.spec.ts
+++ b/e2e/admin-tests.spec.ts
@@ -21,6 +21,17 @@ const sampleTests = {
 
 type TestScopes = { is_global_admin: boolean; editor: { object_type: string; object_id: string }[]; admin: { object_type: string; object_id: string }[] };
 
+/**
+ * Matches BOTH `/tests` (the collection the page GETs to fill its list) and
+ * `/tests/{name}` (what create PUTs and edit PATCHes to, admin-tests.js:822-824).
+ *
+ * A glob of `**​/tests` misses the name-scoped path, which is not a benign miss: the
+ * request escapes the stub entirely and reaches the real API, so a "stubbed" create
+ * test both asserts against a null body and can write through to real data. A glob of
+ * `**​/tests/**` has the mirror problem — it would stop matching the collection GET.
+ */
+const TESTS_ROUTE = /\/tests(?:\/[^/?#]+)?(?:[?#]|$)/;
+
 async function stub(page: Page, scopes: TestScopes): Promise<void> {
     await page.route('**/auth/test-scopes', (r: Route) => r.fulfill({ json: scopes }));
     await page.route('**/auth/me', (r: Route) => r.fulfill({ json: { authenticated: true, roles: ['test_editor'] } }));
@@ -65,7 +76,7 @@ test.describe('admin-tests editor (stubbed)', () => {
     test('create flow submits a PUT with a schema-shaped body', async ({ page }) => {
         await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
         let putBody: Record<string, unknown> | null = null;
-        await page.route('**/tests', (r: Route) => {
+        await page.route(TESTS_ROUTE, (r: Route) => {
             if (r.request().method() === 'PUT') {
                 putBody = r.request().postDataJSON() as Record<string, unknown>;
                 return r.fulfill({ json: { ...putBody } });
@@ -118,7 +129,7 @@ test.describe('admin-tests scope RBAC (stubbed)', () => {
     test('single-scope editor: scope is static text (no picker), PUT carries it', async ({ page }) => {
         await stubEditor(page, { is_global_admin: false, editor: [{ object_type: 'national_calendar_test', object_id: 'USA' }], admin: [] });
         let putBody: Record<string, unknown> | null = null;
-        await page.route('**/tests', (r: Route) => {
+        await page.route(TESTS_ROUTE, (r: Route) => {
             if (r.request().method() === 'PUT') { putBody = r.request().postDataJSON() as Record<string, unknown>; return r.fulfill({ json: {} }); }
             return r.fulfill({ json: sampleTests });
         });
@@ -192,28 +203,33 @@ test.describe('admin-tests delete (stubbed)', () => {
 
 /**
  * Shared create-modal boilerplate for the year-grid tests: stub routes as a
- * global admin, open the editor, pick the variable test type, and select an
- * event so the grid regenerates.
+ * global admin, open the editor, pick the exactCorrespondence test type, and select
+ * an event so the grid regenerates.
+ *
+ * This used to pick a `tt-variable` control. Commit 2db2eb92 merged
+ * variableCorrespondence INTO exactCorrespondence, removing that control (the page
+ * now offers only tt-exact / tt-since / tt-until), and the merged type carries the
+ * former variable behaviour — see the icon semantics asserted below.
  */
-async function openVariableEditor(page: Page, eventKey: string): Promise<void> {
+async function openExactEditor(page: Page, eventKey: string): Promise<void> {
     await stubEditor(page, { is_global_admin: true, editor: [], admin: [] });
     await page.goto('/admin-tests.php');
     await page.locator('#createTestBtn').click();
     await expect(page.locator('#testEditorModal')).toBeVisible();
     // btn-check inputs use pointer-events:none; click the label, not the input
-    await page.locator('label[for="tt-variable"]').click();
+    await page.locator('label[for="tt-exact"]').click();
     await page.locator('#testEventKey').fill(eventKey);
     await page.locator('#testEventKey').dispatchEvent('change');
 }
 
 test.describe('admin-tests year grid (stubbed)', () => {
     test('spans carry hammer/x icons and Sunday highlighting', async ({ page }) => {
-        await openVariableEditor(page, 'StIgnatiusOfLoyola');
+        await openExactEditor(page, 'StIgnatiusOfLoyola');
 
         const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
         await expect(span2005).toBeVisible();
-        // variable type → action icon present as fa-repeat ("toggle assertion",
-        // same semantic as the card toggle — spec R5); x always present;
+        // exactCorrespondence (non-pivot) → action icon is fa-repeat ("toggle
+        // assertion", same semantic as the card toggle — spec R5); x always present;
         // 2005-07-31 is a Sunday
         await expect(span2005.locator('.hammerYear')).toHaveCount(1);
         await expect(span2005.locator('.hammerYear.fa-repeat')).toHaveCount(1);
@@ -228,14 +244,22 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCSS('opacity', '0');
         await span2005.hover();
         await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCSS('opacity', '0.5');
-        // exactCorrespondence type → no action icon at all
+        // until type → the other pivot type, same hammer affordance
+        await page.locator('label[for="tt-until"]').click();
+        await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCount(1);
+        await expect(span2005.locator('.hammerYear.fa-repeat')).toHaveCount(0);
+        // back to exactCorrespondence → the non-pivot repeat icon returns, and unlike
+        // the hammer it is not hover-gated (only .fa-hammer is opacity-0 until hover).
+        // This assertion used to expect NO icon at all, which was the pre-2db2eb92
+        // behaviour: the merge gave exactCorrespondence the former variable semantics.
         await page.locator('label[for="tt-exact"]').click();
-        await expect(span2005.locator('.hammerYear')).toHaveCount(0);
+        await expect(span2005.locator('.hammerYear.fa-repeat')).toHaveCount(1);
+        await expect(span2005.locator('.hammerYear.fa-hammer')).toHaveCount(0);
         await expect(span2005.locator('.removeYear')).toHaveCount(1);
     });
 
     test('changing the base date re-anchors Sunday chips, description, and assertions', async ({ page }) => {
-        await openVariableEditor(page, 'StIgnatiusOfLoyola');
+        await openExactEditor(page, 'StIgnatiusOfLoyola');
 
         // Default base date is 07-31: 2005-07-31 is a Sunday, 2006-07-31 is not,
         // and the suggested text reads "... July 31".
@@ -268,7 +292,7 @@ test.describe('admin-tests year grid (stubbed)', () => {
         await page.goto('/admin-tests.php');
         await page.locator('#createTestBtn').click();
         await expect(page.locator('#testEditorModal')).toBeVisible();
-        await page.locator('label[for="tt-variable"]').click();
+        await page.locator('label[for="tt-exact"]').click();
         await page.locator('#testEventKey').fill('MovableFeastX');
         await page.locator('#testEventKey').dispatchEvent('change');
         const editBtn = page.locator('.assertion-card[data-year="2005"] .editDate');
@@ -278,7 +302,7 @@ test.describe('admin-tests year grid (stubbed)', () => {
     });
 
     test('toggling a per-year card assert updates the year chip styling', async ({ page }) => {
-        await openVariableEditor(page, 'StIgnatiusOfLoyola');
+        await openExactEditor(page, 'StIgnatiusOfLoyola');
         const chip2005 = page.locator('#yearGrid .testYearSpan.year-2005');
         // Exact assertion → "event expected" (no not-expected warning background).
         await expect(chip2005).not.toHaveClass(/bg-warning/);
@@ -291,7 +315,7 @@ test.describe('admin-tests year grid (stubbed)', () => {
     });
 
     test('exclude collapses to the striped bar and restore brings the card back', async ({ page }) => {
-        await openVariableEditor(page, 'StIgnatiusOfLoyola');
+        await openExactEditor(page, 'StIgnatiusOfLoyola');
 
         const span2005 = page.locator('#yearGrid .testYearSpan.year-2005');
         await expect(span2005).toBeVisible();

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,115 +1,88 @@
 import { test as setup, expect } from '@playwright/test';
 import path from 'path';
+import { seedUserRecord, loginAndSaveStateAs } from './rbac/support/seed';
+import { ZitadelAdmin } from './rbac/support/zitadel';
+import type { RbacUser } from './rbac/support/users';
 
-const authFile = path.join(__dirname, '.auth/user.json');
-
-/**
- * Response shape from /auth/login endpoint.
- * The API sets HttpOnly cookies for authentication; the response body
- * contains metadata but tokens are not exposed to JavaScript.
- */
-interface LoginResponseData {
-    message?: string;
-    expires_in?: number;
-}
-
-interface LoginSuccessResult {
-    ok: true;
-    status: number;
-    data: LoginResponseData;
-}
-
-interface LoginErrorResult {
-    ok: false;
-    status: number;
-    error: string;
-}
-
-type LoginResult = LoginSuccessResult | LoginErrorResult;
+const authFile = path.join(__dirname, '.auth', 'user.json');
 
 /**
- * Response shape from /auth/me endpoint check.
- */
-interface AuthCheckResult {
-    ok: boolean;
-    status: number;
-    error?: string;
-}
-
-/**
- * Authentication setup for Playwright tests.
+ * The single administrator identity the calendar-data specs act as.
  *
- * Uses HttpOnly cookie-based authentication:
- * - The API sets HttpOnly cookies (litcal_access_token, litcal_refresh_token) on login
- * - Cookies are automatically included in subsequent requests via credentials: 'include'
- * - Tokens are never exposed to JavaScript, eliminating XSS token theft risks
+ * Zitadel role `admin`, no FGA tuple. That is sufficient for the specs' real PUT/PATCH writes
+ * because the API's OpenFgaAuthorizationMiddleware bypasses every OpenFGA check for holders of
+ * the `admin` role, so no per-calendar scoping has to be seeded here.
  *
- * Playwright's storageState captures cookies, persisting them across test runs.
+ * DELIBERATELY NOT a member of USERS. rbac.setup.ts opens with deleteAllSeededUsers(), which
+ * iterates Object.keys(USERS) and deletes each one — so any identity in that map is destroyed
+ * at the start of an rbac run. The `automated` CI selector runs rbac alongside the chromium
+ * projects, which is exactly when that would bite. Keeping this record out of USERS makes the
+ * collision structurally impossible rather than a matter of project ordering.
  */
-setup('authenticate', async ({ page }) => {
-    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-    // Use URL class for validation and proper encoding
-    const apiUrl = new URL(`${process.env.API_PROTOCOL || 'http'}://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || '8000'}`).origin;
-    const username = process.env.TEST_USERNAME;
-    const password = process.env.TEST_PASSWORD;
+const E2E_ADMIN: RbacUser = {
+    id: 'e2e-chromium-admin',
+    email: 'e2e-chromium-admin+e2e@litcal.test',
+    password: 'E2e-Test-Passw0rd!',
+    role: 'admin',
+    fga: null,
+};
 
-    if (!username || !password) {
-        throw new Error('TEST_USERNAME and TEST_PASSWORD must be set in environment variables');
+/**
+ * Authentication setup for the calendar-data Playwright specs.
+ *
+ * Seeds a Zitadel administrator and logs it in through the real OIDC flow — session API →
+ * PKCE authorize → auth-request finalize → token exchange — then writes the resulting
+ * `litcal_access_token` / `litcal_id_token` cookies to the storageState the chromium projects
+ * declare. This is the same machinery the rbac suite uses (support/seed.ts), so there is one
+ * login implementation rather than two.
+ *
+ * It replaces a login against the API's legacy HS256 `POST /auth/login`. That endpoint's tokens
+ * could never satisfy auth/me.php, which validates through JWKS, so Auth.isAuthenticated()
+ * stayed false in the browser and every calendar-data spec timed out in waitForAuth() — even
+ * though the same token was accepted server-side by AuthHelper. See issue #448.
+ */
+setup('authenticate', async ({ browser }) => {
+    setup.setTimeout(120_000);
+
+    const z = new ZitadelAdmin();
+
+    // The session API needs IAM_LOGIN_CLIENT, which the machine token lacks. Mint a fresh,
+    // session-capable PAT for the `login-client` user and delete it when done.
+    const loginClientUserId = await z.findUserIdByUsername('login-client');
+    if (!loginClientUserId) throw new Error('auth.setup: login-client machine user not found in Zitadel');
+    const pat = await z.mintPat(loginClientUserId);
+
+    try {
+        const userId = await seedUserRecord(E2E_ADMIN);
+        await loginAndSaveStateAs(E2E_ADMIN, pat.token, userId, authFile);
+    } finally {
+        // Surface (don't swallow) a revocation failure so a leaked ephemeral token is visible,
+        // while still not masking a real error from the seeding above.
+        await z.deletePat(loginClientUserId, pat.tokenId).catch((e) =>
+            console.warn('auth.setup: failed to delete ephemeral PAT (token may persist):', String(e)),
+        );
     }
 
-    // First, navigate to the frontend to establish the browser context
-    await page.goto(`${frontendUrl}/extending.php?choice=national`);
-    await page.waitForLoadState('networkidle');
-
-    // Authenticate via fetch with credentials: 'include' to ensure HttpOnly cookies are set
-    const loginResponse: LoginResult = await page.evaluate(async (credentials) => {
-        const response = await fetch(`${credentials.apiUrl}/auth/login`, {
-            method: 'POST',
-            credentials: 'include', // Required for HttpOnly cookie authentication
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json'
-            },
-            body: JSON.stringify({
-                username: credentials.username,
-                password: credentials.password
+    // Prove the saved state actually authenticates the *browser*, which is what the specs need.
+    // Without this the setup passes on a token the client-side check rejects, and the failure
+    // resurfaces as 52 separate waitForAuth() timeouts with no indication of the real cause —
+    // precisely how #448 presented.
+    const context = await browser.newContext({ storageState: authFile });
+    try {
+        const page = await context.newPage();
+        await page.goto(`${process.env.FRONTEND_URL || 'http://localhost:3000'}/extending.php?choice=national`);
+        await expect
+            .poll(() => page.evaluate(() => {
+                // @ts-ignore - Auth is a global object
+                return typeof Auth !== 'undefined' && Auth.isAuthenticated() === true;
+            }), {
+                timeout: 15_000,
+                message: 'saved storageState did not authenticate the browser (auth/me.php rejected the token)',
             })
-        });
-
-        if (!response.ok) {
-            const text = await response.text();
-            return { ok: false, status: response.status, error: text };
-        }
-
-        const data = await response.json();
-        return { ok: true, status: response.status, data };
-    }, { apiUrl, username, password });
-
-    if (!loginResponse.ok) {
-        throw new Error(`Login failed: ${loginResponse.status} - ${loginResponse.error}`);
+            .toBe(true);
+    } finally {
+        await context.close();
     }
 
-    // Verify authentication by making a request to an authenticated endpoint
-    // This verifies that HttpOnly cookies were set correctly
-    const authCheck: AuthCheckResult = await page.evaluate(async (apiUrl) => {
-        try {
-            const response = await fetch(`${apiUrl}/auth/me`, {
-                method: 'GET',
-                credentials: 'include',
-                headers: {
-                    'Accept': 'application/json'
-                }
-            });
-            return { ok: response.ok, status: response.status };
-        } catch (e) {
-            return { ok: false, status: 0, error: String(e) };
-        }
-    }, apiUrl);
-
-    expect(authCheck.ok).toBe(true);
-
-    // Save the authentication state (includes HttpOnly cookies)
-    await page.context().storageState({ path: authFile });
-
-    console.log('Authentication setup complete - cookies saved to storageState');
+    console.log(`Authentication setup complete — ${E2E_ADMIN.email} logged in via Zitadel OIDC, state saved to ${authFile}`);
 });

--- a/e2e/missals-editor.spec.ts
+++ b/e2e/missals-editor.spec.ts
@@ -12,7 +12,7 @@ import { test, expect } from './fixtures';
  */
 
 test.describe('Missals Editor - Authentication', () => {
-    test('should show login required message when not authenticated', async ({ page }) => {
+    test('should redirect to the home page when not authenticated', async ({ page }) => {
         // Clear storage state to simulate unauthenticated user
         await page.context().clearCookies();
 
@@ -20,13 +20,14 @@ test.describe('Missals Editor - Authentication', () => {
         await page.goto(`${baseUrl}/missals-editor.php`);
         await page.waitForLoadState('networkidle');
 
-        // Login required message should be visible
-        const loginMessage = page.locator('#loginRequiredMessage');
-        await expect(loginMessage).toBeVisible();
+        // missals-editor.php guards itself server-side: an unauthenticated request never
+        // renders the editor at all, it is redirected to index.php. This used to assert a
+        // client-side #loginRequiredMessage instead, which the redirect made unreachable —
+        // the markup existed but no request could ever reach it.
+        await expect(page).toHaveURL(/\/index\.php(?:[?#]|$)/);
 
-        // Admin interface should be hidden
-        const adminInterface = page.locator('#adminInterface');
-        await expect(adminInterface).toHaveClass(/d-none/);
+        // ...and none of the editor is served.
+        await expect(page.locator('#adminInterface')).toHaveCount(0);
     });
 
     test('should show admin interface when authenticated', async ({ extendingPage, page }) => {
@@ -40,10 +41,6 @@ test.describe('Missals Editor - Authentication', () => {
         // Admin interface should be visible
         const adminInterface = page.locator('#adminInterface');
         await expect(adminInterface).not.toHaveClass(/d-none/);
-
-        // Login required message should be hidden
-        const loginMessage = page.locator('#loginRequiredMessage');
-        await expect(loginMessage).toHaveAttribute('data-requires-no-auth', '');
     });
 });
 

--- a/e2e/rbac/support/seed.ts
+++ b/e2e/rbac/support/seed.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
-import { USERS } from './users';
+import { USERS, type RbacUser } from './users';
 import { ZitadelAdmin } from './zitadel';
 import { Fga } from './fga';
 
@@ -15,8 +15,16 @@ const REDIRECT_URI = `${process.env.FRONTEND_URL || 'http://localhost:3000'}/aut
 const HOST = new URL(ISSUER).hostname;
 const b64url = (b: Buffer) => b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 
-export async function seedUser(id: string): Promise<string> {
-    const u = USERS[id];
+/**
+ * Provision a user in Zitadel: delete any account already holding the email, create a verified
+ * one, grant its project role, and — for resource-admins only — write its FGA tuple.
+ *
+ * Takes the record rather than a USERS key so an identity that is deliberately NOT a USERS
+ * member can be seeded too. That matters because rbac.setup.ts calls deleteAllSeededUsers(),
+ * which iterates Object.keys(USERS): anything in that map is deleted at the start of an rbac
+ * run. See E2E_ADMIN in e2e/auth.setup.ts, which must survive one.
+ */
+export async function seedUserRecord(u: RbacUser): Promise<string> {
     const z = new ZitadelAdmin();
     const f = new Fga();
 
@@ -34,6 +42,11 @@ export async function seedUser(id: string): Promise<string> {
         await f.write(`user:${userId}`, u.fga.relation, `${u.fga.objectType}:${u.fga.objectId}`);
     }
     return userId;
+}
+
+/** seedUserRecord() addressed by USERS key. */
+export async function seedUser(id: string): Promise<string> {
+    return seedUserRecord(USERS[id]);
 }
 
 /**
@@ -104,9 +117,17 @@ function id_state(): string { return b64url(crypto.randomBytes(8)); }
  * email-unverified (blocked from email-verified-gated pages like permission-requests.php).
  * Cookie domain is `localhost` (port-agnostic) so cookies reach both the frontend (:3000)
  * and the API (:8000). The real cookies are HttpOnly.
+ *
+ * Takes the record rather than a USERS key, and accepts an explicit output path, so a caller
+ * outside the rbac suite can drive the same flow to a different destination — e2e/auth.setup.ts
+ * writes the shared `e2e/.auth/user.json` the chromium projects declare as their storageState.
  */
-export async function loginAndSaveState(id: string, loginClientToken: string, userId?: string): Promise<void> {
-    const u = USERS[id];
+export async function loginAndSaveStateAs(
+    u: RbacUser,
+    loginClientToken: string,
+    userId?: string,
+    authPath?: string,
+): Promise<void> {
     const { accessToken, idToken } = await oidcLogin(u.email, u.password, loginClientToken, userId);
     const cookieBase = {
         domain: 'localhost', path: '/', expires: -1, httpOnly: true, secure: false, sameSite: 'Lax' as const,
@@ -117,9 +138,14 @@ export async function loginAndSaveState(id: string, loginClientToken: string, us
         cookies,
         origins: [],
     };
-    const authPath = path.join(__dirname, '..', '..', '.auth', `${id}.json`);
-    fs.mkdirSync(path.dirname(authPath), { recursive: true });
-    fs.writeFileSync(authPath, JSON.stringify(storageState, null, 2));
+    const target = authPath ?? path.join(__dirname, '..', '..', '.auth', `${u.id}.json`);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, JSON.stringify(storageState, null, 2));
+}
+
+/** loginAndSaveStateAs() addressed by USERS key, writing `e2e/.auth/{id}.json`. */
+export async function loginAndSaveState(id: string, loginClientToken: string, userId?: string): Promise<void> {
+    return loginAndSaveStateAs(USERS[id], loginClientToken, userId);
 }
 
 /**

--- a/missals-editor.php
+++ b/missals-editor.php
@@ -91,11 +91,8 @@ $buttonGroup = '<div id="memorialsFromDecreesBtnGrp">'
     <?php include_once('./layout/header.php'); ?>
     <h1><?php echo $messages['Admin heading']; ?></h1>
 
-    <!-- Login required message (shown when not authenticated) -->
-    <div class="alert alert-info" id="loginRequiredMessage" data-requires-no-auth>
-        <i class="fas fa-info-circle me-2"></i>
-        <?php echo _('Please login to access the admin interface.'); ?>
-    </div>
+    <!-- No login-required message here: the guard at the top of this file redirects
+         unauthenticated visitors to index.php, so such a message could never render. -->
 
     <!-- Admin interface (hidden until authenticated) -->
     <div id="adminInterface" class="d-none" data-requires-auth="true">

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc -p e2e/tsconfig.json --noEmit",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.yarn\" \"#**/vendor/**\" \"#.superpowers\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#.yarn\" \"#**/vendor/**\" \"#.superpowers\"",
-    "format:md": "prettier --write \"**/*.md\" \"!node_modules/**\" \"!.yarn/**\" \"!**/vendor/**\" \"!.superpowers/**\""
+    "format:md": "prettier --write \"**/*.md\" \"!node_modules/**\" \"!.yarn/**\" \"!**/vendor/**\" \"!.superpowers/**\" \"!playwright-report/**\" \"!test-results/**\""
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -69,17 +69,37 @@ export default defineConfig({
         // keeps the rest of `chromium` out of CI.
         //
         // Everything still excluded, and why — re-check before adding any of them:
-        //   diocesan-calendar, national-calendar, wider-region-calendar,
-        //   missals-editor  — call waitForAuth(); blocked on #448.
         //   admin-tests     — 7 of 17 fail for an unrelated, PRE-EXISTING reason
         //                     (verified identical on 780921d0, before any of this
-        //                     work). Needs its own diagnosis, not inclusion here.
+        //                     work). Tracked in issue #453, not fixed here.
+        // The four specs that used to sit in this list — diocesan-calendar,
+        // national-calendar, wider-region-calendar, missals-editor — were blocked
+        // on #448 and now run in `chromium-ci-auth` below.
         {
             name: 'chromium-ci',
             testMatch: /(usage|liturgyOfAnyDay)\.spec\.ts/,
             use: {
                 ...devices['Desktop Chrome'],
             },
+        },
+        // The auth-requiring counterpart to `chromium-ci`: the four calendar-data
+        // specs that issue #448 blocked, unblocked by auth.setup.ts's migration to
+        // the Zitadel OIDC flow.
+        //
+        // Kept as a SEPARATE project rather than merged into `chromium-ci`, because
+        // half of that project's value is declaring no storageState: a Zitadel
+        // outage cannot take those 22 tests down alongside `rbac`. Folding these
+        // four in would hand that property back.
+        //
+        // Not the `chromium` project either — that one also selects admin-tests.
+        {
+            name: 'chromium-ci-auth',
+            testMatch: /(diocesan-calendar|national-calendar|wider-region-calendar|missals-editor)\.spec\.ts/,
+            use: {
+                ...devices['Desktop Chrome'],
+                storageState: 'e2e/.auth/user.json',
+            },
+            dependencies: ['setup'],
         },
         {
             name: 'firefox',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,6 +56,31 @@ export default defineConfig({
             dependencies: ['setup'],
             testIgnore: /rbac\//,
         },
+        // The subset of the `chromium` specs that CI can run green TODAY, so the
+        // automated triggers guard something instead of nothing.
+        //
+        // It exists as its own project rather than a `--grep` in the workflow so
+        // that the CI-ready set is declared in one reviewable place, and adding a
+        // spec to CI is a one-line change here.
+        //
+        // Deliberately NO `storageState` and NO `dependencies: ['setup']`: every
+        // spec listed here is for a page that needs no login. That also makes this
+        // project immune to the auth breakage tracked in issue #448, which is what
+        // keeps the rest of `chromium` out of CI.
+        //
+        // Everything still excluded, and why — re-check before adding any of them:
+        //   diocesan-calendar, national-calendar, wider-region-calendar,
+        //   missals-editor  — call waitForAuth(); blocked on #448.
+        //   admin-tests     — 7 of 17 fail for an unrelated, PRE-EXISTING reason
+        //                     (verified identical on 780921d0, before any of this
+        //                     work). Needs its own diagnosis, not inclusion here.
+        {
+            name: 'chromium-ci',
+            testMatch: /(usage|liturgyOfAnyDay)\.spec\.ts/,
+            use: {
+                ...devices['Desktop Chrome'],
+            },
+        },
         {
             name: 'firefox',
             use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,13 +68,9 @@ export default defineConfig({
         // project immune to the auth breakage tracked in issue #448, which is what
         // keeps the rest of `chromium` out of CI.
         //
-        // Everything still excluded, and why — re-check before adding any of them:
-        //   admin-tests     — 7 of 17 fail for an unrelated, PRE-EXISTING reason
-        //                     (verified identical on 780921d0, before any of this
-        //                     work). Tracked in issue #453, not fixed here.
-        // The four specs that used to sit in this list — diocesan-calendar,
-        // national-calendar, wider-region-calendar, missals-editor — were blocked
-        // on #448 and now run in `chromium-ci-auth` below.
+        // Nothing is excluded from CI any more: every other chromium spec needs a
+        // login and so lives in `chromium-ci-auth` below. Keep that split intact —
+        // a spec belongs here ONLY if its page renders without authentication.
         {
             name: 'chromium-ci',
             testMatch: /(usage|liturgyOfAnyDay)\.spec\.ts/,
@@ -84,17 +80,20 @@ export default defineConfig({
         },
         // The auth-requiring counterpart to `chromium-ci`: the four calendar-data
         // specs that issue #448 blocked, unblocked by auth.setup.ts's migration to
-        // the Zitadel OIDC flow.
+        // the Zitadel OIDC flow, plus admin-tests (issue #453).
         //
         // Kept as a SEPARATE project rather than merged into `chromium-ci`, because
         // half of that project's value is declaring no storageState: a Zitadel
         // outage cannot take those 22 tests down alongside `rbac`. Folding these
-        // four in would hand that property back.
+        // in would hand that property back.
         //
-        // Not the `chromium` project either — that one also selects admin-tests.
+        // admin-tests belongs HERE, not in `chromium-ci`, even though it stubs
+        // /auth/me and /auth/test-scopes: those are client-side route interceptions
+        // and cannot reach admin-tests.php's server-side guard, which 302s an
+        // unauthenticated request to index.php before any markup renders.
         {
             name: 'chromium-ci-auth',
-            testMatch: /(diocesan-calendar|national-calendar|wider-region-calendar|missals-editor)\.spec\.ts/,
+            testMatch: /(diocesan-calendar|national-calendar|wider-region-calendar|missals-editor|admin-tests)\.spec\.ts/,
             use: {
                 ...devices['Desktop Chrome'],
                 storageState: 'e2e/.auth/user.json',


### PR DESCRIPTION
Puts the `chromium` specs under automated CI, instead of leaving them guarded by nothing.

Closes #448. Closes #453.

## The problem

`e2e.yml` resolved its project with `PROJECT: ${{ inputs.project || 'rbac' }}`. `inputs` is populated only for `workflow_dispatch`, so a `schedule` event supplied none and the nightly cron fell through that same `|| 'rbac'` default rather than acting as the broader safety net its presence implied. Verified against run `31564281535` — 32 tests, every one tagged `[rbac]`, no `[chromium]` line.

So the entire `chromium` project — **90 tests across seven spec files** — had no automated trigger at all. That included the two regression guards merged in #446 and #450, both written precisely because those pages had broken before without a test noticing.

Most of those specs could not have run anyway: 52 of them died at `waitForAuth()`, which is issue #448.

## What this does

**1. Fixes the auth split (#448).** `auth.setup.ts` logged in via the API's legacy HS256 `POST /auth/login`. Those tokens can never satisfy `auth/me.php`, which validates through JWKS — so `Auth.isAuthenticated()` stayed `false` in the browser and every calendar-data spec timed out, even though the same token was accepted *server-side* by `AuthHelper`'s legacy fallback, so the page under test rendered fine. Only the client-side check failed.

It now uses the headless session → PKCE → token-exchange flow the `rbac` suite already proves in CI, reusing `support/seed.ts` so there is one login implementation rather than two. `seedUser`/`loginAndSaveState` gained record-taking cores; the key-taking wrappers are unchanged, so no `rbac` spec moves.

The identity is `E2E_ADMIN`, **deliberately not a member of `USERS`**. `rbac.setup.ts` opens with `deleteAllSeededUsers()`, which iterates `Object.keys(USERS)` — so anything in that map is deleted at the start of an `rbac` run, and the `automated` selector runs `rbac` alongside the chromium projects, which is exactly when that would bite. Keeping the record out of `USERS` makes the collision structurally impossible rather than a matter of project ordering.

It carries the Zitadel `admin` role and no FGA tuple, which #448 flagged as unconfirmed. That is sufficient: `OpenFgaAuthorizationMiddleware` bypasses every OpenFGA check for admin-role holders, so the specs asserting real `201`s on `PUT`/`PATCH` authorize with nothing seeded per calendar.

Setup now also asserts the saved state authenticates a **real browser** before finishing. Without that, a bad token passes setup and resurfaces as 52 separate `waitForAuth` timeouts naming no cause — precisely how #448 presented.

**2. Answers #448's open design question.** The issue asked whether HS256 `/auth/login` is meant to remain supported, without noticing that "add HS256 to `auth/me.php`" names *two* different changes:

| Condition | `AuthHelper::getInstance()` | `auth/me.php` (before) |
| --------- | --------------------------- | ---------------------- |
| OIDC **not configured** | falls through to HS256 | **bails** `authenticated:false` |
| OIDC configured, validation **fails** | falls through to HS256 | bails `Token validation failed` |

Only the first row is a bug, and it is independent of the tests: with Zitadel dropped, `AuthHelper` would render pages for an authenticated user while `auth/me.php` told the client nobody was logged in — the #448 symptom reached through configuration instead of token shape. That is fixed.

The second row is deliberately **not** changed. Matching `AuthHelper` there would let any `JWT_SECRET`-signed token satisfy a live Zitadel deployment, and since the tests migrate to OIDC regardless, it buys nothing.

**3. Adds the CI projects.** `chromium-ci` (22 login-free tests) and a new `chromium-ci-auth` (68 tests needing a login), both in a new `automated` selector that runs on `pull_request` and `schedule`, and is the new `workflow_dispatch` default.

They are two projects rather than one on purpose: half of `chromium-ci`'s value is declaring no `storageState`, so a Zitadel outage cannot take those 22 tests down alongside `rbac`. Folding the auth-dependent specs in would hand that property back. The split is by whether a page renders without authentication — not by which specs happen to be green.

## Two pre-existing bugs found in the shadow of #448

Fixing auth made `missals-editor` reachable for the first time, and it immediately failed 10 of 14. Neither cause was auth — the same way #453's failures hid behind `admin-tests`. Both are fixed here, because `missals-editor` cannot join CI otherwise.

- **`assets/js/missals-editor.js`** sent `credentials: 'include'` on the data-source read. `MissalsUrl` and `DecreesUrl` answer with `Access-Control-Allow-Origin: *`, which browsers refuse to pair with credentialed requests — the rule the frontend `CLAUDE.md` states explicitly. The fetch never resolved, so selecting "Decrees" left the action buttons hidden and the editor silently did nothing. **Anywhere the frontend and API are cross-origin, that data source was broken.** One word; it fixed 9 of the 10 failures.
- **`missals-editor.spec.ts`** asserted that an unauthenticated visitor sees `#loginRequiredMessage`. `missals-editor.php` redirects such a request to `index.php` before rendering anything, so that markup could never be served — dead code, guarded by a test. The assertion now checks the redirect, and the markup is gone.

**4. Fixes `admin-tests` (#453).** 7 of its 16 tests failed, from two unrelated pieces of drift.

Five year-grid tests clicked `label[for="tt-variable"]`, a control removed by `2db2eb92` when `variableCorrespondence` was merged *into* `exactCorrespondence`. A straight rename to `tt-exact` was not sufficient: the icon test asserted `variable → fa-repeat` **and** `exact → no icon at all`, so pointing both at one control would have made it contradict itself. The merge gave `exactCorrespondence` the former *variable* semantics — `admin-tests.js:326-332` renders `fa-repeat` for it and reserves `fa-hammer` for the Since/Until pivot — so "exact has no action icon" was itself describing pre-merge behaviour. That assertion now expects the repeat icon, and the freed step covers `tt-until`, previously untested.

Two create-flow tests intercepted `**/tests` while the app PUTs to `/tests/{name}`. **This was worse than a red test: the request escaped the stub and reached the real API**, so a "stubbed" create test was neither stubbed nor testing what it claimed. A glob of `**/tests/**` would trade one bug for another — the same route serves the collection `GET /tests` that fills the list — so both go through one regex covering `/tests` and `/tests/{name}`.

It runs in `chromium-ci-auth`, **not** `chromium-ci`. The issue proposed the latter, reasoning it "needs no login", and the spec does stub `/auth/me` and `/auth/test-scopes` — but those are client-side route interceptions and cannot reach `admin-tests.php`'s server-side guard, which 302s an unauthenticated request to `index.php` before any markup renders (verified by curl). Putting it in `chromium-ci` would have made that project depend on a login it declares it does not need.

## Still excluded

Nothing. Every chromium spec now runs on automated triggers.

## Verification

Against the full local docker stack:

- `--project=setup` passes, including the new in-browser `Auth.isAuthenticated()` assertion.
- `--project=chromium-ci-auth` — **68/68** (the 52 unblocked by #448, plus admin-tests' 16).
- `--project=chromium-ci` — 22/22, unchanged.
- `--project=rbac` — 32/32, so the `seed.ts` refactor is behaviour-preserving.
- `auth/me.php` exercised directly in **both** configurations: with OIDC unconfigured a valid HS256 token authenticates and a malformed one does not; with OIDC configured the *same* token is rejected — confirming the fallback did not widen the live-deployment surface.
- `composer parallel-lint` / `lint` / `analyse`, `yarn typecheck` / `lint`, `composer lint:md` all clean.

- The exact CI command, `--project=rbac --project=chromium-ci --project=chromium-ci-auth --retries=2 --forbid-only`: **123 tests, 120 passed, 1 flaky (recovered on retry), 2 skipped, 0 failed.**

**Note on flakiness.** Earlier local runs showed a single rotating failure — a different test each time (`diocesan` 201-write, `rbac/06`, `rbac/01`, `rbac/04`), each passing when re-run in isolation. It concentrates in the Zitadel login-v2 container under sustained load; recreating that container fixed the registration specs twice. It is local and pre-existing, and CI's earlier run of this branch reported no failures and no flaky retries on a fresh stack. `--retries=2` is what absorbs it. Worth watching, since `automated` now runs ~5 minutes rather than ~3.

## Effect

Automated coverage goes from 32 tests to **123**, with no chromium spec left excluded.

Also refreshes the workflow header and dispatch options, which still described the setup project as using `TEST_USERNAME`/`TEST_PASSWORD` against `/auth/login` and cited the wrong issue (#353, closed, and actually about promoting the workflow to automated triggers). Those two variables had no other consumer and are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authentication**
  * Improved authenticated access and session handling across supported environments.
  * Updated end-to-end authentication to use the configured identity provider.

* **Bug Fixes**
  * Missals Editor now redirects unauthenticated visitors consistently instead of displaying an in-page login prompt.
  * Public Missals Editor requests no longer send unnecessary credentials.

* **Testing**
  * Expanded browser test coverage for authenticated and unauthenticated workflows.
  * Updated administration tests for current test types and API request patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->