### PR TITLE
docs(e2e): correct a false claim about the shared card selectors

### DIFF
--- a/e2e/wider-region-calendar.spec.ts
+++ b/e2e/wider-region-calendar.spec.ts
@@ -124,12 +124,15 @@ test.describe('Wider Region Calendar Form', () => {
         // it, which is what kept this latent instead of a visible flake.
         //
         // The full locale SET is compared, not merely a positive count: the payload needs
-        // every declared locale, so partial localization must not pass. Ids are used
-        // rather than the app's own `.calendarLocales` / `.regionalNationalDataForm`
-        // class selectors because each of those matches three and two elements
-        // respectively (wider region, national, diocesan), so `querySelector` resolves
-        // them by document order. For this flow the first match is the wider-region one
-        // either way, but naming it leaves nothing to infer.
+        // every declared locale, so partial localization must not pass.
+        //
+        // Ids rather than the app's own `.calendarLocales` /
+        // `.regionalNationalDataForm` class selectors, simply because naming the
+        // wider-region controls states which card this scenario is on. Those classes are
+        // unambiguous at runtime — extending.php's `switch ($_GET['choice'])` (:176)
+        // emits exactly one of the wider-region, national and diocesan cards per
+        // request, so only one element ever carries each class, which is what lets
+        // extending.js drive all three cards through unscoped `querySelector` calls.
         const localeInputs = await page.evaluate(() => {
             const selected = Array.from(
                 (document.querySelector('#widerRegionLocales') as HTMLSelectElement).selectedOptions


### PR DESCRIPTION
Comment-only follow-up to #466, correcting a claim I made there that turned out to be false.

## The wrong claim

The comment added in `68ce9c4f` justified using explicit ids like this:

> Ids are used rather than the app's own `.calendarLocales` / `.regionalNationalDataForm` class selectors because each of those matches three and two elements respectively (wider region, national, diocesan), so `querySelector` resolves them by document order.

That is wrong, and misleading in a costly direction: it implies the ~40 unscoped `document.querySelector('.calendarLocales')` calls in `extending.js` are latently broken, and specifically that the national flow reads the wider-region locale select. It would send a reader hunting a bug that does not exist. I raised exactly that false alarm on #466 before checking properly.

## What is actually true

Those classes appear three and two times in `extending.php`'s **source**, but the file emits only one card per **request**:

```php
// extending.php:176
if (isset($_GET['choice'])) {
    switch ($_GET['choice']) {
        case 'widerRegion':   // :178  → #widerRegionLocales, #currentLocalizationWiderRegion, #widerRegionForm
        case 'national':      // :255  → #nationalCalendarLocales, #currentLocalizationNational, #nationalCalendarForm
        case 'diocesan':      // :441  → #diocesanCalendarLocales, #currentLocalizationDiocesan
    }
}
```

So exactly one element carries each class at runtime. The unscoped selectors are unambiguous — and that is the design, not an accident: one shared JS module drives whichever card `?choice=` selected.

The passing national and diocesan E2E specs were the correct signal all along. My error was counting occurrences in the source file and assuming they coexist in the document.

## What changes

Only the comment. The ids stay — naming the wider-region controls usefully states which card the scenario is on — but the rationale is now the true one, and it records *why* the unscoped selectors elsewhere are fine, which is the more useful fact for the next reader.

## Test plan

- [x] Every changed line in the diff is a comment, verified mechanically:

      git diff | grep -E "^[+-]" | grep -vE "^(\+\+\+|---)" | grep -vE "^[+-]\s*//"

  returns nothing.
- [x] `yarn typecheck` and `yarn lint` — clean.
- No behaviour change, so the E2E result on #466 (`ec8bdb88`) still stands for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified end-to-end test comments explaining the use of wider-region element identifiers and unambiguous selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->