### PR TITLE
chore(i18n): regenerate i18n/litcal.pot

### DIFF
--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-13 11:48+0000\n"
+"POT-Creation-Date: 2026-08-14 01:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,7 +97,7 @@ msgid "Request parameters available on all %1$s paths"
 msgstr ""
 
 #. translators: part of page title - refers to the Catholic liturgical calendar
-#: index.php:65 usage.php:35 examples.php:98 liturgyOfAnyDay.php:23
+#: index.php:65 usage.php:35 examples.php:106 liturgyOfAnyDay.php:23
 #: layout/header.php:257 admin-permissions.php:77 admin-permissions.php:304
 #: admin-permissions.php:391 permission-requests.php:244
 msgid "General Roman Calendar"
@@ -173,7 +173,7 @@ msgid ""
 msgstr ""
 
 #. translators: card header for Easter calculation tool
-#: index.php:174 usage.php:297
+#: index.php:174 usage.php:302
 msgid "Calculation of the Dates of Easter"
 msgstr ""
 
@@ -312,87 +312,82 @@ msgid "Calendar subscription"
 msgstr ""
 
 #. translators: label above the iCal/ICS subscription URL
-#: usage.php:145
+#: usage.php:146
 msgid "Calendar subscription URL"
 msgstr ""
 
-#. translators: tooltip for clickable URL - instructs user to click to copy
-#: usage.php:150
-msgid "Click to copy to the clipboard!"
-msgstr ""
-
 #. translators: instruction step for calendar subscription - clicking to copy URL
-#: usage.php:186 usage.php:208 usage.php:249
+#: usage.php:191 usage.php:213 usage.php:254
 msgid "Click on the link above to copy it to the clipboard."
 msgstr ""
 
 #. translators: instruction step - %s is replaced with a link to calendar.google.com
-#: usage.php:188
+#: usage.php:193
 #, php-format
 msgid "Navigate to %s."
 msgstr ""
 
 #. translators: instruction step for Google Calendar - describes UI location
-#: usage.php:190
+#: usage.php:195
 msgid ""
 "At the bottom left corner of the screen, next to Other calendars, click on "
 "the + icon to add a new calendar, and choose <i><b>From URL</b></i>."
 msgstr ""
 
 #. translators: instruction step - pasting the copied URL
-#: usage.php:192 usage.php:212 usage.php:255
+#: usage.php:197 usage.php:217 usage.php:260
 msgid "Paste in the URL that you copied earlier."
 msgstr ""
 
 #. translators: explanation of what happens after subscribing
-#: usage.php:194 usage.php:214 usage.php:234 usage.php:261
+#: usage.php:199 usage.php:219 usage.php:239 usage.php:266
 msgid ""
 "Once subscribed, your calendar will be populated with the events from the "
 "subscription URL."
 msgstr ""
 
 #. translators: info about Google Calendar's polling frequency
-#: usage.php:196 usage.php:236
+#: usage.php:201 usage.php:241
 msgid "Google Calendar will poll the calendar URL every 8 hours."
 msgstr ""
 
 #. translators: explanation about automatic updates via subscription
-#: usage.php:198 usage.php:218 usage.php:238 usage.php:269
+#: usage.php:203 usage.php:223 usage.php:243 usage.php:274
 msgid ""
 "Since you have made a subscription, any updates in the Liturgical Calendar "
 "API will be propagated to your subscription."
 msgstr ""
 
 #. translators: explanation about yearly calendar refresh behavior
-#: usage.php:200 usage.php:220 usage.php:240 usage.php:271
+#: usage.php:205 usage.php:225 usage.php:245 usage.php:276
 msgid ""
 "You will only see events for the current year. On the first day of a new "
 "year however, new events will be created automatically for the new year."
 msgstr ""
 
 #. translators: info about cross-device availability for Google Calendar
-#: usage.php:202
+#: usage.php:207
 msgid ""
 "Once the calendar has been added from a desktop, it will become available "
 "for the same Gmail account on the Google Calendar app on a smartphone."
 msgstr ""
 
 #. translators: instruction step for iPhone - describes Settings menu path
-#: usage.php:210
+#: usage.php:215
 msgid ""
 "Go to <i><b>Phone Settings → Accounts → Add account → Other → Add Calendar</"
 "b></i>."
 msgstr ""
 
 #. translators: info about iPhone Calendar's polling frequency settings location
-#: usage.php:216
+#: usage.php:221
 msgid ""
 "The iPhone Calendar app will poll the calendar URL based on the settings at "
 "<i><b>Phone Settings → Accounts → Fetch New Data → Fetch</b></i>."
 msgstr ""
 
 #. translators: instruction for Android - %s is a link to the Google Calendar tab; prerequisite step
-#: usage.php:226
+#: usage.php:231
 #, php-format
 msgid ""
 "If you have not yet added the calendar subscription from the desktop version "
@@ -400,53 +395,53 @@ msgid ""
 msgstr ""
 
 #. translators: instruction step for Android
-#: usage.php:228
+#: usage.php:233
 msgid "Open the Google Calendar app."
 msgstr ""
 
 #. translators: instruction step for Android - describes app Settings navigation
-#: usage.php:230
+#: usage.php:235
 msgid ""
 "Go to <i><b>Settings</b></i>, then under the account which you used for the "
 "Desktop version, click on the Calendar subscription name."
 msgstr ""
 
 #. translators: instruction step for Android - enabling sync
-#: usage.php:232
+#: usage.php:237
 msgid "Make sure <i><b>Synchronization</b></i> is turned on."
 msgstr ""
 
 #. translators: note about which Outlook version was tested
-#: usage.php:247
+#: usage.php:252
 msgid "tested with Outlook 2013"
 msgstr ""
 
 #. translators: instruction step for Outlook - switching views
-#: usage.php:251
+#: usage.php:256
 msgid "At the bottom of the screen, switch from Email view to Calendar view."
 msgstr ""
 
 #. translators: instruction step for Outlook - describes ribbon menu navigation
-#: usage.php:253
+#: usage.php:258
 msgid ""
 "On the ribbon of the Home menu item, click on <i><b>Open calendar → From the "
 "internet</b></i>."
 msgstr ""
 
 #. translators: instruction step for Outlook - checkbox option for polling interval
-#: usage.php:257
+#: usage.php:262
 msgid ""
 "On the following screen, check the checkbox along the lines of \"Poll this "
 "calendar in the interval suggested by the creator\"."
 msgstr ""
 
 #. translators: info about Outlook Calendar's polling frequency
-#: usage.php:259
+#: usage.php:264
 msgid "Outlook Calendar should now poll the calendar URL once a day."
 msgstr ""
 
 #. translators: instruction for Outlook - ensuring calendar is in correct folder for internet subscription
-#: usage.php:263
+#: usage.php:268
 msgid ""
 "Make sure the Calendar is created in the Other calendars folder; if you find "
 "it under the Personal calendars folder, drag it and drop it onto the Other "
@@ -455,14 +450,14 @@ msgid ""
 msgstr ""
 
 #. translators: instruction for Outlook - how to manually refresh data
-#: usage.php:265
+#: usage.php:270
 msgid ""
 "You can manually fetch new data by clicking on <i><b>Send/receive all</b></"
 "i> (from the SEND/RECEIVE menu item)."
 msgstr ""
 
 #. translators: info about Outlook's HTML support in event descriptions
-#: usage.php:267
+#: usage.php:272
 msgid ""
 "Outlook Calendar supports a minimal amount of HTML in the event description, "
 "so the event descriptions provided by the subscription URL are a little bit "
@@ -470,81 +465,81 @@ msgid ""
 msgstr ""
 
 #. translators: accordion section header - Easter date calculation tool
-#: usage.php:286 layout/header.php:337
+#: usage.php:291 layout/header.php:337
 msgid "Dates of Easter"
 msgstr ""
 
 #. translators: subtitle after card header - describes the example UI
-#: usage.php:299
+#: usage.php:304
 msgid "Example interface"
 msgstr ""
 
 #. translators: description of Easter date calculation range - 1583 is when Gregorian calendar started
-#: usage.php:305
+#: usage.php:310
 msgid "Example display of the date of Easter from 1583 to 9999"
 msgstr ""
 
 #. translators: button text to go to Easter date calculator
-#: usage.php:309
+#: usage.php:314
 msgid "Calculate the Dates of Easter"
 msgstr ""
 
 #. translators: accordion section header - daily liturgy information and apps
-#: usage.php:322 layout/header.php:341
+#: usage.php:327 layout/header.php:341
 msgid "Liturgy of the Day"
 msgstr ""
 
 #. translators: card header - Amazon Alexa flash briefing skill
-#: usage.php:334
+#: usage.php:339
 msgid "Alexa News Brief"
 msgstr ""
 
 #. translators: description of Alexa skill - flash briefing format
-#: usage.php:340
+#: usage.php:345
 msgid "Daily news brief with the liturgy of the day, as an Amazon Alexa skill"
 msgstr ""
 
 #. translators: tooltip for USA Alexa skill - explains timezone options
-#: usage.php:345
+#: usage.php:350
 msgid ""
 "Four feeds to choose from, according to timezone within the USA. The "
 "calendar is the national liturgical calendar for the United States."
 msgstr ""
 
 #. translators: tooltip for Italy Alexa skill - single feed with national calendar
-#: usage.php:351
+#: usage.php:356
 msgid "Single feed with the national liturgical calendar for Italy."
 msgstr ""
 
 #. translators: tooltip for Rome Diocese Alexa skill - specific to Diocese of Rome
-#: usage.php:357
+#: usage.php:362
 msgid ""
 "Single feed with the liturgical calendar specific to the Diocese of Rome."
 msgstr ""
 
 #. translators: card header - Amazon Alexa conversational skill (not flash briefing)
-#: usage.php:368
+#: usage.php:373
 msgid "Alexa interactive skill"
 msgstr ""
 
 #. translators: status indicator for features not yet available
-#: usage.php:374 usage.php:388
+#: usage.php:379 usage.php:393
 msgid "In development"
 msgstr ""
 
 #. translators: card header - Google Assistant voice application
-#: usage.php:382
+#: usage.php:387
 msgid "Google Assistant app"
 msgstr ""
 
 #. translators: card header - tool to look up liturgy for any date
 #. translators: button text to go to liturgy lookup page
-#: usage.php:398 usage.php:408 liturgyOfAnyDay.php:23 liturgyOfAnyDay.php:31
+#: usage.php:403 usage.php:413 liturgyOfAnyDay.php:23 liturgyOfAnyDay.php:31
 msgid "Liturgy of any day"
 msgstr ""
 
 #. translators: example use case for the liturgy lookup tool
-#: usage.php:404
+#: usage.php:409
 msgid ""
 "For example, you can find the liturgy of the day from the day of your "
 "baptism."
@@ -598,7 +593,7 @@ msgstr ""
 msgid "Liturgical Calendar as an HTML table produced by Javascript"
 msgstr ""
 
-#: examples.php:136
+#: examples.php:144
 #, php-format
 msgid "Example '%s' not found"
 msgstr ""


### PR DESCRIPTION
Automated regeneration of `i18n/litcal.pot` from the project source files.

Generated by the [Update POTs workflow](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/actions/runs/31761037821).