### PR TITLE
docs(env): document the E2E keys .env.example was missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,17 @@ ZITADEL_CLIENT_ID=your-frontend-client-id
 # ZITADEL_PROJECT_ID=your-project-id
 # ZITADEL_ORG_ID=your-zitadel-org-id
 
+# Machine (service-account) PAT for Zitadel's management API. Written by
+# setup-zitadel.sh --update-env. Required by the RBAC E2E suite only — its
+# helpers create, find and delete seeded users through the management API
+# (e2e/rbac/support/zitadel.ts). The app itself never uses it.
+#
+# It goes STALE whenever Zitadel's volumes are wiped (docker compose down -v).
+# The API healthcheck does not exercise Zitadel, so litcal-api still reports
+# healthy while holding an invalid PAT; re-run with --force-secrets, then
+# recreate litcal-api, litcal-frontend and litcal-tests so they re-read .env.
+# ZITADEL_MACHINE_TOKEN=
+
 ##
 # Docker Compose Port Configuration
 # These variables control which HOST ports are exposed when using docker compose.
@@ -147,10 +158,55 @@ ZITADEL_CLIENT_ID=your-frontend-client-id
 # TESTS_PORT=3003
 # DB_PORT=5432
 # ADMINER_PORT=8088
+# MAILPIT_PORT=8025
+# OPENFGA_HTTP_PORT=8083
+# OPENFGA_GRPC_PORT=8084
+# OPENFGA_PLAYGROUND_PORT=3001
+#
+# Zitadel is the exception: its host ports (8080 for the API, 8081 for the
+# login-v2 UI) are HARDCODED in docker-compose.yml, because ZITADEL_EXTERNALPORT
+# and the OIDC issuer must agree with them. There is no env override — if
+# something else on the host already holds 8080, docker creates the container
+# WITHOUT that binding rather than failing loudly. The symptom is that every
+# host-side Zitadel call fails while `docker compose ps` looks healthy. Confirm
+# with:
+#   docker compose ps -q zitadel | xargs docker inspect \
+#     --format '{{json .NetworkSettings.Ports}}'
+# An empty "8080/tcp":[] means the port was taken: free it, then
+#   docker compose up -d --force-recreate zitadel litcal-api litcal-frontend litcal-tests
 
 # Mailpit REST API base URL (local email capture). Used by the RBAC E2E
 # registration specs to read Zitadel verification emails. Default: http://localhost:8025
 MAILPIT_API_URL=http://localhost:8025
+
+##
+# OpenFGA — fine-grained authorization store. Required by the RBAC E2E suite
+# (e2e/rbac/support/fga.ts), which writes and deletes relationship tuples to set
+# up scoped-permission scenarios. Not used by the frontend app itself.
+#
+# OPENFGA_API_URL is written by setup-zitadel.sh --update-env. The HOST port is
+# 8083 (the container listens on 8080; see OPENFGA_HTTP_PORT above) — a value
+# like 18083 is simply wrong and shows up as a connection-refused in rbac-setup.
+#
+# STORE_ID and MODEL_ID are NOT written by any script: they are generated when
+# the stack first provisions OpenFGA, so they change every time its volumes are
+# wiped. A stale pair fails as
+#   FGA write 400: {"code":"authorization_model_not_found", ...}
+# which is easy to misread as a permissions problem. Re-resolve them from the
+# running stack — this is exactly what .github/workflows/e2e.yml does:
+#
+#   store=$(curl -sS http://localhost:8083/stores \
+#     | python3 -c "import sys,json;s=json.load(sys.stdin)['stores'];print(s[0]['id'])")
+#   model=$(curl -sS "http://localhost:8083/stores/$store/authorization-models" \
+#     | python3 -c "import sys,json;m=json.load(sys.stdin)['authorization_models'];print(m[0]['id'])")
+#
+# The containers read the same pair from .env (with the in-network
+# OPENFGA_API_URL=http://openfga:8080); keep the two files in step, and recreate
+# litcal-api after changing .env, since compose only re-reads it on create.
+##
+OPENFGA_API_URL=http://localhost:8083
+# OPENFGA_STORE_ID=
+# OPENFGA_MODEL_ID=
 
 # Internal URL for server-side frontend->API calls (e.g. AuthHelper GET /auth/admin-scopes).
 # Needed in containerized/Docker deploys where API_HOST (the public host) is not reachable from

--- a/.env.example
+++ b/.env.example
@@ -165,11 +165,14 @@ ZITADEL_CLIENT_ID=your-frontend-client-id
 #
 # Zitadel is the exception: its host ports (8080 for the API, 8081 for the
 # login-v2 UI) are HARDCODED in docker-compose.yml, because ZITADEL_EXTERNALPORT
-# and the OIDC issuer must agree with them. There is no env override — if
-# something else on the host already holds 8080, docker creates the container
-# WITHOUT that binding rather than failing loudly. The symptom is that every
-# host-side Zitadel call fails while `docker compose ps` looks healthy. Confirm
-# with:
+# and the OIDC issuer must agree with them. There is no env override.
+#
+# If something else on the host already holds 8080, docker does NOT fail with
+# "port is already allocated" here — it creates and starts the container WITHOUT
+# that binding. Verified on this stack: with a listener occupying 127.0.0.1:8080,
+# `docker compose up -d --force-recreate zitadel` exits 0, `docker compose ps`
+# reports "healthy", and only the inspect below reveals the missing mapping. So
+# every host-side Zitadel call fails while the stack looks fine. Confirm with:
 #   docker compose ps -q zitadel | xargs docker inspect \
 #     --format '{{json .NetworkSettings.Ports}}'
 # An empty "8080/tcp":[] means the port was taken: free it, then
@@ -184,9 +187,11 @@ MAILPIT_API_URL=http://localhost:8025
 # (e2e/rbac/support/fga.ts), which writes and deletes relationship tuples to set
 # up scoped-permission scenarios. Not used by the frontend app itself.
 #
-# OPENFGA_API_URL is written by setup-zitadel.sh --update-env. The HOST port is
-# 8083 (the container listens on 8080; see OPENFGA_HTTP_PORT above) — a value
-# like 18083 is simply wrong and shows up as a connection-refused in rbac-setup.
+# OPENFGA_API_URL is written by setup-zitadel.sh --update-env. Its host port must
+# track OPENFGA_HTTP_PORT above (default 8083) — override that and this URL, plus
+# the snippet below, have to follow. The container itself always listens on 8080,
+# so only the host side moves. A port matching neither (18083, say) shows up only
+# as a connection-refused inside rbac-setup.
 #
 # STORE_ID and MODEL_ID are NOT written by any script: they are generated when
 # the stack first provisions OpenFGA, so they change every time its volumes are
@@ -195,9 +200,10 @@ MAILPIT_API_URL=http://localhost:8025
 # which is easy to misread as a permissions problem. Re-resolve them from the
 # running stack — this is exactly what .github/workflows/e2e.yml does:
 #
-#   store=$(curl -sS http://localhost:8083/stores \
+#   fga="http://localhost:${OPENFGA_HTTP_PORT:-8083}"
+#   store=$(curl -sS "$fga/stores" \
 #     | python3 -c "import sys,json;s=json.load(sys.stdin)['stores'];print(s[0]['id'])")
-#   model=$(curl -sS "http://localhost:8083/stores/$store/authorization-models" \
+#   model=$(curl -sS "$fga/stores/$store/authorization-models" \
 #     | python3 -c "import sys,json;m=json.load(sys.stdin)['authorization_models'];print(m[0]['id'])")
 #
 # The containers read the same pair from .env (with the in-network


### PR DESCRIPTION
Documents the four E2E settings `.env.example` never mentioned, and completes the docker-compose port list.

Follow-up to #452, where each of these cost real debugging time on a local stack.

## The gap

The RBAC E2E suite reads four settings the template says nothing about:

| Key | Read by |
| --- | --- |
| `OPENFGA_API_URL` | `e2e/rbac/support/fga.ts` |
| `OPENFGA_STORE_ID` | `e2e/rbac/support/fga.ts` |
| `OPENFGA_MODEL_ID` | `e2e/rbac/support/fga.ts` |
| `ZITADEL_MACHINE_TOKEN` | `e2e/rbac/support/zitadel.ts` |

This was an inconsistency rather than a scoping decision: `MAILPIT_API_URL` was already documented and is equally harness-only. As it stood, the suite's requirements were discoverable only by reading `.github/workflows/e2e.yml`, which resolves them at runtime.

Verified mechanically — every `process.env.*` read under `e2e/` and `playwright.config.ts` is now present in the template, except `CI`, which the runner sets.

## Why the comments are longer than the keys

Each of these fails in a way that points somewhere other than the cause, so the notes describe the failure mode rather than only the setting:

- **`OPENFGA_STORE_ID` / `OPENFGA_MODEL_ID` are written by no script.** They are regenerated whenever OpenFGA's volumes are wiped, and a stale pair fails as `{"code":"authorization_model_not_found"}` — which reads like a permissions problem, not a config-drift one. The resolve-from-the-running-stack snippet included is the one `e2e.yml` already uses, so there is one method rather than two.
- **A wrong `OPENFGA_API_URL` port** surfaces only as connection-refused inside `rbac-setup`. The host port is `8083`; the container listens on `8080`.
- **`ZITADEL_MACHINE_TOKEN` goes stale on `docker compose down -v`,** and `litcal-api` still reports **healthy** while holding an invalid PAT, because its healthcheck (`GET /calendars`) never touches Zitadel.

## Port list

Added the four missing overrides — `MAILPIT_PORT`, `OPENFGA_HTTP_PORT`, `OPENFGA_GRPC_PORT`, `OPENFGA_PLAYGROUND_PORT`. All 12 port defaults are verified to match `docker-compose.yml`.

Also records that **Zitadel is the exception with no override at all**: its host ports (`8080` API, `8081` login-v2 UI) are hardcoded because `ZITADEL_EXTERNALPORT` and the OIDC issuer must agree with them. That matters more than it sounds — when another process already holds `8080`, docker creates the container **without** that binding instead of failing, so `docker compose ps` reports healthy while every host-side Zitadel call fails. The `docker inspect` command that confirms it (`"8080/tcp":[]`) is included, along with the recreate that fixes it.

## Scope

Documentation only — no key's value or default changes, and nothing outside `.env.example` is touched. `docker-compose.override.example.yml` was checked and needs nothing: valid YAML, and all bind-mount sources still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added environment configuration guidance for Zitadel authentication and OpenFGA integration.
  * Documented placeholders for the OpenFGA API URL, store ID, and model ID.
  * Expanded Docker port guidance, including Zitadel’s fixed host-port behavior and troubleshooting steps.
  * Clarified that existing Mailpit configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->