### PR TITLE
fix(extending): gate the regional Save button on the translations load

### DIFF
--- a/assets/js/extending.js
+++ b/assets/js/extending.js
@@ -1550,6 +1550,7 @@ const updateRegionalCalendarForm = (data) => {
     /**
      * Load translation data
      */
+    let translationsLoaded = Promise.resolve();
     if (document.querySelector('.calendarLocales').selectedOptions.length > 1) {
         const currentLocalization = document.querySelector('.currentLocalizationChoices').value;
         const otherLocalizations = Array.from(document.querySelector('.calendarLocales').selectedOptions)
@@ -1557,11 +1558,8 @@ const updateRegionalCalendarForm = (data) => {
                                     .map(({ value }) => value);
         console.log('otherLocalizations:', otherLocalizations);
         if (DataLoader.lastRequestPath !== API.path) {
-            document.querySelector('#overlay').classList.remove('hidden');
-            Promise.all(
-                otherLocalizations.map(
-                    localization => fetch(API.path + '/' + localization).then(response => response.json())
-                )
+            translationsLoaded = Promise.all(
+                otherLocalizations.map(localization => fetchLocalization(API.path, localization))
             )
             .then(data => {
                 toastr["success"](`Calendar translation data retrieved successfully for calendar ${API.key} and locales ${otherLocalizations.join(', ')}`, Messages['Success']);
@@ -1575,8 +1573,6 @@ const updateRegionalCalendarForm = (data) => {
                 refreshOtherLocalizationInputs(otherLocalizations);
                 DataLoader.lastRequestPath = API.path;
                 DataLoader.lastRequestLocale = currentLocalization;
-            }).finally(() => {
-                document.querySelector('#overlay').classList.add('hidden');
             });
         } else {
             // We are requesting the same calendar, just with a different locale
@@ -1584,8 +1580,7 @@ const updateRegionalCalendarForm = (data) => {
             if (DataLoader.allLocalesLoaded.hasOwnProperty(API.path)) {
                 refreshOtherLocalizationInputs(otherLocalizations);
             } else {
-                document.querySelector('#overlay').classList.remove('hidden');
-                fetch(API.path + '/' + DataLoader.lastRequestLocale).then(response => response.json()).then(localizationData => {
+                translationsLoaded = fetchLocalization(API.path, DataLoader.lastRequestLocale).then(localizationData => {
                     if (false === TranslationData.has(API.path)) {
                         TranslationData.set(API.path, new Map());
                     }
@@ -1593,16 +1588,29 @@ const updateRegionalCalendarForm = (data) => {
                     console.log('TranslationData:', TranslationData);
                     refreshOtherLocalizationInputs(otherLocalizations);
                     DataLoader.allLocalesLoaded[API.path] = true;
-                }).finally(() => {
-                    document.querySelector('#overlay').classList.add('hidden');
                 });
             }
         }
-    } else {
-        document.querySelector('#overlay').classList.add('hidden');
     }
 
-    document.querySelector('.serializeRegionalNationalData').disabled = false;
+    // Save must not become available until every locale the calendar declares has its
+    // inputs on the page. The serializer builds `payload.i18n` from the
+    // `input[data-locale]` fields refreshOtherLocalizationInputs() creates, so enabling
+    // it any earlier lets the user submit fewer locales than `metadata.locales`
+    // announces — which the API rejects (issue #465, and #462 for the diocesan twin).
+    //
+    // On failure Save stays disabled, deliberately: the payload really would be
+    // incomplete, so the useful outcome is an error the user can see rather than a
+    // button that produces a rejected write. The rejection is handled here rather than
+    // propagated because the caller's `.catch()` interprets failures as data-fetch
+    // failures (inspecting `error.status` for the create-new-calendar case) and would
+    // mis-handle a translation error.
+    return translationsLoaded.then(() => {
+        document.querySelector('.serializeRegionalNationalData').disabled = false;
+    }).catch(error => {
+        toastr["error"](error.message, Messages['Error']);
+        console.error(error);
+    });
 }
 
 /**
@@ -1702,9 +1710,14 @@ const fetchRegionalCalendarData = (headers) => {
                 });*/
             }
         }).finally(() => {
-            // Leave this commented out for now, we don't want to remove the overlay until all locales are loaded,
-            // see updateRegionalCalendarForm()
-            //document.querySelector('#overlay').classList.add('hidden');
+            // Safe to hide here now: updateRegionalCalendarForm() returns its
+            // translations promise, so this `.finally()` does not run until the
+            // secondary locales are loaded. It previously could not — hence the
+            // hide being commented out — which left the overlay stuck up on the
+            // two paths that never reached updateRegionalCalendarForm()'s own
+            // per-branch hides: a cached `allLocalesLoaded` calendar, and the
+            // 404 create-a-new-calendar case handled in the `.catch()` above.
+            document.querySelector('#overlay').classList.add('hidden');
         });
     } else {
         console.log(`%c No calendar found on path ${API.path} with key ${API.key}, we must be creating a new calendar. Setting API.method to PUT. `, 'background: #fbff00ff; color: #000000ff; font-weight: bold; padding: 2px 1px;');

--- a/e2e/wider-region-calendar.spec.ts
+++ b/e2e/wider-region-calendar.spec.ts
@@ -116,17 +116,45 @@ test.describe('Wider Region Calendar Form', () => {
         // with a 422. Every wider region is multi-locale (Americas declares 23), so this
         // is always meaningful here.
         //
-        // count() takes a point-in-time snapshot with no auto-retry, deliberately: the
-        // translations do arrive eventually even when Save was enabled too early, so a
-        // waiting assertion would pass either way. The i18n/locales check further down
-        // catches the same defect from the payload side, but only if the click lands
-        // inside the race window — the incidental waits above usually close it, which is
-        // what kept this latent instead of a visible flake.
-        const localeInputCount = await page.locator('input[data-locale]').count();
+        // A single page.evaluate() takes a point-in-time snapshot with no auto-retry,
+        // deliberately: the translations do arrive eventually even when Save was enabled
+        // too early, so a waiting assertion would pass either way. The i18n/locales check
+        // further down catches the same defect from the payload side, but only if the
+        // click lands inside the race window — the incidental waits above usually close
+        // it, which is what kept this latent instead of a visible flake.
+        //
+        // The full locale SET is compared, not merely a positive count: the payload needs
+        // every declared locale, so partial localization must not pass. Ids are used
+        // rather than the app's own `.calendarLocales` / `.regionalNationalDataForm`
+        // class selectors because each of those matches three and two elements
+        // respectively (wider region, national, diocesan), so `querySelector` resolves
+        // them by document order. For this flow the first match is the wider-region one
+        // either way, but naming it leaves nothing to infer.
+        const localeInputs = await page.evaluate(() => {
+            const selected = Array.from(
+                (document.querySelector('#widerRegionLocales') as HTMLSelectElement).selectedOptions
+            ).map(option => option.value);
+            const current = (document.querySelector('#currentLocalizationWiderRegion') as HTMLSelectElement).value;
+            // One input per (event, locale) pair, so de-duplicate to a locale set.
+            const present = Array.from(new Set(
+                Array.from(document.querySelectorAll('#widerRegionForm input[data-locale]'))
+                    .map(input => (input as HTMLElement).dataset.locale)
+            ));
+            return {
+                expected: selected.filter(locale => locale !== current).sort(),
+                present: present.sort()
+            };
+        });
+        // Guards the assertion below against passing vacuously if the form ever loads
+        // with a single locale selected — every wider region declares several.
         expect(
-            localeInputCount,
-            'secondary-locale inputs must exist before Save is enabled (issue #465)'
+            localeInputs.expected.length,
+            'this scenario must have secondary locales for the assertion below to mean anything'
         ).toBeGreaterThan(0);
+        expect(
+            localeInputs.present,
+            'inputs for EVERY secondary locale must exist before Save is enabled (issue #465)'
+        ).toEqual(localeInputs.expected);
 
         // Click the save button using page.evaluate for more reliable triggering
         await page.evaluate(() => {

--- a/e2e/wider-region-calendar.spec.ts
+++ b/e2e/wider-region-calendar.spec.ts
@@ -109,6 +109,25 @@ test.describe('Wider Region Calendar Form', () => {
             return;
         }
 
+        // Ordering assertion for issue #465: by the moment Save becomes enabled, the
+        // secondary-locale inputs must already exist. The serializer builds
+        // `payload.i18n` from those fields, so enabling Save any earlier permits a write
+        // carrying fewer locales than `metadata.locales` declares, which the API rejects
+        // with a 422. Every wider region is multi-locale (Americas declares 23), so this
+        // is always meaningful here.
+        //
+        // count() takes a point-in-time snapshot with no auto-retry, deliberately: the
+        // translations do arrive eventually even when Save was enabled too early, so a
+        // waiting assertion would pass either way. The i18n/locales check further down
+        // catches the same defect from the payload side, but only if the click lands
+        // inside the race window — the incidental waits above usually close it, which is
+        // what kept this latent instead of a visible flake.
+        const localeInputCount = await page.locator('input[data-locale]').count();
+        expect(
+            localeInputCount,
+            'secondary-locale inputs must exist before Save is enabled (issue #465)'
+        ).toBeGreaterThan(0);
+
         // Click the save button using page.evaluate for more reliable triggering
         await page.evaluate(() => {
             const btn = document.querySelector('#serializeWiderRegionData') as HTMLButtonElement;


### PR DESCRIPTION
Closes #465 — both defects, plus two overlay leaks found while verifying them. The national/wider-region twin of #462.

## 1. Save enabled before translations load

This flow's *overlay* handling was already correct — both async branches hid it in their own `.finally()`. The problem was the button, enabled synchronously at the end of the function, outside every promise chain:

```js
// before, extending.js:1605 — runs while the fetches above are still in flight
document.querySelector('.serializeRegionalNationalData').disabled = false;
```

The serializer builds `payload.i18n` from the `input[data-locale]` fields `refreshOtherLocalizationInputs()` creates, so a save in that window submits fewer locales than `metadata.locales` declares. Since [LiturgicalCalendarAPI#796](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/796) that is a clean 422 rather than a 500, but it is still a save the user asked for that silently does not happen.

Save is now enabled from the translations promise. **On failure it stays disabled**, deliberately: the payload really would be incomplete, so an error the user can see beats a button that produces a rejected write.

The rejection is handled locally rather than propagated, which is the one non-obvious part. The caller's `.catch()` inspects `error.status` to detect the create-a-new-calendar case:

```js
if (404 === error.status || 400 === error.status) { /* switch to PUT */ }
```

A translation `Error` has no `.status`, so letting it through would fall to the `else` branch — whose user-facing toast is commented out. It would have been silent.

## 2. Failed localization fetches parsed as translations

Both fetches now go through `fetchLocalization()` (added in #464), which checks `response.ok`. A `problem+json` error body parses perfectly well as JSON, so an unsuccessful response was stored in `TranslationData` as if it were translation data — and the blank inputs built from it could be saved as real, empty translation strings.

#465 noted the helper could not simply be reused here because this flow had no `.catch()`, so throwing would have produced an unhandled rejection with no user-visible message. It has one now, which is what makes the reuse safe.

## Two overlay leaks, fixed as a consequence

Returning the promise lets the caller own the overlay again, which removes the commented-out hide that existed *only* because of the missing return:

```js
// before
}).finally(() => {
    // Leave this commented out for now, we don't want to remove the overlay until all locales are loaded,
    // see updateRegionalCalendarForm()
    //document.querySelector('#overlay').classList.add('hidden');
});
```

That delegation was incomplete: `updateRegionalCalendarForm()` never hid the overlay on two paths — a cached `allLocalesLoaded` calendar, and the 404 create-new case, which skips the function entirely — so on those the overlay stayed up indefinitely. Show and hide are now symmetric and one level apart: `fetchEventsAndCalendarData()` shows it, `fetchRegionalCalendarData()`'s `.finally()` hides it. Three scattered hides collapse into one.

## E2E

The wider-region UPDATE spec **already** asserted `Object.keys(i18n)` equals `metadata.locales`. That is why this stayed latent rather than flaking: the incidental waits before the Save click usually closed the window.

Added the ordering assertion that makes the guarantee explicit rather than incidental — the locale inputs must exist *at the moment* Save becomes enabled. It is a point-in-time `count()`, not a waiting assertion, because the translations arrive eventually even when Save was enabled too early, so a waiting form would pass either way. Every wider region is multi-locale (Americas declares 23, Europe 32), so it is always meaningful there.

Both the national and wider-region specs already `await expect(saveButton).toBeEnabled()` before clicking, so the later enable does not disturb them.

## Test plan

- [x] `yarn test:unit` — 168 passed
- [x] `yarn lint` (eslint), `yarn typecheck`, `node --check assets/js/extending.js` — clean
- [x] `composer parallel-lint`, `composer lint` — clean, via the pre-commit hook
- [x] Verified by inspection that `updateRegionalCalendarForm()` no longer references `#overlay` at all, and that `fetchEventsAndCalendarData()` (which shows it) always reaches `fetchRegionalCalendarData()` (which now hides it)
- [ ] E2E — **not run locally.** Same blocker as #464: `auth.setup.ts` cannot run off port 3000 because Zitadel's provisioned redirect URIs are pinned there, and the docker `litcal-frontend` bind-mounts `./assets` from the main checkout, so pointing a spec at it would exercise unfixed code. Left for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Save remains disabled until all required regional or national calendar translations are loaded.
  - Translation loading errors are displayed, preventing incomplete calendar submissions.
  - Improved loading-overlay behavior across cached-locale and new-calendar workflows.

- **Tests**
  - Added coverage to verify secondary-locale fields are populated before Save becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->