### PR TITLE
fix(rbac): emit rite-qualified OpenFGA object ids

### DIFF
--- a/admin-dashboard.php
+++ b/admin-dashboard.php
@@ -136,7 +136,10 @@ if (!$hasCalendarRole) {
     <?php if (
     !$isAdmin
     && $authHelper->hasRole('test_editor')
-    && $authHelper->canViewAnyResourceOfType('national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test')
+    // `rite_calendar_test` generalises `general_roman_calendar_test` (API #785): its id is the
+    // rite itself, so `rite_calendar_test:ambrosian` is a scope only it can express. The older
+    // type stays listed because pre-migration grants still carry it.
+    && $authHelper->canViewAnyResourceOfType('national_calendar_test', 'diocesan_calendar_test', 'rite_calendar_test', 'general_roman_calendar_test')
 ) : ?>
     <hr class="my-4">
     <h4 class="mb-3 text-black" style="--bs-text-opacity: .6;">

--- a/assets/js/__tests__/adminTestsScope.test.js
+++ b/assets/js/__tests__/adminTestsScope.test.js
@@ -1,0 +1,217 @@
+/**
+ * Regression test for the bare-vs-rite-qualified id confusion fixed in
+ * fix/rite-qualified-fga-object-ids follow-up.
+ *
+ * PR #461 made deriveScope() return a rite-qualified OpenFGA object_id
+ * (`roman/USA`, `ambrosian/lugano_ch`). That id is correct as an FGA
+ * identifier, but two admin-tests.js call sites — authorizedScopeChoices()
+ * and the editor's locked-scope derivation — fed that SAME value into
+ * #testScopeId, which selectedScope() reads verbatim into
+ * `applies_to.national_calendar` / `applies_to.diocesan_calendar`. The API's
+ * LitCalTest.json schema constrains those fields to a bare calendar id
+ * (CommonDef.json#/definitions/NationalCalendarId), so a rite-qualified value
+ * there is rejected with a 422 — this is exactly the regression CI caught
+ * (e2e/admin-tests.spec.ts:130 expected "USA", got "roman/USA").
+ *
+ * These tests exercise the real module (not a reimplementation of its logic)
+ * by loading it in jsdom against a fixture that mirrors admin-tests.php,
+ * dispatching DOMContentLoaded, and reading the internals it exposes on
+ * window.__adminTests.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted() runs before module imports — admin-tests.js reads
+// window.AdminTestsConfig at DOMContentLoaded time (not at import time), but
+// bootstrap must exist before the module's top-level
+// `bootstrap.Modal.getOrCreateInstance(editorModalEl)` call, which runs
+// inside the DOMContentLoaded handler as soon as it's dispatched.
+vi.hoisted(() => {
+    globalThis.window = globalThis;
+    globalThis.bootstrap = {
+        Modal: { getOrCreateInstance: vi.fn(() => ({ show: vi.fn(), hide: vi.fn() })) },
+    };
+});
+
+// admin-tests.js imports CalendarSelect/RiteSelect/ApiClient/CalendarSelectFilter
+// from an import-map-resolved package that only exists at runtime in the
+// browser (see layout/footer.php), not as an npm dependency. vitest.config.js
+// aliases the bare specifier to a local inert stub (see
+// assets/js/__tests__/stubs/components-js.js) so the module can be loaded
+// here at all. None of the tests below exercise a code path that calls into
+// it — the fix under test lives entirely in the synchronous id-composition
+// logic, not in the CalendarSelect/RiteSelect/ApiClient wiring.
+
+/** Fixture mirroring the ids admin-tests.php renders (see that file for the source of truth). */
+const FIXTURE_HTML = `
+    <div class="row g-2 align-items-end">
+        <input type="text" class="form-control" id="filterTestName" />
+        <input type="text" class="form-control" id="filterTestScope" />
+        <button type="button" id="refreshTestsBtn">Refresh</button>
+        <button type="button" id="createTestBtn">New Test</button>
+    </div>
+    <span class="badge" id="testsCount">0</span>
+    <table><tbody id="testsTableBody"></tbody></table>
+
+    <div class="modal fade" id="testEditorModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header"><h5 id="testEditorModalLabel">Test Definition</h5></div>
+                <div class="modal-body">
+                    <div id="testEditorAlerts"></div>
+                    <form id="testEditorForm" novalidate>
+                        <select class="form-select" id="testScopeType">
+                            <option value="general_roman_calendar">General Roman Calendar</option>
+                            <option value="national_calendar">National Calendar</option>
+                            <option value="diocesan_calendar">Diocesan Calendar</option>
+                        </select>
+                        <div id="testScopeStatic" class="form-text d-none"></div>
+                        <div id="testScopeIdMount"></div>
+                        <input type="text" class="form-control" id="testEventKey" list="testEventKeyList" />
+                        <datalist id="testEventKeyList"></datalist>
+                        <small id="derivedTestName"></small>
+                        <input type="date" class="form-control" id="baseDate" />
+                        <div id="testTypeGroup">
+                            <input type="radio" name="testType" id="tt-exact" value="exactCorrespondence">
+                            <input type="radio" name="testType" id="tt-since" value="exactCorrespondenceSince">
+                            <input type="radio" name="testType" id="tt-until" value="exactCorrespondenceUntil">
+                        </div>
+                        <textarea class="form-control" id="testDescription"></textarea>
+                        <div id="yearsRangeSlider">
+                            <input type="range" id="lowerRange" min="1970" max="2050" value="1999" />
+                            <input type="range" id="upperRange" min="1970" max="2050" value="2030" />
+                        </div>
+                        <div id="yearGrid"></div>
+                        <div id="yearGridLegend"></div>
+                        <div id="assertionsContainer"></div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" id="saveTestBtn">Save</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="testCommentModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog"><div class="modal-content">
+            <div class="modal-body">
+                <input type="hidden" id="commentYear" />
+                <textarea class="form-control" id="commentText"></textarea>
+            </div>
+            <div class="modal-footer"><button type="button" id="saveCommentBtn">Save comment</button></div>
+        </div></div>
+    </div>
+
+    <div class="modal fade" id="deleteTestModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog"><div class="modal-content">
+            <div class="modal-body">
+                <div id="deleteTestAlerts"></div>
+                <p id="deleteTestConfirmText"></p>
+            </div>
+            <div class="modal-footer"><button type="button" id="confirmDeleteTestBtn">Delete</button></div>
+        </div></div>
+    </div>
+`;
+
+/**
+ * Load admin-tests.js fresh against the fixture DOM and drive it through
+ * DOMContentLoaded so its `window.__adminTests` test seam is populated.
+ * vi.resetModules() + a fresh dynamic import is required because the module
+ * wires everything inside a single `DOMContentLoaded` closure that runs (and
+ * populates window.__adminTests) only once per import.
+ */
+async function loadAdminTests() {
+    document.body.innerHTML = FIXTURE_HTML;
+    window.AdminTestsConfig = {
+        apiUrl: 'http://localhost:8000',
+        i18n: {
+            loading: 'Loading...', noTests: 'No tests found.', failedToLoad: 'Failed to load.',
+            createSuccess: 'Created.', updateSuccess: 'Updated.', deleteSuccess: 'Deleted.',
+            saving: 'Saving...', deleting: 'Deleting...', edit: 'Edit', delete: 'Delete',
+            confirmDelete: 'Delete "%s"?', generalRomanCalendar: 'General Roman Calendar',
+            nationalCalendar: 'National Calendar', diocesanCalendar: 'Diocesan Calendar',
+            requiredFields: 'Fill required fields.', denied403: 'Denied.', conflict409: 'Conflict.',
+            setYear: 'set pivot year', toggleAssertion: 'toggle', removeYear: 'remove',
+            sundayInYear: '%1$s %2$s Sunday', excludedRestore: '%s excluded', testNameLabel: 'Test name:',
+            invalidName: 'Invalid name.',
+        },
+        locale: 'en-US',
+    };
+    vi.resetModules();
+    await import('../admin-tests.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    // The DOMContentLoaded handler is synchronous up through the
+    // window.__adminTests assignments exercised below, but flush microtasks
+    // in case anything scheduled a promise continuation.
+    await Promise.resolve();
+    return window.__adminTests;
+}
+
+describe('admin-tests.js — bare vs. rite-qualified calendar ids', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('deriveScope() still returns a rite-qualified FGA object_id (unchanged PR #461 behavior)', async () => {
+        const api = await loadAdminTests();
+        expect(api.deriveScope({ rite: 'roman', national_calendar: 'USA' }))
+            .toEqual({ object_type: 'national_calendar_test', object_id: 'roman/USA' });
+        expect(api.deriveScope({ rite: 'ambrosian', diocesan_calendar: 'lugano_ch' }))
+            .toEqual({ object_type: 'diocesan_calendar_test', object_id: 'ambrosian/lugano_ch' });
+    });
+
+    it('authorizedScopeChoices() strips the rite qualifier before it can reach applies_to', async () => {
+        const api = await loadAdminTests();
+        api.state.scopes = {
+            is_global_admin: false,
+            editor: [
+                { object_type: 'national_calendar_test', object_id: 'roman/USA', relation: 'editor' },
+                { object_type: 'diocesan_calendar_test', object_id: 'ambrosian/lugano_ch', relation: 'editor' },
+            ],
+            admin: [],
+        };
+        const choices = api.authorizedScopeChoices();
+        expect(choices).toEqual(
+            expect.arrayContaining([
+                { type: 'national_calendar', id: 'USA' },
+                { type: 'diocesan_calendar', id: 'lugano_ch' },
+            ])
+        );
+        // The regression, stated directly: neither choice may carry a '/'.
+        choices.forEach((c) => expect(c.id).not.toContain('/'));
+    });
+
+    it('deriveLockedScope() (the editor "edit" path) also strips the rite qualifier', async () => {
+        const api = await loadAdminTests();
+        expect(api.deriveLockedScope({ rite: 'roman', national_calendar: 'USA' }))
+            .toEqual({ type: 'national_calendar', id: 'USA' });
+        expect(api.deriveLockedScope({ rite: 'ambrosian', diocesan_calendar: 'lugano_ch' }))
+            .toEqual({ type: 'diocesan_calendar', id: 'lugano_ch' });
+        // No calendar named → rite-level scope, already bare (the rite itself).
+        expect(api.deriveLockedScope({ rite: 'ambrosian' }))
+            .toEqual({ type: 'general_roman_calendar', id: 'ambrosian' });
+    });
+
+    it('selectedScope() round-trips a bare id from #testScopeId straight into applies_to', async () => {
+        const api = await loadAdminTests();
+        document.getElementById('testScopeType').value = 'national_calendar';
+        const hid = document.createElement('input');
+        hid.id = 'testScopeId';
+        hid.value = 'USA';
+        document.getElementById('testScopeIdMount').appendChild(hid);
+
+        expect(api.selectedScope()).toEqual({ national_calendar: 'USA' });
+    });
+
+    it('selectedScope() for a diocesan scope emits applies_to.diocesan_calendar bare', async () => {
+        const api = await loadAdminTests();
+        document.getElementById('testScopeType').value = 'diocesan_calendar';
+        const hid = document.createElement('input');
+        hid.id = 'testScopeId';
+        hid.value = 'lugano_ch';
+        document.getElementById('testScopeIdMount').appendChild(hid);
+
+        expect(api.selectedScope()).toEqual({ diocesan_calendar: 'lugano_ch' });
+    });
+});

--- a/assets/js/__tests__/adminTestsScope.test.js
+++ b/assets/js/__tests__/adminTestsScope.test.js
@@ -182,6 +182,40 @@ describe('admin-tests.js — bare vs. rite-qualified calendar ids', () => {
         choices.forEach((c) => expect(c.id).not.toContain('/'));
     });
 
+    it('authorizedScopeChoices() collapses a legacy bare grant and its migrated twin into one choice', async () => {
+        // The API's tuple migration is copy-then-prune, so during the migration
+        // window BOTH forms of the same grant exist in the store. Deduping on the
+        // raw object_id would key them separately and offer the user the same
+        // calendar twice, with two identical "USA" labels and no way to tell them
+        // apart. Dedupe must therefore run on the normalized id.
+        const api = await loadAdminTests();
+        api.state.scopes = {
+            is_global_admin: false,
+            editor: [
+                { object_type: 'national_calendar_test', object_id: 'USA', relation: 'editor' },
+                { object_type: 'national_calendar_test', object_id: 'roman/USA', relation: 'editor' },
+            ],
+            admin: [],
+        };
+        const choices = api.authorizedScopeChoices();
+        expect(choices).toEqual([{ type: 'national_calendar', id: 'USA' }]);
+    });
+
+    it('authorizedScopeChoices() keeps distinct calendars that share a bare id across types', async () => {
+        // Guard against over-collapsing: normalizing the id must not merge two
+        // genuinely different scopes that happen to share a bare id.
+        const api = await loadAdminTests();
+        api.state.scopes = {
+            is_global_admin: false,
+            editor: [
+                { object_type: 'national_calendar_test', object_id: 'roman/US', relation: 'editor' },
+                { object_type: 'diocesan_calendar_test', object_id: 'roman/US', relation: 'editor' },
+            ],
+            admin: [],
+        };
+        expect(api.authorizedScopeChoices()).toHaveLength(2);
+    });
+
     it('deriveLockedScope() (the editor "edit" path) also strips the rite qualifier', async () => {
         const api = await loadAdminTests();
         expect(api.deriveLockedScope({ rite: 'roman', national_calendar: 'USA' }))

--- a/assets/js/__tests__/riteScopedObjectId.test.js
+++ b/assets/js/__tests__/riteScopedObjectId.test.js
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+    AMBROSIAN_RITE,
+    ROMAN_RITE,
+    bareCalendarId,
+    isRiteQualifiedObjectType,
+    parseRiteQualifiedId,
+    qualifyObjectId,
+    riteForObjectType,
+    sameObjectId,
+    splitObjectId,
+} from '../riteScopedObjectId.js';
+
+/**
+ * These assertions are the frontend half of a contract owned by the API:
+ * `RiteScopedObjectId` and `AccessRequestRepository::isValidObjectIdForType()`
+ * (LiturgicalCalendarAPI #785 / #786 / #788). Every expected string below is the
+ * exact id that validator accepts — a wrong one here is a 403 or a 422 in
+ * production, or worse, a grant on a resource the user did not name.
+ */
+
+describe('isRiteQualifiedObjectType', () => {
+    it.each([
+        'national_calendar',
+        'diocesan_calendar',
+        'wider_region',
+        'national_calendar_test',
+        'diocesan_calendar_test',
+    ])('%s names a calendar and is qualified', (type) => {
+        expect(isRiteQualifiedObjectType(type)).toBe(true);
+    });
+
+    it.each([
+        // Not calendars: temporale, decrees, missal editions — Roman by construction.
+        'general_roman_calendar',
+        'general_roman_calendar_test',
+        // The exception that proves the rule: its id IS the rite.
+        'rite_calendar_test',
+        'something_else',
+    ])('%s keeps a bare id', (type) => {
+        expect(isRiteQualifiedObjectType(type)).toBe(false);
+    });
+});
+
+describe('qualifyObjectId', () => {
+    it('qualifies a national calendar as roman', () => {
+        expect(qualifyObjectId('national_calendar', 'US')).toBe('roman/US');
+        expect(qualifyObjectId('national_calendar', 'IT')).toBe('roman/IT');
+    });
+
+    it('qualifies a wider region as roman', () => {
+        expect(qualifyObjectId('wider_region', 'Europe')).toBe('roman/Europe');
+    });
+
+    it('qualifies a national test scope as roman', () => {
+        expect(qualifyObjectId('national_calendar_test', 'IT')).toBe('roman/IT');
+    });
+
+    it('takes the supplied rite for a diocesan calendar', () => {
+        expect(qualifyObjectId('diocesan_calendar', 'lugano_ch', AMBROSIAN_RITE))
+            .toBe('ambrosian/lugano_ch');
+        expect(qualifyObjectId('diocesan_calendar', 'romamo_it', ROMAN_RITE))
+            .toBe('roman/romamo_it');
+        expect(qualifyObjectId('diocesan_calendar_test', 'milano_it', AMBROSIAN_RITE))
+            .toBe('ambrosian/milano_it');
+    });
+
+    it('falls back to roman for a diocesan calendar with no announced rite', () => {
+        expect(qualifyObjectId('diocesan_calendar', 'rotter_nl')).toBe('roman/rotter_nl');
+        expect(qualifyObjectId('diocesan_calendar', 'rotter_nl', 'gallican')).toBe('roman/rotter_nl');
+    });
+
+    it('pins the roman-only types to roman even when handed another rite', () => {
+        // The Ambrosian rite has no national tier and no wider regions; the API
+        // rejects those ids outright, so composing one could only ever 422.
+        expect(qualifyObjectId('national_calendar', 'IT', AMBROSIAN_RITE)).toBe('roman/IT');
+        expect(qualifyObjectId('wider_region', 'Europe', AMBROSIAN_RITE)).toBe('roman/Europe');
+        expect(qualifyObjectId('national_calendar_test', 'IT', AMBROSIAN_RITE)).toBe('roman/IT');
+    });
+
+    it('leaves the bare-id types untouched', () => {
+        expect(qualifyObjectId('general_roman_calendar', 'temporale')).toBe('temporale');
+        expect(qualifyObjectId('general_roman_calendar', 'decrees')).toBe('decrees');
+        expect(qualifyObjectId('general_roman_calendar', 'EDITIO_TYPICA_2008')).toBe('EDITIO_TYPICA_2008');
+        expect(qualifyObjectId('general_roman_calendar_test', 'general_roman_calendar'))
+            .toBe('general_roman_calendar');
+        expect(qualifyObjectId('rite_calendar_test', 'ambrosian')).toBe('ambrosian');
+    });
+
+    it('is idempotent — an already-qualified id is not qualified twice', () => {
+        expect(qualifyObjectId('national_calendar', 'roman/US')).toBe('roman/US');
+        expect(qualifyObjectId('diocesan_calendar', 'ambrosian/lugano_ch', AMBROSIAN_RITE))
+            .toBe('ambrosian/lugano_ch');
+    });
+
+    it('leaves an empty id empty rather than emitting a bare rite prefix', () => {
+        expect(qualifyObjectId('national_calendar', '')).toBe('');
+    });
+});
+
+describe('parseRiteQualifiedId', () => {
+    it('splits a qualified id', () => {
+        expect(parseRiteQualifiedId('ambrosian/lugano_ch')).toEqual({
+            rite: 'ambrosian',
+            id: 'lugano_ch',
+        });
+    });
+
+    it('returns null for an unqualified legacy id', () => {
+        expect(parseRiteQualifiedId('US')).toBeNull();
+    });
+
+    it('returns null when the prefix names no known rite', () => {
+        // Same rule as Rite::tryFrom() on the API side.
+        expect(parseRiteQualifiedId('mozarabic/toledo_es')).toBeNull();
+    });
+
+    it('returns null for a prefix with an empty calendar id', () => {
+        expect(parseRiteQualifiedId('roman/')).toBeNull();
+    });
+});
+
+describe('riteForObjectType', () => {
+    it('answers roman for the roman-only types regardless of the argument', () => {
+        expect(riteForObjectType('national_calendar', AMBROSIAN_RITE)).toBe('roman');
+        expect(riteForObjectType('wider_region', undefined)).toBe('roman');
+        expect(riteForObjectType('national_calendar_test', AMBROSIAN_RITE)).toBe('roman');
+    });
+
+    it('passes an announced rite through for the diocesan types', () => {
+        expect(riteForObjectType('diocesan_calendar', AMBROSIAN_RITE)).toBe('ambrosian');
+        expect(riteForObjectType('diocesan_calendar_test', ROMAN_RITE)).toBe('roman');
+    });
+
+    it('defaults an unknown or missing rite to roman', () => {
+        expect(riteForObjectType('diocesan_calendar', undefined)).toBe('roman');
+        expect(riteForObjectType('diocesan_calendar', 'nonsense')).toBe('roman');
+    });
+});
+
+describe('splitObjectId / bareCalendarId — legacy tolerance', () => {
+    it('splits a migrated id', () => {
+        expect(splitObjectId('diocesan_calendar', 'ambrosian/lugano_ch'))
+            .toEqual({ rite: 'ambrosian', id: 'lugano_ch' });
+    });
+
+    it('reads a pre-migration bare id as roman', () => {
+        // Grants written before the migration are still live and still
+        // authorize on the API side for the whole migration window.
+        expect(splitObjectId('national_calendar', 'IT'))
+            .toEqual({ rite: 'roman', id: 'IT' });
+    });
+
+    it('keeps a bare-id type whole', () => {
+        expect(splitObjectId('general_roman_calendar', 'temporale'))
+            .toEqual({ rite: 'roman', id: 'temporale' });
+        // Not parsed as rite=roman,id='' — the whole id is the resource name.
+        expect(bareCalendarId('rite_calendar_test', 'ambrosian')).toBe('ambrosian');
+    });
+
+    it('strips the rite for display', () => {
+        expect(bareCalendarId('national_calendar_test', 'roman/IT')).toBe('IT');
+        expect(bareCalendarId('national_calendar_test', 'IT')).toBe('IT');
+    });
+});
+
+describe('sameObjectId', () => {
+    it('matches a legacy grant against a migrated scope', () => {
+        expect(sameObjectId('national_calendar_test', 'IT', 'roman/IT')).toBe(true);
+        expect(sameObjectId('diocesan_calendar_test', 'romamo_it', 'roman/romamo_it')).toBe(true);
+    });
+
+    it('does not match across rites', () => {
+        // The whole point of qualifying: a Roman lugano_ch and an Ambrosian one
+        // are different resources, and a grant on one must not cover the other.
+        expect(sameObjectId('diocesan_calendar', 'roman/lugano_ch', 'ambrosian/lugano_ch')).toBe(false);
+        // A legacy bare id reads as Roman, so it does NOT cover the Ambrosian one.
+        expect(sameObjectId('diocesan_calendar', 'lugano_ch', 'ambrosian/lugano_ch')).toBe(false);
+    });
+
+    it('does not match different calendars', () => {
+        expect(sameObjectId('national_calendar', 'roman/IT', 'roman/US')).toBe(false);
+    });
+
+    it('compares bare-id types verbatim', () => {
+        expect(sameObjectId('general_roman_calendar', 'temporale', 'temporale')).toBe(true);
+        expect(sameObjectId('general_roman_calendar', 'temporale', 'decrees')).toBe(false);
+    });
+});

--- a/assets/js/__tests__/stubs/components-js.js
+++ b/assets/js/__tests__/stubs/components-js.js
@@ -13,6 +13,14 @@
 import { vi } from 'vitest';
 
 class ChainableStub {
+    // The real components expose the mounted element as `_domElement`, and
+    // permission-requests.js and admin-permissions.js both attach a `change`
+    // listener to a RiteSelect's. Without an inert stand-in here, any test that
+    // reaches those rite-linked paths dies on `addEventListener` of undefined
+    // rather than on whatever it was actually asserting. appendTo() is a no-op,
+    // so this stays available afterwards.
+    _domElement = { addEventListener() {} };
+
     filter() { return this; }
     allowNull() { return this; }
     class() { return this; }

--- a/assets/js/__tests__/stubs/components-js.js
+++ b/assets/js/__tests__/stubs/components-js.js
@@ -1,0 +1,42 @@
+/**
+ * Test-only stand-in for `@liturgical-calendar/components-js`.
+ *
+ * In the browser this package resolves via the import map footer.php emits
+ * (`./assets/components-js/index.js`, a build artifact not present in this
+ * checkout — see layout/footer.php). Under vitest there is nothing on disk
+ * for Vite to resolve, so vitest.config.js aliases the bare specifier to
+ * this file for every test. It exists purely so modules that import the
+ * package (admin-tests.js, admin-permissions.js, permission-requests.js)
+ * can be loaded in jsdom; none of the exports here need real behavior
+ * beyond "chainable and inert" unless a specific test exercises them.
+ */
+import { vi } from 'vitest';
+
+class ChainableStub {
+    filter() { return this; }
+    allowNull() { return this; }
+    class() { return this; }
+    id() { return this; }
+    name() { return this; }
+    label() { return this; }
+    wrapper() { return this; }
+    after() { return this; }
+    disabled() { return this; }
+    linkToRiteSelect() { return this; }
+    linkToNationsSelect() { return this; }
+    appendTo() {}
+}
+
+export class CalendarSelect extends ChainableStub {}
+export class RiteSelect extends ChainableStub {}
+export class WebCalendar extends ChainableStub {}
+
+export const CalendarSelectFilter = Object.freeze({
+    NATIONAL_CALENDARS: 'nationalCalendars',
+    DIOCESAN_CALENDARS: 'diocesanCalendars',
+    ALL_CALENDARS: 'allCalendars',
+});
+
+export const ApiClient = {
+    init: vi.fn(() => Promise.resolve(null)),
+};

--- a/assets/js/admin-permissions.js
+++ b/assets/js/admin-permissions.js
@@ -11,6 +11,7 @@ import {
     CalendarSelectFilter,
     RiteSelect,
 } from '@liturgical-calendar/components-js';
+import { qualifyObjectId } from './riteScopedObjectId.js';
 
 // Initialize the API client once; CalendarSelect requires this to have resolved.
 // Since components-js 2.0.0 init() rejects on failure rather than resolving to
@@ -482,6 +483,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const objectType = grantObjectType.value;
         const objectIdEl = document.getElementById('grantObjectId');
         const objectId = objectIdEl ? objectIdEl.value.trim() : '';
+        const objectRiteEl = document.getElementById('grantObjectRite');
+        const objectRite = objectRiteEl ? objectRiteEl.value : undefined;
         const relation = grantRelation.value;
 
         if (!user || !objectType || !objectId || !relation) {
@@ -509,7 +512,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 body: JSON.stringify({
                     user: user,
                     object_type: objectType,
-                    object_id: objectId,
+                    // The CalendarSelect's option values are bare calendar ids;
+                    // the API authorizes against rite-qualified ones for every
+                    // type that names a calendar (LiturgicalCalendarAPI #786).
+                    // #grantObjectRite is the RiteSelect the diocesan calendar
+                    // list is filtered by, so it carries the diocese's announced
+                    // rite; national / wider-region scopes have no rite select
+                    // and are pinned to `roman` structurally.
+                    object_id: qualifyObjectId(objectType, objectId, objectRite),
                     relation: relation
                 })
             });

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -99,6 +99,27 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     /**
+     * The `{ type, id }` pair renderScopeControl()'s `pin()` needs to lock the
+     * scope UI to an existing test's own scope, for the editor's "editing"
+     * path. `id` MUST be a bare calendar id: it ends up in #testScopeId and
+     * from there in selectedScope()'s `{ [type]: id }`, which becomes
+     * `applies_to.national_calendar` / `applies_to.diocesan_calendar` on save
+     * — never the rite-qualified FGA object id deriveScope() returns.
+     *
+     * @param {object} appliesTo - A test's `applies_to`.
+     * @returns {{type: string, id: string}} The locked scope for the editor UI.
+     */
+    function deriveLockedScope(appliesTo) {
+        const scope = deriveScope(appliesTo);
+        return {
+            type: scope.object_type === 'national_calendar_test' ? 'national_calendar'
+                : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
+                    : 'general_roman_calendar',
+            id: bareCalendarId(scope.object_type, scope.object_id),
+        };
+    }
+
+    /**
      * Whether one of the caller's granted scopes covers this test's scope.
      *
      * Tolerant of both pre-migration forms, because a grant written before
@@ -255,7 +276,11 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('filterTestScope').addEventListener('input', renderTableRows);
 
     // Expose internals for later tasks (editor/delete wiring appended below).
-    window.__adminTests = { state, fetchJson, deriveScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, RiteSelect, ApiClient };
+    window.__adminTests = { state, fetchJson, deriveScope, deriveLockedScope, gateByScope, showModalAlert, loadTests, renderTableRows, AssertionsBuilder, TestType, CalendarSelect, CalendarSelectFilter, RiteSelect, ApiClient };
+    // selectedScope and authorizedScopeChoices are defined further down in
+    // this closure; attached to the same exposed object once available so
+    // tests can reach them without a full DOM/component round-trip through
+    // openEditor()/renderScopeControl().
 
     // ---- editor -----------------------------------------------------------
 
@@ -282,6 +307,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const id = idEl ? idEl.value : '';
         return id ? { [type]: id } : undefined;
     }
+    window.__adminTests.selectedScope = selectedScope;
 
     function eventsPath(appliesTo) {
         if (appliesTo && appliesTo.diocesan_calendar) return `/events/diocese/${appliesTo.diocesan_calendar}`;
@@ -650,10 +676,14 @@ document.addEventListener('DOMContentLoaded', () => {
             const type = s.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
                 : s.object_type === 'national_calendar_test' ? 'national_calendar'
                     : 'general_roman_calendar';
-            choices.push({ type, id: s.object_id });
+            // `applies_to` (via #testScopeId → selectedScope()) holds bare
+            // calendar ids, never FGA object ids — strip the rite qualifier
+            // s.object_id carries (e.g. `roman/USA`) before it reaches there.
+            choices.push({ type, id: bareCalendarId(s.object_type, s.object_id) });
         });
         return choices;
     }
+    window.__adminTests.authorizedScopeChoices = authorizedScopeChoices;
 
     // Configure the scope UI to one of three modes and guarantee that afterwards
     // #testScopeType (value) and, for scoped types, #testScopeId (value) reflect
@@ -818,13 +848,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // constrained to the user's permissions (full picker for global admins).
         let lockedScope = null;
         if (test) {
-            const scope = deriveScope(test.applies_to);
-            lockedScope = {
-                type: scope.object_type === 'national_calendar_test' ? 'national_calendar'
-                    : scope.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
-                        : 'general_roman_calendar',
-                id: scope.object_id,
-            };
+            lockedScope = deriveLockedScope(test.applies_to);
         }
         await renderScopeControl(lockedScope);
         editorModal.show();

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -10,6 +10,7 @@ import {
     RiteSelect,
 } from '@liturgical-calendar/components-js';
 import { AssertionsBuilder, TestType, AssertType } from './AssertionsBuilder.js';
+import { ROMAN_RITE, bareCalendarId, qualifyObjectId, sameObjectId } from './riteScopedObjectId.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const config = window.AdminTestsConfig;
@@ -59,19 +60,64 @@ document.addEventListener('DOMContentLoaded', () => {
         return data;
     }
 
-    /** Mirror TestScopeResolver: derive a test's scope object from applies_to. */
+    /**
+     * Mirror TestScopeResolver::mapAppliesTo(): derive a test's scope object
+     * from applies_to.
+     *
+     *   { rite, diocesan_calendar } → diocesan_calendar_test:<rite>/<id>
+     *   { rite, national_calendar } → national_calendar_test:<rite>/<id>
+     *   { rite }                    → rite_calendar_test:<rite>
+     *   absent                      → rite_calendar_test:roman
+     *
+     * `rite_calendar_test` generalises the old `general_roman_calendar_test`,
+     * whose fixed id `general_roman_calendar` denoted exactly the Roman
+     * rite-level calendar; gateByScope() below still honours that older type so
+     * pre-migration grants keep authorizing.
+     */
     function deriveScope(appliesTo) {
+        const rite = (appliesTo && appliesTo.rite) || ROMAN_RITE;
         if (appliesTo && appliesTo.diocesan_calendar) {
-            return { object_type: 'diocesan_calendar_test', object_id: appliesTo.diocesan_calendar };
+            return {
+                object_type: 'diocesan_calendar_test',
+                object_id: qualifyObjectId('diocesan_calendar_test', appliesTo.diocesan_calendar, rite),
+            };
         }
         if (appliesTo && appliesTo.national_calendar) {
-            return { object_type: 'national_calendar_test', object_id: appliesTo.national_calendar };
+            // qualifyObjectId() pins national scopes to `roman` whatever the
+            // test declares: the Ambrosian rite has no national tier, and the
+            // API rejects `national_calendar_test:ambrosian/*` outright. A test
+            // carrying that impossible pair is gated shut rather than matched
+            // against a scope that could never have been granted.
+            return {
+                object_type: 'national_calendar_test',
+                object_id: qualifyObjectId('national_calendar_test', appliesTo.national_calendar, rite),
+            };
         }
-        return { object_type: 'general_roman_calendar_test', object_id: 'general_roman_calendar' };
+        // No calendar named: the scope is the rite-level calendar, whose id IS
+        // the rite — bare, not rite-qualified.
+        return { object_type: 'rite_calendar_test', object_id: rite };
     }
 
+    /**
+     * Whether one of the caller's granted scopes covers this test's scope.
+     *
+     * Tolerant of both pre-migration forms, because a grant written before
+     * LiturgicalCalendarAPI #785 is still live and still authorizes on the API
+     * side: an unqualified `national_calendar_test:IT` is read as Roman, and
+     * `general_roman_calendar_test:general_roman_calendar` is the Roman
+     * rite-level calendar under its former type name.
+     */
     function gateByScope(scopeObj, scopes) {
-        return scopes.some((s) => s.object_type === scopeObj.object_type && s.object_id === scopeObj.object_id);
+        return scopes.some((s) => {
+            if (
+                scopeObj.object_type === 'rite_calendar_test'
+                && s.object_type === 'general_roman_calendar_test'
+            ) {
+                return scopeObj.object_id === ROMAN_RITE;
+            }
+            return s.object_type === scopeObj.object_type
+                && sameObjectId(scopeObj.object_type, s.object_id, scopeObj.object_id);
+        });
     }
 
     function showModalAlert(modalEl, type, message) {
@@ -100,8 +146,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function scopeLabel(appliesTo) {
         const s = deriveScope(appliesTo);
-        if (s.object_type === 'national_calendar_test') return `${i18n.nationalCalendar}: ${s.object_id}`;
-        if (s.object_type === 'diocesan_calendar_test') return `${i18n.diocesanCalendar}: ${s.object_id}`;
+        // Labels show the bare calendar id: the `roman/` in `roman/IT` is an
+        // authorization-model detail, not something to put in front of a user.
+        if (s.object_type === 'national_calendar_test') {
+            return `${i18n.nationalCalendar}: ${bareCalendarId(s.object_type, s.object_id)}`;
+        }
+        if (s.object_type === 'diocesan_calendar_test') {
+            return `${i18n.diocesanCalendar}: ${bareCalendarId(s.object_type, s.object_id)}`;
+        }
         return i18n.generalRomanCalendar;
     }
 

--- a/assets/js/admin-tests.js
+++ b/assets/js/admin-tests.js
@@ -670,16 +670,23 @@ document.addEventListener('DOMContentLoaded', () => {
         const seen = new Set();
         const choices = [];
         [...(state.scopes.editor || []), ...(state.scopes.admin || [])].forEach((s) => {
-            const key = `${s.object_type}:${s.object_id}`;
-            if (seen.has(key)) return;
-            seen.add(key);
             const type = s.object_type === 'diocesan_calendar_test' ? 'diocesan_calendar'
                 : s.object_type === 'national_calendar_test' ? 'national_calendar'
                     : 'general_roman_calendar';
             // `applies_to` (via #testScopeId → selectedScope()) holds bare
             // calendar ids, never FGA object ids — strip the rite qualifier
             // s.object_id carries (e.g. `roman/USA`) before it reaches there.
-            choices.push({ type, id: bareCalendarId(s.object_type, s.object_id) });
+            const id = bareCalendarId(s.object_type, s.object_id);
+            // Dedupe on the NORMALIZED id, not the raw object_id. The API's tuple
+            // migration is copy-then-prune, so during the migration window a legacy
+            // bare grant (`national_calendar_test:USA`) and its migrated twin
+            // (`national_calendar_test:roman/USA`) both exist — two tuples naming
+            // one calendar. Keying on the raw id would offer the user the same
+            // calendar twice, with identical labels.
+            const key = `${type}:${id}`;
+            if (seen.has(key)) return;
+            seen.add(key);
+            choices.push({ type, id });
         });
         return choices;
     }

--- a/assets/js/permission-requests.js
+++ b/assets/js/permission-requests.js
@@ -11,6 +11,7 @@ import {
     CalendarSelectFilter,
     RiteSelect,
 } from '@liturgical-calendar/components-js';
+import { qualifyObjectId, splitObjectId } from './riteScopedObjectId.js';
 
 // Initialize the API client once; CalendarSelect requires this to have resolved.
 // Since components-js 2.0.0 init() rejects on failure rather than resolving to
@@ -484,9 +485,18 @@ document.addEventListener('DOMContentLoaded', async function() {
                 return null;
             }
 
+            // The CalendarSelect's option values are bare calendar ids, but the
+            // API validates a rite-qualified object id for every type that names
+            // a calendar (`AccessRequestRepository::isValidObjectIdForType()`),
+            // so qualify on the way out. The rite comes from the RiteSelect this
+            // row mounts for diocesan scopes — the same select the diocese list
+            // was filtered by, so it IS the diocese's announced rite, never a
+            // guess. National/wider-region scopes have no rite select and
+            // qualifyObjectId() pins them to `roman` structurally.
+            const riteEl = row.querySelector('.perm-object-rite');
             permissions.push({
                 object_type: objectType,
-                object_id: objectId,
+                object_id: qualifyObjectId(objectType, objectId, riteEl ? riteEl.value : undefined),
                 relation: relation
             });
         }
@@ -691,8 +701,21 @@ document.addEventListener('DOMContentLoaded', async function() {
             // Sync the object-id control (mounts a CalendarSelect for calendar
             // scopes; await so the <select> exists before we set its value).
             await syncRowObjectIdField(row, perm.object_type || '');
+            // A stored object_id is rite-qualified (`ambrosian/lugano_ch`), while
+            // the CalendarSelect's option values are bare — so split, restore the
+            // rite first, then the calendar. splitObjectId() tolerates a legacy
+            // bare id from a request stored before the API migration.
+            const { rite, id } = splitObjectId(perm.object_type || '', perm.object_id || '');
+            const riteField = row.querySelector('.perm-object-rite');
+            if (riteField && riteField.value !== rite) {
+                riteField.value = rite;
+                // linkToRiteSelect() rebuilds the calendar options from this
+                // event; without it the diocese list still holds the old rite's
+                // dioceses and the assignment below silently selects nothing.
+                riteField.dispatchEvent(new Event('change'));
+            }
             const idField = row.querySelector('.perm-object-id');
-            if (idField) idField.value = perm.object_id || '';
+            if (idField) idField.value = id;
             if (relSelect) relSelect.value = perm.relation || '';
         }
     }

--- a/assets/js/riteScopedObjectId.js
+++ b/assets/js/riteScopedObjectId.js
@@ -1,0 +1,219 @@
+/**
+ * The `<rite>/<calendarId>` form of an OpenFGA object id.
+ *
+ * Port of the API's `LiturgicalCalendar\Api\Services\RiteScopedObjectId`
+ * (LiturgicalCalendarAPI #785 for the test scopes, #786/#788 for the data
+ * resource types). The API is the authority; this module exists so the three
+ * frontend surfaces that COMPOSE object ids — the access-request form
+ * (`permission-requests.js`), the admin grant modal (`admin-permissions.js`)
+ * and the admin-tests scope gate (`admin-tests.js`) — all compose the same
+ * thing, instead of each growing its own string concatenation.
+ *
+ * A calendar id alone does not identify a calendar: the API's source tree is
+ * partitioned by rite (`jsondata/sourcedata/rite/{rite}/calendars/...`), so
+ * nothing stops the same diocese being defined under both rites. `lugano_ch`
+ * only HAPPENS to be Ambrosian-only today. A grant on the bare id would be
+ * ambiguous, and would silently widen to cover a Roman `lugano_ch` the moment
+ * one existed. Hence:
+ *
+ *   diocesan_calendar:ambrosian/lugano_ch   diocesan_calendar_test:ambrosian/lugano_ch
+ *   national_calendar:roman/US              national_calendar_test:roman/US
+ *   wider_region:roman/Europe
+ *
+ * `general_roman_calendar` and `general_roman_calendar_test` keep BARE ids:
+ * their ids are not calendars (they are `temporale`, `decrees` and missal
+ * editions, Roman by construction), so there is no rite to qualify with.
+ * `rite_calendar_test` is the exception that proves the rule — its id IS the
+ * rite (`rite_calendar_test:ambrosian`), so it is bare too.
+ *
+ * This module is deliberately dependency-free (no `@liturgical-calendar/components-js`
+ * import) so it can be unit-tested without the browser importmap that supplies
+ * that package at runtime.
+ *
+ * @module riteScopedObjectId
+ */
+
+/**
+ * Separates the rite from the calendar id.
+ *
+ * `/` is safe in an OpenFGA object id — only whitespace, `:`, `#` and `*`
+ * carry meaning there — and reads as the hierarchy it is: rite over calendar.
+ * Mirrors `RiteScopedObjectId::SEPARATOR`.
+ * @type {string}
+ */
+export const RITE_SEPARATOR = '/';
+
+/** @type {string} The Roman rite id. Mirrors the API's `Rite::ROMAN`. */
+export const ROMAN_RITE = 'roman';
+
+/** @type {string} The Ambrosian rite id. Mirrors the API's `Rite::AMBROSIAN`. */
+export const AMBROSIAN_RITE = 'ambrosian';
+
+/**
+ * Every rite the API knows about. Mirrors `LiturgicalCalendar\Api\Enum\Rite`.
+ *
+ * Used only for PARSING: an id whose prefix names no known rite is treated as
+ * unqualified rather than as a rite called something else — the same rule
+ * `RiteScopedObjectId::parse()` applies via `Rite::tryFrom()`.
+ * @type {ReadonlyArray<string>}
+ */
+export const KNOWN_RITES = Object.freeze([ROMAN_RITE, AMBROSIAN_RITE]);
+
+/**
+ * Object types whose id names a calendar, and is therefore rite-qualified.
+ * Mirrors the two branches of `AccessRequestRepository::isValidObjectIdForType()`
+ * that call the parser.
+ * @type {ReadonlyArray<string>}
+ */
+export const RITE_QUALIFIED_OBJECT_TYPES = Object.freeze([
+    'national_calendar',
+    'diocesan_calendar',
+    'wider_region',
+    'national_calendar_test',
+    'diocesan_calendar_test',
+]);
+
+/**
+ * Rite-qualified types that exist under the Roman rite ONLY.
+ *
+ * `roman/` is structurally correct for these, not a guess: the Ambrosian rite
+ * has no national tier and no wider regions, and the API rejects
+ * `national_calendar:ambrosian/*` and `wider_region:ambrosian/*` outright
+ * (`isValidObjectIdForType()`; `RegionalDataParams::validateRiteCompatibility()`).
+ * Only the diocesan tier exists under more than one rite.
+ * @type {ReadonlyArray<string>}
+ */
+export const ROMAN_ONLY_OBJECT_TYPES = Object.freeze([
+    'national_calendar',
+    'wider_region',
+    'national_calendar_test',
+]);
+
+/**
+ * Whether this object type's ids carry a `<rite>/` prefix.
+ * @param {string} objectType - An OpenFGA object type.
+ * @returns {boolean} True when ids of this type are rite-qualified.
+ */
+export function isRiteQualifiedObjectType(objectType) {
+    return RITE_QUALIFIED_OBJECT_TYPES.includes(objectType);
+}
+
+/**
+ * Split a rite-qualified object id back into its rite and calendar id.
+ *
+ * Returns null when the id is NOT rite-qualified — an unmigrated legacy id
+ * such as a bare `rotter_nl`, or a prefix that names no known rite. Callers
+ * decide what an unqualified id means for them. Mirrors
+ * `RiteScopedObjectId::parse()`.
+ *
+ * @param {string} objectId - The raw object id.
+ * @returns {{rite: string, id: string}|null} The split, or null when unqualified.
+ */
+export function parseRiteQualifiedId(objectId) {
+    if (typeof objectId !== 'string') return null;
+    const idx = objectId.indexOf(RITE_SEPARATOR);
+    if (idx === -1) return null;
+    const rite = objectId.slice(0, idx);
+    const id = objectId.slice(idx + RITE_SEPARATOR.length);
+    if (!KNOWN_RITES.includes(rite) || id === '') return null;
+    return { rite, id };
+}
+
+/**
+ * The rite a given object type's id must carry.
+ *
+ * For the Roman-only types the answer is `roman` whatever the caller passes —
+ * the caller has no say, because the API has none either. For
+ * `diocesan_calendar` / `diocesan_calendar_test` the rite is the diocese's own,
+ * which the caller must supply (in practice from the `/calendars` metadata,
+ * via the `RiteSelect` the diocesan CalendarSelect is linked to).
+ *
+ * @param {string} objectType - An OpenFGA object type.
+ * @param {string} [rite] - The rite the UI announced for this calendar.
+ * @returns {string} The rite to qualify with.
+ */
+export function riteForObjectType(objectType, rite) {
+    if (ROMAN_ONLY_OBJECT_TYPES.includes(objectType)) return ROMAN_RITE;
+    return KNOWN_RITES.includes(rite) ? rite : ROMAN_RITE;
+}
+
+/**
+ * Compose the object id to send to the API for this type.
+ *
+ * Idempotent: an id that already carries a known rite prefix is returned
+ * unchanged, so a value round-tripped out of the API and back in is not
+ * double-qualified. Types with bare ids (`general_roman_calendar`,
+ * `general_roman_calendar_test`, `rite_calendar_test`, and anything unknown)
+ * pass through untouched — qualifying those would invent a rite for a resource
+ * that has none.
+ *
+ * @param {string} objectType - An OpenFGA object type.
+ * @param {string} objectId - The bare calendar id as chosen in the UI.
+ * @param {string} [rite] - The rite the UI announced for this calendar.
+ * @returns {string} The object id in the form the API validates.
+ */
+export function qualifyObjectId(objectType, objectId, rite) {
+    if (!isRiteQualifiedObjectType(objectType)) return objectId;
+    if (typeof objectId !== 'string' || objectId === '') return objectId;
+    if (parseRiteQualifiedId(objectId) !== null) return objectId;
+    return riteForObjectType(objectType, rite) + RITE_SEPARATOR + objectId;
+}
+
+/**
+ * Split any stored object id into its rite and bare calendar id, tolerating
+ * legacy unqualified ids.
+ *
+ * Grants written before the API migration carry bare ids, and the API keeps
+ * accepting them for the whole migration window — so anything READ back (an
+ * existing tuple, a stored access request, a `/auth/test-scopes` entry) may be
+ * in either form. Unqualified ids resolve to the Roman rite, which is what the
+ * API's own migration infers for every type but the diocesan one, and the only
+ * rite that existed when those ids were written.
+ *
+ * For a type with bare ids the whole id is returned as `id`, with `rite` set to
+ * the Roman rite so callers can compare uniformly.
+ *
+ * @param {string} objectType - An OpenFGA object type.
+ * @param {string} objectId - The raw object id, qualified or not.
+ * @returns {{rite: string, id: string}} The rite and the bare calendar id.
+ */
+export function splitObjectId(objectType, objectId) {
+    const raw = typeof objectId === 'string' ? objectId : '';
+    if (!isRiteQualifiedObjectType(objectType)) {
+        return { rite: ROMAN_RITE, id: raw };
+    }
+    const parsed = parseRiteQualifiedId(raw);
+    return parsed === null ? { rite: ROMAN_RITE, id: raw } : parsed;
+}
+
+/**
+ * The calendar id with any rite qualifier stripped — for display, and for
+ * pre-filling a UI control whose option values are bare calendar ids.
+ * Mirrors `RiteScopedObjectId::calendarId()`.
+ *
+ * @param {string} objectType - An OpenFGA object type.
+ * @param {string} objectId - The raw object id, qualified or not.
+ * @returns {string} The bare calendar id.
+ */
+export function bareCalendarId(objectType, objectId) {
+    return splitObjectId(objectType, objectId).id;
+}
+
+/**
+ * Whether two object ids of the same type name the same resource, across the
+ * qualified/unqualified boundary.
+ *
+ * The comparison a permission gate needs while both forms are in circulation:
+ * a legacy `national_calendar_test:IT` grant still authorizes a test whose
+ * scope now derives as `national_calendar_test:roman/IT`.
+ *
+ * @param {string} objectType - The OpenFGA object type both ids belong to.
+ * @param {string} a - One object id.
+ * @param {string} b - The other object id.
+ * @returns {boolean} True when both name the same rite and calendar.
+ */
+export function sameObjectId(objectType, a, b) {
+    const left = splitObjectId(objectType, a);
+    const right = splitObjectId(objectType, b);
+    return left.rite === right.rite && left.id === right.id;
+}

--- a/e2e/rbac/01-cei-admin-register-request.spec.ts
+++ b/e2e/rbac/01-cei-admin-register-request.spec.ts
@@ -51,7 +51,7 @@ async function purgeCeiAdmin(): Promise<void> {
     // beforeAll, or via settleCleanup in teardown) instead of silently leaving stale state.
     const zid = await z.findUserIdByEmail(USERS['cei-admin'].email);
     if (zid) {
-        await f.delete(`user:${zid}`, 'admin', 'national_calendar:IT');
+        await f.delete(`user:${zid}`, 'admin', 'national_calendar:roman/IT');
         await z.deleteUser(zid);
     }
     if (fs.existsSync(CEI_ADMIN_AUTH)) {
@@ -153,7 +153,7 @@ test('01 — cei-admin registers + admin@IT: scoped review lifecycle', async ({ 
     const zid = await z.findUserIdByEmail(cei.email);
     expect(zid).not.toBeNull();
     expect(
-        await new Fga().check(`user:${zid}`, 'admin', 'national_calendar:IT'),
+        await new Fga().check(`user:${zid}`, 'admin', 'national_calendar:roman/IT'),
     ).toBe(true);
 
     // ── Step 8: super-admin sees the approval (durable DOM evidence of the grant) ─

--- a/e2e/rbac/02-cei-editor-edit-request.spec.ts
+++ b/e2e/rbac/02-cei-editor-edit-request.spec.ts
@@ -122,7 +122,7 @@ test('02 — cei-editor edit@IT: scoped review lifecycle', async ({ browser }) =
     const zid = await z.findUserIdByEmail(USERS['cei-editor'].email);
     expect(zid).not.toBeNull();
     expect(
-        await new Fga().check(`user:${zid}`, 'editor', 'national_calendar:IT'),
+        await new Fga().check(`user:${zid}`, 'editor', 'national_calendar:roman/IT'),
     ).toBe(true);
 
     // ── Step 8: super-admin sees the approval ─────────────────────────────────
@@ -152,7 +152,7 @@ test.afterEach(async () => {
         // cei-admin was created on-demand by seedAndLogin — delete it + its admin tuple.
         ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
         ceiAdminId
-            ? new Fga().delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            ? new Fga().delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
             : Promise.resolve(),
     ]);
 

--- a/e2e/rbac/03-usccb-admin-request.spec.ts
+++ b/e2e/rbac/03-usccb-admin-request.spec.ts
@@ -98,7 +98,7 @@ test('03 — admin@USA request not visible to cei-admin (out-of-scope IT admin)'
     const zid = await z.findUserIdByEmail(USERS['grc-editor'].email);
     expect(zid).not.toBeNull();
     expect(
-        await new Fga().check(`user:${zid}`, 'admin', 'national_calendar:US'),
+        await new Fga().check(`user:${zid}`, 'admin', 'national_calendar:roman/US'),
     ).toBe(true);
 
     // ── Step 5: Durable DOM evidence — super-admin sees the approval ──────────
@@ -132,12 +132,12 @@ test.afterEach(async () => {
         truncateAppTables(), // app-table rows created by this scenario
         // Revoke the admin@US tuple the approval may have written for grc-editor
         grcEditorId
-            ? f.delete(`user:${grcEditorId}`, 'admin', 'national_calendar:US')
+            ? f.delete(`user:${grcEditorId}`, 'admin', 'national_calendar:roman/US')
             : Promise.resolve(),
         // cei-admin was created on-demand by seedAndLogin — delete it + its admin@IT tuple
         ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
         ceiAdminId
-            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
             : Promise.resolve(),
     ]);
 });

--- a/e2e/rbac/04-usccb-editor-register-request.spec.ts
+++ b/e2e/rbac/04-usccb-editor-register-request.spec.ts
@@ -63,7 +63,7 @@ async function purgeUsccbEditor(): Promise<void> {
     // beforeAll, or via settleCleanup in teardown) instead of silently leaving stale state.
     const zid = await z.findUserIdByEmail(USERS['usccb-editor'].email);
     if (zid) {
-        await f.delete(`user:${zid}`, 'editor', 'national_calendar:US');
+        await f.delete(`user:${zid}`, 'editor', 'national_calendar:roman/US');
         await z.deleteUser(zid);
     }
     if (fs.existsSync(USCCB_EDITOR_AUTH)) {
@@ -148,7 +148,7 @@ test('04 — usccb-editor registers + editor@US: resource-admin grant', async ({
     const zid = await z.findUserIdByEmail(editor.email);
     expect(zid).not.toBeNull();
     expect(
-        await new Fga().check(`user:${zid}`, 'editor', 'national_calendar:US'),
+        await new Fga().check(`user:${zid}`, 'editor', 'national_calendar:roman/US'),
     ).toBe(true);
 
     // ── Step 6: super-admin sees the approval (durable DOM evidence of the grant) ─
@@ -176,7 +176,7 @@ test.afterEach(async () => {
         // cei-admin was created on-demand by seedAndLogin — delete it + its admin@IT tuple.
         ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
         ceiAdminId
-            ? new Fga().delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            ? new Fga().delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
             : Promise.resolve(),
     ]);
 });

--- a/e2e/rbac/05-rome-admin-request.spec.ts
+++ b/e2e/rbac/05-rome-admin-request.spec.ts
@@ -111,7 +111,7 @@ test('05 — admin@romamo_it request: rome-admin + super-admin see it; cei-admin
     const zid = await z.findUserIdByEmail(USERS['grc-editor'].email);
     expect(zid).not.toBeNull();
     expect(
-        await new Fga().check(`user:${zid}`, 'admin', 'diocesan_calendar:romamo_it'),
+        await new Fga().check(`user:${zid}`, 'admin', 'diocesan_calendar:roman/romamo_it'),
     ).toBe(true);
 
     // ── Step 5: Durable DOM evidence — super-admin sees the approved row ──────
@@ -145,12 +145,12 @@ test.afterEach(async () => {
         truncateAppTables(), // app-table rows created by this scenario
         // Revoke the admin@romamo_it tuple the approval may have written for grc-editor
         grcEditorId
-            ? f.delete(`user:${grcEditorId}`, 'admin', 'diocesan_calendar:romamo_it')
+            ? f.delete(`user:${grcEditorId}`, 'admin', 'diocesan_calendar:roman/romamo_it')
             : Promise.resolve(),
         // cei-admin was created on-demand by seedAndLogin — delete it + its admin@IT tuple
         ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
         ceiAdminId
-            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
             : Promise.resolve(),
     ]);
 });

--- a/e2e/rbac/06-rome-editor-request.spec.ts
+++ b/e2e/rbac/06-rome-editor-request.spec.ts
@@ -109,7 +109,7 @@ test('06 — rome-editor edit@romamo_it: rome-admin approves; scoped visibility'
     const zid = await z.findUserIdByEmail(USERS['rome-editor'].email);
     expect(zid).not.toBeNull();
     expect(
-        await new Fga().check(`user:${zid}`, 'editor', 'diocesan_calendar:romamo_it'),
+        await new Fga().check(`user:${zid}`, 'editor', 'diocesan_calendar:roman/romamo_it'),
     ).toBe(true);
 
     // ── Step 5: Durable DOM evidence — super-admin sees the approved row ──────
@@ -142,7 +142,7 @@ test.afterEach(async () => {
         // cei-admin was created on-demand by seedAndLogin — delete it + its admin@IT tuple
         ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
         ceiAdminId
-            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
             : Promise.resolve(),
     ]);
 });

--- a/e2e/rbac/07-dashboard-card-scoping.spec.ts
+++ b/e2e/rbac/07-dashboard-card-scoping.spec.ts
@@ -161,7 +161,7 @@ test.describe.serial('07 — dashboard card scoping matrix', () => {
         await settleCleanup('scenario 07 afterAll', [
             ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
             ceiAdminId
-                ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+                ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
                 : Promise.resolve(),
             fs.promises.rm(path.join(__dirname, '..', '.auth', 'cei-admin.json'), { force: true }),
         ]);

--- a/e2e/rbac/08-negative-auth.spec.ts
+++ b/e2e/rbac/08-negative-auth.spec.ts
@@ -172,7 +172,7 @@ test('08 — cei-admin cannot act on (403) or see USA-scoped access request', as
     // Sanity: the approval granted grc-editor editor@national_calendar:US, so the request is
     // genuinely APPROVED — the revoke below exercises the authz branch, not the state guard.
     const grcId = await new ZitadelAdmin().findUserIdByEmail(USERS['grc-editor'].email);
-    expect(await new Fga().check(`user:${grcId}`, 'editor', 'national_calendar:US')).toBe(true);
+    expect(await new Fga().check(`user:${grcId}`, 'editor', 'national_calendar:roman/US')).toBe(true);
 
     // ── Step 7: (a′) cei-admin revokes the APPROVED request → 403 by SCOPE ────
     // With the state guard satisfied (approved), the API reaches the authorization check,
@@ -208,11 +208,11 @@ test.afterEach(async () => {
         // cei-admin was created on-demand by seedAndLogin — delete it + its admin@IT tuple.
         ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
         ceiAdminId
-            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            ? f.delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
             : Promise.resolve(),
         // Step 6 approved the request → grc-editor earned editor@national_calendar:US; revoke it.
         grcEditorId
-            ? f.delete(`user:${grcEditorId}`, 'editor', 'national_calendar:US')
+            ? f.delete(`user:${grcEditorId}`, 'editor', 'national_calendar:roman/US')
             : Promise.resolve(),
     ]);
 });

--- a/e2e/rbac/09-revoke-after-grant.spec.ts
+++ b/e2e/rbac/09-revoke-after-grant.spec.ts
@@ -109,7 +109,7 @@ test('09 — revoke-after-grant: FGA tuple removed and request shows revoked sta
     const ceiEditorId = await z.findUserIdByEmail(USERS['cei-editor'].email);
     expect(ceiEditorId).not.toBeNull();
     expect(
-        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:IT'),
+        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:roman/IT'),
     ).toBe(true);
 
     // ── Post-grant check: with the editor@national_calendar:IT tuple now active,
@@ -131,7 +131,7 @@ test('09 — revoke-after-grant: FGA tuple removed and request shows revoked sta
 
     // ── Step 5: CORE — FGA tuple is REMOVED ──────────────────────────────────
     expect(
-        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:IT'),
+        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:roman/IT'),
     ).toBe(false);
 
     // ── Step 6: CORE — request row appears in 'revoked' tab (admin view) ─────
@@ -205,7 +205,7 @@ test.afterEach(async () => {
         // cei-admin was created on-demand by seedAndLogin — delete it + its admin tuple.
         ceiAdminId ? z.deleteUser(ceiAdminId) : Promise.resolve(),
         ceiAdminId
-            ? new Fga().delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:IT')
+            ? new Fga().delete(`user:${ceiAdminId}`, 'admin', 'national_calendar:roman/IT')
             : Promise.resolve(),
         fs.promises.rm(path.join(__dirname, '..', '.auth', 'cei-admin.json'), { force: true }),
     ]);

--- a/e2e/rbac/10-scoped-data-editing.spec.ts
+++ b/e2e/rbac/10-scoped-data-editing.spec.ts
@@ -82,11 +82,11 @@ test('10 — scoped data editing: cei-editor writes IT (ok) but is denied USA (4
     const ceiEditorId = await z.findUserIdByEmail(USERS['cei-editor'].email);
     expect(ceiEditorId).not.toBeNull();
     expect(
-        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:IT'),
+        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:roman/IT'),
     ).toBe(true);
     // ...and does NOT exist for the USA calendar (cei-editor holds no US scope).
     expect(
-        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:US'),
+        await new Fga().check(`user:${ceiEditorId}`, 'editor', 'national_calendar:roman/US'),
     ).toBe(false);
 
     const headers = {

--- a/e2e/rbac/11-session-resilience.spec.ts
+++ b/e2e/rbac/11-session-resilience.spec.ts
@@ -206,7 +206,7 @@ test('11c — grant/revoke is reflected on the next authorization decision (no s
     const body = buildItNationalPayload();
 
     // ── Phase 1 — NO scope: FGA false + the IT write is DENIED (403) ─────────
-    expect(await fga.check(subject, 'editor', 'national_calendar:IT')).toBe(false);
+    expect(await fga.check(subject, 'editor', 'national_calendar:roman/IT')).toBe(false);
     {
         const cei = await actingAs(browser, 'cei-editor');
         try {
@@ -222,7 +222,7 @@ test('11c — grant/revoke is reflected on the next authorization decision (no s
 
     // ── Phase 2 — GRANT mid-session: FGA true + the very next write is AUTHORIZED (201) ─
     await grantScope('cei-editor');
-    expect(await fga.check(subject, 'editor', 'national_calendar:IT')).toBe(true);
+    expect(await fga.check(subject, 'editor', 'national_calendar:roman/IT')).toBe(true);
     {
         const cei = await actingAs(browser, 'cei-editor');
         try {
@@ -238,7 +238,7 @@ test('11c — grant/revoke is reflected on the next authorization decision (no s
 
     // ── Phase 3 — REVOKE mid-session: FGA false + the next write is DENIED again (403) ─
     await revokeScope('cei-editor');
-    expect(await fga.check(subject, 'editor', 'national_calendar:IT')).toBe(false);
+    expect(await fga.check(subject, 'editor', 'national_calendar:roman/IT')).toBe(false);
     {
         const cei = await actingAs(browser, 'cei-editor');
         try {

--- a/e2e/rbac/13-admin-tests-crud.spec.ts
+++ b/e2e/rbac/13-admin-tests-crud.spec.ts
@@ -98,7 +98,7 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
             // previous failed run so re-runs start from a clean slate.
             const staleId = await z.findUserIdByEmail(EDITOR_EMAIL);
             if (staleId) {
-                await f.delete(`user:${staleId}`, 'editor', `national_calendar_test:${NATION}`)
+                await f.delete(`user:${staleId}`, 'editor', `national_calendar_test:roman/${NATION}`)
                     .catch(() => {}); // tolerate already-absent tuple
                 await z.deleteUser(staleId);
             }
@@ -117,7 +117,7 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
             // 2. Write the FGA `editor` tuple on national_calendar_test:IT.
             //    Mirrors the tuple that the access-request approval flow would write
             //    after a `test_editor` request is reviewed (see spec 12 for that flow).
-            await f.write(`user:${editorZitadelId}`, 'editor', `national_calendar_test:${NATION}`);
+            await f.write(`user:${editorZitadelId}`, 'editor', `national_calendar_test:roman/${NATION}`);
 
             // 3. Headless OIDC login → write .auth/test-editor-it.json.
             //    Mirrors the logic in loginAndSaveState() from support/seed.ts.
@@ -246,7 +246,7 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
         if (uid) {
             // Fga.delete tolerates "not found" — safe if test 2 already deleted the tuple.
             cleanupOps.push(
-                f.delete(`user:${uid}`, 'editor', `national_calendar_test:${NATION}`),
+                f.delete(`user:${uid}`, 'editor', `national_calendar_test:roman/${NATION}`),
             );
             // ZitadelAdmin.deleteUser tolerates 404 — safe on re-runs where the user is absent.
             cleanupOps.push(z.deleteUser(uid));

--- a/e2e/rbac/13-admin-tests-crud.spec.ts
+++ b/e2e/rbac/13-admin-tests-crud.spec.ts
@@ -100,6 +100,11 @@ test.describe('admin-tests CRUD (real RBAC)', () => {
             if (staleId) {
                 await f.delete(`user:${staleId}`, 'editor', `national_calendar_test:roman/${NATION}`)
                     .catch(() => {}); // tolerate already-absent tuple
+                // A run from before the rite-qualification migration seeded the
+                // legacy bare form. Clean that up too, or a stale unqualified
+                // tuple survives teardown and leaks into the next run.
+                await f.delete(`user:${staleId}`, 'editor', `national_calendar_test:${NATION}`)
+                    .catch(() => {}); // tolerate already-absent tuple
                 await z.deleteUser(staleId);
             }
 

--- a/e2e/rbac/support/fga.test.ts
+++ b/e2e/rbac/support/fga.test.ts
@@ -4,7 +4,7 @@ import { Fga } from './fga';
 test('write, check true, delete, check false (idempotent)', async () => {
     const f = new Fga();
     const user = 'user:fga-probe-e2e';
-    const obj = 'national_calendar:ZZ';
+    const obj = 'national_calendar:roman/ZZ';
     await f.delete(user, 'admin', obj); // clean slate, must not throw
     expect(await f.check(user, 'admin', obj)).toBe(false);
     await f.write(user, 'admin', obj);

--- a/e2e/rbac/support/users.ts
+++ b/e2e/rbac/support/users.ts
@@ -1,5 +1,20 @@
 export type RbacRelation = 'admin' | 'editor';
 
+/**
+ * Object ids that name a calendar are rite-qualified `<rite>/<calendarId>`
+ * (LiturgicalCalendarAPI #785 for the `*_test` types, #786/#788 for the data
+ * resource types) — the API composes and validates exactly this form, so a
+ * tuple seeded on a bare id authorizes nothing.
+ *
+ * `general_roman_calendar` ids stay BARE: `temporale`, `decrees` and the missal
+ * editions are not calendars, and are Roman by construction.
+ *
+ * Every calendar in these fixtures is Roman (IT, US, Europe, and the diocese of
+ * Rome). The four Ambrosian dioceses — lugano_ch, milano_it, bergam_it,
+ * novara_it — would take `ambrosian/`; none is seeded here.
+ */
+export const ROMAN = 'roman';
+
 export interface RbacUser {
     id: string;
     email: string;
@@ -16,17 +31,17 @@ function mk(id: string, role: RbacUser['role'], fga: RbacUser['fga']): RbacUser 
 
 export const USERS: Record<string, RbacUser> = {
     'super-admin': mk('super-admin', 'admin', null),
-    'cei-admin': mk('cei-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'IT' }),
-    'cei-editor': mk('cei-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'IT' }),
-    'usccb-admin': mk('usccb-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: 'US' }),
-    'usccb-editor': mk('usccb-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: 'US' }),
-    'rome-admin': mk('rome-admin', 'calendar_editor', { relation: 'admin', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
-    'rome-editor': mk('rome-editor', 'calendar_editor', { relation: 'editor', objectType: 'diocesan_calendar', objectId: 'romamo_it' }),
+    'cei-admin': mk('cei-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: `${ROMAN}/IT` }),
+    'cei-editor': mk('cei-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: `${ROMAN}/IT` }),
+    'usccb-admin': mk('usccb-admin', 'calendar_editor', { relation: 'admin', objectType: 'national_calendar', objectId: `${ROMAN}/US` }),
+    'usccb-editor': mk('usccb-editor', 'calendar_editor', { relation: 'editor', objectType: 'national_calendar', objectId: `${ROMAN}/US` }),
+    'rome-admin': mk('rome-admin', 'calendar_editor', { relation: 'admin', objectType: 'diocesan_calendar', objectId: `${ROMAN}/romamo_it` }),
+    'rome-editor': mk('rome-editor', 'calendar_editor', { relation: 'editor', objectType: 'diocesan_calendar', objectId: `${ROMAN}/romamo_it` }),
     'grc-admin': mk('grc-admin', 'calendar_editor', { relation: 'admin', objectType: 'general_roman_calendar', objectId: 'temporale' }),
     'grc-editor': mk('grc-editor', 'calendar_editor', { relation: 'editor', objectType: 'general_roman_calendar', objectId: 'temporale' }),
-    'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: 'Europe' }),
-    'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: 'Europe' }),
-    'tests-editor': mk('tests-editor', 'test_editor', { relation: 'editor', objectType: 'national_calendar_test', objectId: 'IT' }),
+    'europe-admin': mk('europe-admin', 'calendar_editor', { relation: 'admin', objectType: 'wider_region', objectId: `${ROMAN}/Europe` }),
+    'europe-editor': mk('europe-editor', 'calendar_editor', { relation: 'editor', objectType: 'wider_region', objectId: `${ROMAN}/Europe` }),
+    'tests-editor': mk('tests-editor', 'test_editor', { relation: 'editor', objectType: 'national_calendar_test', objectId: `${ROMAN}/IT` }),
     'tests-editor-noscope': mk('tests-editor-noscope', 'test_editor', null),
 };
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -9,10 +10,12 @@ export default defineConfig({
             // admin-permissions.js, permission-requests.js), so tests need
             // something on disk for Vite to resolve — see the stub's own
             // header comment for why its exports are inert stand-ins.
-            '@liturgical-calendar/components-js': new URL(
-                './assets/js/__tests__/stubs/components-js.js',
-                import.meta.url
-            ).pathname,
+            // fileURLToPath, not URL.pathname: the latter percent-encodes spaces
+            // and keeps the leading slash on Windows drive letters, so a checkout
+            // under such a path would fail to resolve.
+            '@liturgical-calendar/components-js': fileURLToPath(
+                new URL('./assets/js/__tests__/stubs/components-js.js', import.meta.url)
+            ),
         },
     },
     test: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            // In the browser this resolves via the import map in
+            // layout/footer.php (a build artifact not present in this
+            // checkout). Modules under test import it directly (admin-tests.js,
+            // admin-permissions.js, permission-requests.js), so tests need
+            // something on disk for Vite to resolve — see the stub's own
+            // header comment for why its exports are inert stand-ins.
+            '@liturgical-calendar/components-js': new URL(
+                './assets/js/__tests__/stubs/components-js.js',
+                import.meta.url
+            ).pathname,
+        },
+    },
     test: {
         environment: 'jsdom',
         include: ['assets/js/__tests__/**/*.test.js'],


### PR DESCRIPTION
Fixes the live CI failure on `development`: 13 RBAC e2e specs fail because the frontend composes **bare** OpenFGA object ids while the merged API requires **rite-qualified** ones.

## The bug

The e2e stack builds `litcal-api` fresh from the API's `#development`, which now contains:

- **API #785** — rite-qualified *test* scope ids (`national_calendar_test:roman/IT`, `diocesan_calendar_test:ambrosian/lugano_ch`) plus a new `rite_calendar_test:<rite>` type generalising `general_roman_calendar_test`.
- **API #786/#788** — rite-qualified *data* resource ids (`national_calendar:roman/US`, `diocesan_calendar:ambrosian/lugano_ch`, `wider_region:roman/Europe`).

Observed, `e2e/rbac/10-scoped-data-editing.spec.ts`:

```text
PATCH /data/nation/IT should succeed (2xx) for cei-editor scoped to IT; got 403:
  "detail": "No editor permission for national_calendar:roman/IT"
```

And `e2e/rbac/12-test-editor-scoped-test-request.spec.ts` submitted an access request for `national_calendar_test:IT`, which the API's validator now rejects — so zero request rows appeared.

## The fix

`assets/js/riteScopedObjectId.js` is a new, dependency-free port of the API's `src/Services/RiteScopedObjectId.php`. It is deliberately free of any `@liturgical-calendar/components-js` import (that package is supplied by the browser importmap, not npm) so it unit-tests directly with the existing vitest setup.

**Composition always emits the qualified form; parsing tolerates both**, because grants written before the API migration are still live and still authorize on the API side for the whole migration window.

| Object type | Id emitted | Why |
|--------------------------------|-------------------------|--------------------------------------------------------------|
| `national_calendar` | `roman/US` | Roman-only tier; API rejects `ambrosian/*` outright |
| `wider_region` | `roman/Europe` | Roman-only tier |
| `national_calendar_test` | `roman/IT` | Roman-only tier |
| `diocesan_calendar(_test)` | `<rite>/<id>` | the diocese's own rite, from `/calendars` metadata |
| `general_roman_calendar` | `temporale` *(bare)* | not calendars — Roman by construction (per the #786 spec) |
| `general_roman_calendar_test` | *(bare)* | same |
| `rite_calendar_test` | `ambrosian` *(bare)* | its id **is** the rite |

The diocesan rite is **never** guessed and **never** hardcoded: it is read from the `RiteSelect` that the diocesan `CalendarSelect` is linked to, and `CalendarSelect#_applyRite()` derives its diocese list from `ApiBase.diocesanCalendars(rite)` — i.e. straight from the rite each diocese is announced with in `/calendars`.

### Construction / parsing sites changed

- `assets/js/permission-requests.js` — qualify on access-request submit; split on resubmit pre-fill (restores the rite select first, so the linked calendar list is rebuilt before the id is assigned).
- `assets/js/admin-permissions.js` — qualify on grant. Revoke round-trips the id the tuple table already carries, so it needs no change.
- `assets/js/admin-tests.js` — `deriveScope()` now mirrors `TestScopeResolver::mapAppliesTo()` exactly, including `rite_calendar_test`; `gateByScope()` accepts both the legacy bare ids and the older `general_roman_calendar_test` type so pre-migration grants keep authorizing; `scopeLabel()` shows the bare calendar id (the `roman/` is a model detail, not user-facing).
- `admin-dashboard.php` — the Tests-card gate also accepts `rite_calendar_test`, the only type able to express `ambrosian` at rite level.
- RBAC e2e fixtures — `e2e/rbac/support/users.ts` plus 31 raw FGA object literals across 13 spec/support files now seed the tuples the API checks. `general_roman_calendar:temporale` and `general_roman_calendar:decrees` stay bare.

The UI select option values stay bare calendar ids, so `e2e/rbac/support/requestAccess.ts` and every spec that drives it are untouched.

## Verification

- `yarn test:unit` — 152 passed, including 40 new assertions in `assets/js/__tests__/riteScopedObjectId.test.js`.
- `yarn lint`, `yarn typecheck` — clean.
- `composer test` (13 tests, 36 assertions) and `composer lint` — clean.
- **Contract cross-check against the API itself**: every id this branch composes was run through `AccessRequestRepository::isValidObjectIdForType()` as it exists at `LiturgicalCalendarAPI@origin/development`. All 21 cases match, including that each *pre-fix* bare id (`national_calendar:IT`, `wider_region:Europe`, `national_calendar_test:IT`) is rejected and that `general_roman_calendar:roman/temporale` is rejected — i.e. GRC really must stay bare.
- **The e2e suite was NOT run.** The only running stack (`localhost:3000` / `:8000`) serves the shared main checkouts, not this worktree, so exercising it would validate the wrong code and interfere with concurrent work. A parallel stack is not reachable here either: `docker-compose.yml` builds `litcal-frontend` from GitHub `#development` rather than the local tree, pins Zitadel to 8080/8081 with no env override, and the provisioned OIDC redirect URIs are bound to `http://localhost:3000`. Claiming e2e verification would have been false.

## Relationship to #460

No textual conflict — `git merge-tree` of this branch and `fix/admin-tests-applies-to-rite` is clean, and the merged `admin-tests.js` carries both changes coherently.

This PR deliberately does **not** touch `selectedScope()`, `parseScopedId()`, `authorizedScopeChoices()` or `lockedScopeForTest()` — #460 owns those, and it is #460 that makes the admin-tests create/update payload carry `applies_to.rite`. `e2e/rbac/13-admin-tests-crud.spec.ts`'s write path therefore still needs #460 to land; this PR fixes its seeded tuple and its read-side gating. Once both are in, `parseScopedId()` in `admin-tests.js` duplicates `parseRiteQualifiedId()` here and should be collapsed into the shared module — a small follow-up, not worth a conflict now.

## Known follow-ups (not in scope)

- Neither request UI offers `rite_calendar_test` as a requestable type yet (it needs new i18n strings); `general_roman_calendar_test` still covers the Roman rite-level case.
- `authorizedScopeChoices()` maps a `rite_calendar_test:ambrosian` grant onto the General Roman branch. Harmless today (no such grant exists) and it sits inside #460's hunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rite-aware calendar permissions and test scopes.
  - Calendar access now preserves the selected rite when granting permissions or submitting requests.
  - Added support for national, diocesan, and rite-specific calendar scopes.

- **Bug Fixes**
  - Improved editing and resubmission of scoped calendar permissions.
  - Preserved compatibility with existing permissions created before the migration.
  - Normalized calendar identifiers consistently across administration and authorization workflows.

- **Tests**
  - Expanded coverage for rite-specific permissions, scope selection, legacy identifiers, and authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->