### PR TITLE
build: make markdown lint/format exclusions config-driven

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,27 @@
+// Runner options for markdownlint-cli2. Rule configuration lives in
+// .markdownlint.yaml, which is still read — this file only controls WHICH files
+// get linted.
+//
+// It exists so the composer and yarn scripts stop each carrying their own
+// hand-maintained exclusion list. They had already drifted apart (issue #447):
+// `#vendor` vs `#**/vendor/**`, `#examples` in one and not the other, and later
+// `#playwright-report`/`#test-results` in composer only — which meant
+// `composer lint:md` reported 46 files clean while `yarn lint:md` reported 52
+// files with errors, on the same working tree.
+{
+    // Honour .gitignore. This is the substantive fix: every generated directory
+    // that accumulates markdown is already gitignored, so none of them has to be
+    // enumerated here, and a NEW one never breaks the pre-commit hook.
+    //
+    // Playwright is the recurring offender — a single run writes
+    // test-results/*/error-context.md and playwright-report/data/*.md, which used
+    // to block every commit touching markdown until they were deleted by hand.
+    "gitignore": true,
+
+    // .yarn is the one exclusion .gitignore cannot express for us: it is only
+    // PARTIALLY ignored (.gitignore has `.yarn/*` with negations re-including
+    // patches, plugins, releases, sdks and versions), so `gitignore: true` alone
+    // would leave the re-included subdirectories in scope. They hold no markdown
+    // today; this keeps it that way by intent rather than by luck.
+    "ignores": [".yarn/**"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+# Prettier reads .gitignore automatically (since 3.0 its default --ignore-path is
+# ['.gitignore', '.prettierignore']), so every generated directory is already
+# excluded — node_modules, vendor, examples, .superpowers, playwright-report and
+# test-results all live in .gitignore. Verified: an intentionally malformed
+# test-results/**.md is reported by `prettier --check` from a tracked path and
+# silently skipped from the gitignored one.
+#
+# Only what .gitignore cannot express for us belongs here.
+
+# Partially gitignored: `.gitignore` has `.yarn/*` with negations re-including
+# patches, plugins, releases, sdks and versions, so those subdirectories would
+# otherwise stay in scope. Mirrors the `ignores` entry in .markdownlint-cli2.jsonc
+# so both tools agree on the file set.
+.yarn/

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -39,7 +39,8 @@ composer test              # phpunit tests
 ## Markdown
 
 ```bash
-composer lint:md           # markdownlint-cli2 over **/*.md (excl. node_modules, vendor, examples, .yarn)
+composer lint:md           # markdownlint-cli2 over **/*.md; exclusions live in .markdownlint-cli2.jsonc
+                           # ("gitignore": true), NOT inline in the script — same for yarn lint:md
 composer lint:md:fix
 yarn format:md             # prettier — formats tables / spacing
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,14 @@ composer lint                # Check code standards (PSR-12)
 composer lint:fix            # Auto-fix code standards
 composer analyse             # PHPStan level 7
 
-# Markdown
+# Markdown (yarn lint:md / lint:md:fix are the same commands)
 composer lint:md             # Check markdown
 composer lint:md:fix         # Auto-fix markdown
 yarn format:md               # Format with prettier (aligns tables)
+# Which files get linted is config, not script arguments: .markdownlint-cli2.jsonc
+# sets "gitignore": true (rules stay in .markdownlint.yaml), and prettier reads
+# .gitignore plus .prettierignore. Do not add inline exclusion globs to the
+# composer/yarn scripts — that is how they drifted apart in issue #447.
 
 # JavaScript/TypeScript
 yarn typecheck               # Type check e2e tests

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,8 @@
         ],
         "lint": "phpcs || ( echo 'Linting failed. Please run composer lint:fix to fix the linting issues.' && exit 1 )",
         "lint:fix": "bash scripts/lint-fix.sh",
-        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#playwright-report\" \"#test-results\"",
-        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#examples\" \"#.yarn\" \"#.superpowers\" \"#playwright-report\" \"#test-results\" --fix",
+        "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\"",
+        "lint:md:fix": "npx --yes markdownlint-cli2 \"**/*.md\" --fix",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit tests"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "test:install": "playwright install --with-deps",
     "tsc": "tsc",
     "typecheck": "tsc -p e2e/tsconfig.json --noEmit",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.yarn\" \"#**/vendor/**\" \"#.superpowers\"",
-    "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#.yarn\" \"#**/vendor/**\" \"#.superpowers\"",
-    "format:md": "prettier --write \"**/*.md\" \"!node_modules/**\" \"!.yarn/**\" \"!**/vendor/**\" \"!.superpowers/**\" \"!playwright-report/**\" \"!test-results/**\""
+    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
+    "format:md": "prettier --write \"**/*.md\""
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Replaces five hand-maintained exclusion lists with two config files both toolchains read.

Closes #447.

## The divergence, reproduced

The issue predicted the lists would drift. They had — and one of the divergences was introduced by #452, which added `#playwright-report`/`#test-results` to the composer scripts only. That is precisely the half-fix #447 was filed about.

Measured on this working tree before the change, with one malformed `.md` inside gitignored `test-results/`:

| Command | Files linted | Result |
| --- | --- | --- |
| `composer lint:md` | 46 | 0 issues |
| `yarn lint:md` | 52 | **2 issues** |

Same tool, same repository, different answers. `composer lint:md` is a pre-commit hook, so the version that *does* see those files blocks every commit touching markdown until someone deletes them by hand.

## The change

- **`.markdownlint-cli2.jsonc`** — `"gitignore": true`. Every generated directory that accumulates markdown is already gitignored, so none needs enumerating, and a **new** one never breaks the hook. Playwright is the recurring offender: a single run writes `test-results/*/error-context.md` and `playwright-report/data/*.md`.
- **`.prettierignore`** — one entry, for the only thing `.gitignore` cannot express (see below).

All five scripts reduce to the bare glob. Rule configuration is untouched and still lives in `.markdownlint.yaml`.

## Two of the issue's premises were wrong

Both checked rather than assumed:

**Prettier already respects `.gitignore`.** Since 3.0 its default `--ignore-path` is `['.gitignore', '.prettierignore']`, so `format:md` was never going to rewrite Playwright's artifacts — the issue's third acceptance criterion was already satisfied. Verified by placing an identical malformed file in a tracked path and a gitignored one: flagged in the first, silently skipped in the second. Only the markdownlint half was broken, which is why `.prettierignore` is one line rather than seven.

**`.yarn` is only partially gitignored.** `.gitignore` has `.yarn/*` with negations re-including `patches`, `plugins`, `releases`, `sdks` and `versions`, so `"gitignore": true` alone would have left those in scope. It is the one exclusion both config files still name explicitly — it holds no markdown today, and this keeps it that way by intent rather than by luck.

## Verification

| Acceptance criterion | Result |
| --- | --- |
| All four commands agree on the file set | Identical `Finding:` line, 46 files each |
| Malformed `.md` in a gitignored dir does not break the pre-commit hook | **This commit was made with one present** |
| `yarn format:md` leaves gitignored artifacts untouched | byte-identical (md5 compared) |

Plus one check the issue did not ask for: that `.markdownlint.yaml` is still read alongside the new config file. It is — MD013 fires at 180, not the default 80. A config file that silently replaced the rule set would have made everything pass for the wrong reason.

## Scope

Tooling configuration only. No markdown content changes, and no rule changes — `git status` after `yarn format:md` is clean. `CLAUDE.md` and the Serena command notes are updated to say exclusions are config-driven, so the next person does not re-add inline globs and restart the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
