### PR TITLE
fix(extending): keep the diocesan i18n fetch in the load chain

### DIFF
--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -3114,6 +3114,39 @@ const populateRowWithEventData = (row, liturgical_event, metadata) => {
 };
 
 /**
+ * Fetches one secondary localization of the calendar at `path`.
+ *
+ * The `response.ok` check matters more than it looks. These translations feed
+ * TranslationData, from which refreshOtherLocalizationInputs() fills the
+ * `input[data-locale]` fields, from which the save handler builds `payload.i18n`.
+ * A problem+json error body parses perfectly well as JSON, so without this check a
+ * failed fetch would be stored as if it were translations and the resulting blank
+ * inputs would be saved as real — but empty — translation strings. Throwing instead
+ * routes it to the caller's `.catch()`, which surfaces a toast.
+ *
+ * The message deliberately does not begin with the status code: the diocesan
+ * `.catch()` swallows messages starting with '404' (its own already-handled
+ * not-found case), which would silence a 404 from this endpoint too.
+ *
+ * `credentials: 'omit'` is required, not incidental. Only PUT/PATCH/DELETE on
+ * `/data` are authenticated; GET is public and answers with
+ * `Access-Control-Allow-Origin: *`, and browsers refuse to pair a wildcard ACAO
+ * with a credentialed request. See CLAUDE.md, "API Communication".
+ *
+ * @param {string} path - The calendar's API path (`API.path`).
+ * @param {string} localization - The locale to fetch, e.g. `fr_CA`.
+ * @returns {Promise<Object>} The parsed localization data.
+ */
+const fetchLocalization = (path, localization) => fetch(`${path}/${localization}`, {
+    credentials: 'omit'
+}).then(response => {
+    if (false === response.ok) {
+        throw new Error(`Could not load the ${localization} translation (HTTP ${response.status} ${response.statusText})`);
+    }
+    return response.json();
+});
+
+/**
  * Handles retrieving the Diocesan Calendar data and related i18n data from the API.
  * @function
  */
@@ -3185,7 +3218,7 @@ const loadDiocesanCalendarData = () => {
                                         .map(({ value }) => value);
             if (DataLoader.lastRequestPath !== API.path) {
                 // We are requesting a totally different calendar, we need to reload ALL i18n data
-                translationsLoaded = Promise.all(otherLocalizations.map(localization => fetch(API.path + '/' + localization).then(response => response.json()))).then(data => {
+                translationsLoaded = Promise.all(otherLocalizations.map(localization => fetchLocalization(API.path, localization))).then(data => {
                     toastr["success"]("Diocesan Calendar translation data was retrieved successfully", Messages['Success']);
                     if (false === TranslationData.has(API.path)) {
                         TranslationData.set(API.path, new Map());
@@ -3205,7 +3238,7 @@ const loadDiocesanCalendarData = () => {
                 if (DataLoader.allLocalesLoaded.hasOwnProperty(API.path)) {
                     refreshOtherLocalizationInputs(otherLocalizations);
                 } else {
-                    translationsLoaded = fetch(API.path + '/' + DataLoader.lastRequestLocale).then(response => response.json()).then(localizationData => {
+                    translationsLoaded = fetchLocalization(API.path, DataLoader.lastRequestLocale).then(localizationData => {
                         if (false === TranslationData.has(API.path)) {
                             TranslationData.set(API.path, new Map());
                         }

--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -3172,6 +3172,12 @@ const loadDiocesanCalendarData = () => {
             }
         }
         fillDiocesanFormWithData(data);
+        // The secondary-locale fetches MUST stay in the outer chain. The `.finally()`
+        // below hides #overlay, and the save handler builds `payload.i18n` by reading
+        // the `input[data-locale]` fields that refreshOtherLocalizationInputs() adds
+        // here. Let the overlay lift first and a save lands with one locale in `i18n`
+        // while `metadata.locales` announces two, which the API rejects (issue #462).
+        let translationsLoaded = Promise.resolve();
         if (document.querySelector('.calendarLocales').selectedOptions.length > 1) {
             const currentLocalization = document.querySelector('.currentLocalizationChoices').value;
             const otherLocalizations = Array.from(document.querySelector('.calendarLocales').selectedOptions)
@@ -3179,7 +3185,7 @@ const loadDiocesanCalendarData = () => {
                                         .map(({ value }) => value);
             if (DataLoader.lastRequestPath !== API.path) {
                 // We are requesting a totally different calendar, we need to reload ALL i18n data
-                Promise.all(otherLocalizations.map(localization => fetch(API.path + '/' + localization).then(response => response.json()))).then(data => {
+                translationsLoaded = Promise.all(otherLocalizations.map(localization => fetch(API.path + '/' + localization).then(response => response.json()))).then(data => {
                     toastr["success"]("Diocesan Calendar translation data was retrieved successfully", Messages['Success']);
                     if (false === TranslationData.has(API.path)) {
                         TranslationData.set(API.path, new Map());
@@ -3199,7 +3205,7 @@ const loadDiocesanCalendarData = () => {
                 if (DataLoader.allLocalesLoaded.hasOwnProperty(API.path)) {
                     refreshOtherLocalizationInputs(otherLocalizations);
                 } else {
-                    fetch(API.path + '/' + DataLoader.lastRequestLocale).then(response => response.json()).then(localizationData => {
+                    translationsLoaded = fetch(API.path + '/' + DataLoader.lastRequestLocale).then(response => response.json()).then(localizationData => {
                         if (false === TranslationData.has(API.path)) {
                             TranslationData.set(API.path, new Map());
                         }
@@ -3213,6 +3219,9 @@ const loadDiocesanCalendarData = () => {
         }
 
         setFocusFirstTabWithData();
+        // Returned, not awaited inline, so focus still moves as soon as the primary
+        // locale is on screen — only the overlay waits for the translations.
+        return translationsLoaded;
     }).catch(error => {
         if ( error instanceof Error && error.message.startsWith('404') ) { //we have already handled 404 Not Found above
             return;

--- a/e2e/diocesan-calendar.spec.ts
+++ b/e2e/diocesan-calendar.spec.ts
@@ -343,21 +343,29 @@ test.describe('Diocesan Calendar Form', () => {
         let responseStatus: number | null = null;
         let responseBody: any = null;
 
-        // Load an existing diocesan calendar (UPDATE scenario - should use PATCH)
-        // Dynamically discover a nation with existing diocesan calendars
-        const nationsWithDioceses = await extendingPage.getNationsWithExistingDiocesanCalendars();
+        // Load an existing diocesan calendar (UPDATE scenario - should use PATCH).
+        //
+        // The nation is chosen deterministically, preferring one whose diocese
+        // announces more than one locale. A random pick used to decide whether this
+        // spec exercised the multi-locale editor path at all, which is what turned
+        // issue #462 into an intermittent ~40% failure instead of a standing red:
+        // only the multi-locale path loads secondary translations, and only that
+        // path could submit an `i18n` narrower than `metadata.locales`. Preferring
+        // it means a regression there fails every run, not two runs in five.
+        const existingDioceses = await extendingPage.getExistingDiocesanCalendars();
 
-        if (nationsWithDioceses.length === 0) {
+        if (existingDioceses.length === 0) {
             test.skip(true, 'No nations with existing diocesan calendars found');
             return;
         }
 
-        // Pick a random nation for better coverage across test runs
-        const randomIndex = Math.floor(Math.random() * nationsWithDioceses.length);
-        const selectedNation = nationsWithDioceses[randomIndex];
-        // Log index for reproducibility - to reproduce a failure, use: nationsWithDioceses[<index>]
-        console.log(`REPRODUCIBILITY: Selected nation index ${randomIndex} of ${nationsWithDioceses.length} = ${selectedNation}`);
-        console.log(`REPRODUCIBILITY: Available nations: [${nationsWithDioceses.join(', ')}]`);
+        const multiLocaleDioceses = existingDioceses.filter(d => d.locales.length > 1);
+        // Sorted so the fallback is stable too — an arbitrary-but-fixed choice beats
+        // whatever order the API happened to return.
+        const nationsWithDioceses = [...new Set(existingDioceses.map(d => d.nation))].sort();
+        const preferredNations = [...new Set(multiLocaleDioceses.map(d => d.nation))].sort();
+        const selectedNation = preferredNations[0] ?? nationsWithDioceses[0];
+        console.log(`Selected nation ${selectedNation} (multi-locale nations: [${preferredNations.join(', ')}], all: [${nationsWithDioceses.join(', ')}])`);
 
         const nationalSelect = page.locator('#diocesanCalendarNationalDependency');
 
@@ -387,18 +395,23 @@ test.describe('Diocesan Calendar Form', () => {
             }));
         });
 
-        // Get existing diocesan calendar IDs for the selected nation
-        const existingDioceseIds = await extendingPage.getExistingDiocesanCalendarIds(selectedNation);
+        // Existing calendars for the selected nation, multi-locale ones first — same
+        // reason as the nation choice above: that is the path worth exercising.
+        const nationDioceses = existingDioceses.filter(d => d.nation === selectedNation);
+        const preferredIds = nationDioceses.filter(d => d.locales.length > 1).map(d => d.calendar_id);
+        const existingDioceseIds = nationDioceses.map(d => d.calendar_id);
 
         // Find a diocese that exists in the datalist AND has existing calendar data
-        const dioceseToUpdate = availableDioceses.find(d => existingDioceseIds.includes(d.key));
+        const dioceseToUpdate = availableDioceses.find(d => preferredIds.includes(d.key))
+            ?? availableDioceses.find(d => existingDioceseIds.includes(d.key));
 
         if (!dioceseToUpdate) {
             test.skip(true, `No ${selectedNation} dioceses with existing calendar data found`);
             return;
         }
 
-        console.log(`Selected diocese for UPDATE test: ${dioceseToUpdate.name} (${dioceseToUpdate.key})`);
+        const expectedLocales = nationDioceses.find(d => d.calendar_id === dioceseToUpdate.key)?.locales ?? [];
+        console.log(`Selected diocese for UPDATE test: ${dioceseToUpdate.name} (${dioceseToUpdate.key}), locales [${expectedLocales.join(', ')}]`);
 
         const dioceseInput = page.locator('#diocesanCalendarDioceseName');
         await dioceseInput.fill(dioceseToUpdate.name);
@@ -417,6 +430,31 @@ test.describe('Diocesan Calendar Form', () => {
             }
             return false;
         }, { timeout: 15000 });
+
+        // The check above is satisfied by the PRIMARY locale alone, so on a
+        // multi-locale calendar it returns while the secondary-locale translations
+        // may still be in flight. #overlay is the app's own "editor is ready"
+        // signal, so wait for that instead — it is shown synchronously at the top of
+        // loadDiocesanCalendarData(), and the wait above guarantees we are already
+        // past that point. `networkidle` below is not a substitute: the translation
+        // fetches are kicked off from a `.then()` and can start after the network
+        // first goes idle.
+        await expect(page.locator('#overlay')).toHaveClass(/hidden/, { timeout: 15000 });
+
+        // Ordering assertion, and the regression test for issue #462: by the time
+        // the overlay lifts, the secondary-locale inputs must already exist. They are
+        // what the save handler reads to build `payload.i18n`, so if the overlay
+        // lifts first, a save submits fewer locales than `metadata.locales` announces
+        // and the API rejects it. count() takes a point-in-time snapshot with no
+        // auto-retry — waiting here would defeat the purpose, since the translations
+        // do eventually arrive even when the overlay lifted too early.
+        if (expectedLocales.length > 1) {
+            const localeInputCount = await page.locator('input[data-locale]').count();
+            expect(
+                localeInputCount,
+                'secondary-locale inputs must be present before the overlay lifts (issue #462)'
+            ).toBeGreaterThan(0);
+        }
 
         // Wait for network activity to complete
         await page.waitForLoadState('networkidle');
@@ -476,6 +514,14 @@ test.describe('Diocesan Calendar Form', () => {
 
             // Validate nation is a 2-letter ISO code
             expect(capturedPayload.metadata.nation).toMatch(/^[A-Z]{2}$/);
+
+            // The contract DiocesanData::validateTranslations() enforces: `i18n` must
+            // key exactly the locales `metadata.locales` announces. Asserting it on
+            // the captured body pins issue #462 to the payload itself, independently
+            // of any timing — a short `i18n` is what made the API 500.
+            expect(capturedPayload).toHaveProperty('i18n');
+            expect(Object.keys(capturedPayload.i18n).sort())
+                .toEqual([...capturedPayload.metadata.locales].sort());
         } finally {
             // CLEANUP: Revert changes using git restore AND git clean in the API folder
             if (needsGitRestore) {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -271,6 +271,31 @@ export class ExtendingPageHelper {
     }
 
     /**
+     * Get existing diocesan calendars with the locales each announces.
+     *
+     * `locales` is what makes a diocese interesting to the UPDATE spec: a
+     * multi-locale calendar is the only kind whose editor has to load secondary
+     * translations before a save is safe, so that is the case worth pinning a
+     * test to rather than leaving to a random pick (issue #462).
+     *
+     * @returns Array of `{ calendar_id, nation, locales }` for every diocesan calendar
+     */
+    async getExistingDiocesanCalendars(): Promise<Array<{ calendar_id: string; nation: string; locales: string[] }>> {
+        const apiBaseUrl = await this.getApiBaseUrl();
+        const response = await this.page.request.get(`${apiBaseUrl}/calendars`);
+        const data = await response.json();
+
+        const diocesanCalendars: Array<{ calendar_id: string; nation: string; locales?: string[] }> =
+            data.litcal_metadata?.diocesan_calendars || [];
+
+        return diocesanCalendars.map(d => ({
+            calendar_id: d.calendar_id,
+            nation: d.nation,
+            locales: d.locales ?? [],
+        }));
+    }
+
+    /**
      * Get nation codes that have existing diocesan calendars.
      * @returns Array of unique 2-letter ISO nation codes with existing diocesan data
      */


### PR DESCRIPTION
Fixes the frontend half of #462, plus the E2E robustness item that issue lists as its third defect. The API half is [LiturgicalCalendarAPI#796](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/796) — independent of this, either can land first.

## The bug

`loadDiocesanCalendarData()` hid `#overlay` and re-enabled Save before the secondary-locale translations resolved: the inner promise was never returned into the outer chain, so the outer `.finally()` ran first.

The window is narrow but consequential. Verified by reading the whole path:

- `refreshOtherLocalizationInputs()` is what inserts the `input[data-locale]` fields
- the save handler builds `payload.i18n` by reading exactly those (`extending.js:3812`)
- if they do not exist yet that NodeList is empty, the loop adds nothing, and `i18n` ships with the primary locale alone while `metadata.locales` already announces two
- `DiocesanData::validateTranslations()` then rejects the payload

The issue rated the race ordering "medium-high" pending a captured PATCH body. That is now settled from the code — the overlay is hidden by the outer `.finally()`, the inputs are inserted by an un-awaited inner chain. No capture needed.

## What changed

**`assets/js/extending.js`** — **both** inner chains are returned, not just the `Promise.all` the issue named. The `else` branch (same calendar, different locale) had the identical defect, so fixing only the first would have left the locale-switch path racy.

The promise is returned rather than awaited inline so focus still moves as soon as the primary locale is on screen — only the overlay waits. Knock-on improvement: a failed translation fetch now reaches the outer `.catch()` and surfaces a toast instead of being swallowed.

**`e2e/diocesan-calendar.spec.ts`, `e2e/fixtures.ts`** — same root cause, from the test side. The spec picked a nation at random, so whether it exercised the multi-locale path at all was a coin flip; that is why this presented as an intermittent ~40% failure rather than a standing red. Only `charlo_ca` (CA) and `lugano_ch` (CH) are multi-locale among reachable dioceses, which is 2 of the 5 nations with existing calendars — matching the observed incidence.

- prefers a multi-locale calendar, derived from `/calendars` rather than hardcoded, with a stable sorted fallback
- waits on `#overlay` instead of a populated `litEventName`, which the primary locale alone satisfies. `networkidle` is not a substitute: the translation fetches are kicked off from a `.then()` and can start after the network first goes idle
- two assertions pin the bug from both ends: the locale inputs must exist **at the moment** the overlay lifts (a point-in-time `count()`, deliberately not auto-retrying, since the translations do eventually arrive even when the overlay lifted early), and the captured payload's `i18n` keys must equal `metadata.locales`

A new `getExistingDiocesanCalendars()` fixture helper exposes each calendar's `locales`; the existing `getExistingDiocesanCalendarIds()` is left in place for the CREATE spec.

## Test plan

- [x] `yarn test:unit` — 168 passed
- [x] `yarn lint` (eslint), `yarn typecheck`, `node --check assets/js/extending.js` — clean
- [x] `composer parallel-lint`, `composer lint` — clean, via the pre-commit hook
- [ ] `e2e/diocesan-calendar.spec.ts` — **not run locally.** `auth.setup.ts` cannot run off port 3000 because Zitadel's provisioned redirect URIs are pinned there, and the existing `e2e/.auth/user.json` has expired. The docker `litcal-frontend` on :3000 bind-mounts `./assets` from the main checkout, so pointing the spec at it would have exercised unfixed code and the result would have meant nothing. Left for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diocesan calendar editing with more reliable loading of secondary-language translations.
  * The loading overlay now remains visible until localized fields are ready, while preserving immediate tab focus.
  * Saving calendars now consistently includes translation data for all configured locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->